### PR TITLE
Add Shape trait

### DIFF
--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -168,6 +168,15 @@ impl BezPath {
     }
 }
 
+impl<'a> IntoIterator for &'a BezPath {
+    type Item = PathEl;
+    type IntoIter = std::iter::Cloned<std::slice::Iter<'a, PathEl>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements().iter().cloned()
+    }
+}
+
 impl Mul<PathEl> for Affine {
     type Output = PathEl;
 

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -8,7 +8,7 @@ use crate::common::{solve_cubic, solve_quadratic};
 use crate::MAX_EXTREMA;
 use crate::{
     Affine, CubicBez, Line, ParamCurve, ParamCurveArclen, ParamCurveArea, ParamCurveExtrema,
-    ParamCurveNearest, QuadBez, Vec2,
+    ParamCurveNearest, QuadBez, Shape, Vec2,
 };
 
 /// A path that can Bézier segments up to cubic, possibly with multiple subpaths.
@@ -39,6 +39,11 @@ impl BezPath {
     /// Create a new path.
     pub fn new() -> BezPath {
         Default::default()
+    }
+
+    /// Create a path from a vector of path elements.
+    pub fn from_vec(v: Vec<PathEl>) -> BezPath {
+        BezPath(v)
     }
 
     /// Push a generic path element onto the path.
@@ -401,5 +406,39 @@ impl PathSeg {
             .into_iter()
             .map(|range| self.subsegment(range).winding_inner(p))
             .sum()
+    }
+}
+
+impl Shape for BezPath {
+    type BezPathIter = std::vec::IntoIter<PathEl>;
+
+    fn to_bez_path(&self, _tolerance: f64) -> Self::BezPathIter {
+        self.clone().0.into_iter()
+    }
+
+    fn to_owned_bez_path(&self, _tolerance: f64) -> BezPath {
+        self.clone()
+    }
+
+    /// Signed area.
+    ///
+    /// TODO: figure out sign convention, see #4.
+    ///
+    /// TODO: clean up duplication with impl method.
+    fn area(&self) -> f64 {
+        BezPath::area(self)
+    }
+
+    fn perimeter(&self, accuracy: f64) -> f64 {
+        self.arclen(accuracy)
+    }
+
+    /// Winding number of point.
+    ///
+    /// TODO: figure out sign convention, see #4.
+    ///
+    /// TODO: clean up duplication with impl method.
+    fn winding(&self, pt: Vec2) -> i32 {
+        BezPath::winding(self, pt)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod line;
 mod param_curve;
 mod quadbez;
 mod rect;
+mod shape;
 mod svg;
 mod vec2;
 
@@ -18,5 +19,6 @@ pub use crate::line::*;
 pub use crate::param_curve::*;
 pub use crate::quadbez::*;
 pub use crate::rect::*;
+pub use crate::shape::*;
 pub use crate::svg::*;
 pub use crate::vec2::*;

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -2,7 +2,7 @@
 
 use std::ops::{Add, Sub};
 
-use crate::Vec2;
+use crate::{PathEl, Shape, Vec2};
 
 /// A rectangle.
 #[derive(Clone, Copy, Default, Debug)]
@@ -132,6 +132,20 @@ impl Rect {
         }
     }
 
+    /// Compute the union with one point.
+    ///
+    /// As opposed to [`union`](#method.union), this method includes the
+    /// perimeter of zero-area rectangles. Thus, a succession of `union_pt`
+    /// operations on a series of points yields their enclosing rectangle.
+    pub fn union_pt(&self, pt: Vec2) -> Rect {
+        Rect::new(
+            self.x0.min(pt.x),
+            self.y0.min(pt.y),
+            self.x1.max(pt.y),
+            self.y1.max(pt.y),
+        )
+    }
+
     /// The intersection of two rectangles.
     ///
     /// The result is empty if either input has negative width or
@@ -192,6 +206,74 @@ impl Sub<Vec2> for Rect {
             y0: self.y0 - v.y,
             x1: self.x1 - v.x,
             y1: self.y1 - v.y,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct RectPathIter {
+    rect: Rect,
+    ix: usize,
+}
+
+impl Shape for Rect {
+    type BezPathIter = RectPathIter;
+
+    fn to_bez_path(&self, _tolerance: f64) -> RectPathIter {
+        RectPathIter { rect: *self, ix: 0 }
+    }
+
+    // It's a bit of duplication having both this and the impl method, but
+    // removing that would require using the trait. We'll leave it for now.
+    #[inline]
+    fn area(&self) -> f64 {
+        Rect::area(self)
+    }
+
+    #[inline]
+    fn perimeter(&self, _accuracy: f64) -> f64 {
+        2.0 * (self.width().abs() + self.height().abs())
+    }
+
+    /// Note: this function is carefully designed so that if the plane is
+    /// tiled with rectangles, the winding number will be nonzero for exactly
+    /// one of them.
+    #[inline]
+    fn winding(&self, pt: Vec2) -> i32 {
+        let xmin = self.x0.min(self.x1);
+        let xmax = self.x0.max(self.x1);
+        let ymin = self.y0.min(self.y1);
+        let ymax = self.y0.max(self.y1);
+        if pt.x >= xmin && pt.x < xmax && pt.y >= ymin && pt.y < ymax {
+            if (self.x1 > self.x0) ^ (self.y1 > self.y0) {
+                -1
+            } else {
+                1
+            }
+        } else {
+            0
+        }
+    }
+
+    #[inline]
+    fn as_rect(&self) -> Option<Rect> {
+        Some(*self)
+    }
+}
+
+// This is clockwise in a y-down coordinate system for positive area.
+impl Iterator for RectPathIter {
+    type Item = PathEl;
+
+    fn next(&mut self) -> Option<PathEl> {
+        self.ix += 1;
+        match self.ix {
+            1 => Some(PathEl::Moveto(Vec2::new(self.rect.x0, self.rect.y0))),
+            2 => Some(PathEl::Lineto(Vec2::new(self.rect.x1, self.rect.y0))),
+            3 => Some(PathEl::Lineto(Vec2::new(self.rect.x1, self.rect.y1))),
+            4 => Some(PathEl::Lineto(Vec2::new(self.rect.x0, self.rect.y1))),
+            5 => Some(PathEl::Closepath),
+            _ => None,
         }
     }
 }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1,0 +1,47 @@
+//! A generic trait for shapes.
+
+use crate::{BezPath, PathEl, Rect, Vec2};
+
+/// A generic trait for closed shapes.
+pub trait Shape {
+    /// The iterator resulting from `to_bez_path`.
+    ///
+    /// TODO: When GAT's land, the type of this can be changed to
+    /// contain a `&'a self` reference, which would let us take
+    /// iterators from complex shapes without cloning.
+    type BezPathIter: Iterator<Item = PathEl>;
+
+    /// Convert to a Bézier path.
+    fn to_bez_path(&self, tolerance: f64) -> Self::BezPathIter;
+
+    /// Convert to an owned Bézier path.
+    ///
+    /// This might be less copying, and less computation in the
+    /// iterator. I'm not yet sure this method is worth having.
+    fn to_owned_bez_path(&self, tolerance: f64) -> BezPath {
+        BezPath::from_vec(self.to_bez_path(tolerance).collect())
+    }
+
+    /// Signed area.
+    ///
+    /// TODO: figure out sign convention, see #4.
+    fn area(&self) -> f64;
+
+    /// Total length of perimeter.
+    fn perimeter(&self, accuracy: f64) -> f64;
+
+    /// Winding number of point.
+    ///
+    /// TODO: figure out sign convention, see #4.
+    fn winding(&self, pt: Vec2) -> i32;
+
+    // TODO: centroid would be a good method to add.
+
+    /// If the shape is a rectangle, report that.
+    fn as_rect(&self) -> Option<Rect> {
+        None
+    }
+
+    // TODO: we'll have as_circle and probably as_rounded_rect,
+    // as it's likely renderers will special-case on those.
+}


### PR DESCRIPTION
We want to use Shape as the main interface for filling and clipping
closed paths. One central idea of this trait is that special cases
(rect, circle) can be preserved, and a consumer can access those or
just get a path iterator, at its choosing.

Also some iterator stuff to make use more ergonomic.