### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: rust
+
+rust:
+  - 1.31.1
+  - stable
+  - beta
+  - nightly
+
+cache: cargo
+before_script:
+  - rustup component add rustfmt
+script:
+  - if [[ "$TRAVIS_RUST_VERSION" = stable ]]; then cargo fmt --all -- --check; fi
+  - RUSTFLAGS="-D warnings" cargo check --all || exit
+  - cargo build
+  - cargo test

--- a/examples/arclen_accuracy.rs
+++ b/examples/arclen_accuracy.rs
@@ -1,5 +1,8 @@
 //! A test program to plot the error of arclength approximation.
 
+// Lots of stuff is commented out or was just something to try.
+#![allow(unused)]
+
 // TODO: make more functionality accessible from command line rather than uncommenting.
 
 use std::env;

--- a/examples/cubic_arclen.rs
+++ b/examples/cubic_arclen.rs
@@ -1,5 +1,8 @@
 //! Research testbed for arclengths of cubic Bézier segments.
 
+// Lots of stuff is commented out or was just something to try.
+#![allow(unused)]
+
 use kurbo::common::*;
 use kurbo::{CubicBez, ParamCurve, ParamCurveArclen, ParamCurveCurvature, ParamCurveDeriv, Vec2};
 


### PR DESCRIPTION
This adds CI through Travis, checks rustfmt, runs tests, and forbids
warnings. The rustfmt style is pinned to stable. We also currently are
backwards compatible to rust 1.31.1, but will roll that forward as new
features are compelling; this just means it's a conscious choice.

Also clean up some warnings :)

Addresses #1