### PR TITLE
Improvements for Segment Iterator

### DIFF
--- a/src/affine.rs
+++ b/src/affine.rs
@@ -5,7 +5,7 @@ use std::ops::{Mul, MulAssign};
 use crate::Vec2;
 
 /// A 2D affine transform.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Affine([f64; 6]);
 
 impl Affine {

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -84,8 +84,7 @@ impl BezPath {
     /// Iterate over the path segments.
     pub fn segments<'a>(&'a self) -> impl Iterator<Item = PathSeg> + 'a {
         BezPathSegs {
-            c: &self.0,
-            ix: 0,
+            c: self.0.iter(),
             start: None,
             last: None,
         }
@@ -203,8 +202,7 @@ impl Mul<BezPath> for Affine {
 }
 
 struct BezPathSegs<'a> {
-    c: &'a [PathEl],
-    ix: usize,
+    c: std::slice::Iter<'a, PathEl>,
     start: Option<Vec2>,
     last: Option<Vec2>,
 }
@@ -213,8 +211,7 @@ impl<'a> Iterator for BezPathSegs<'a> {
     type Item = PathSeg;
 
     fn next(&mut self) -> Option<PathSeg> {
-        while let Some(el) = self.c.get(self.ix) {
-            self.ix += 1;
+        for el in &mut self.c {
             match *el {
                 PathEl::Moveto(p) => {
                     self.start = Some(p);

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -12,13 +12,13 @@ use crate::{
 };
 
 /// A path that can Bézier segments up to cubic, possibly with multiple subpaths.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct BezPath(Vec<PathEl>);
 
 /// The element of a Bézier path.
 ///
 /// A valid path has `Moveto` at the beginning of each subpath.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum PathEl {
     Moveto(Vec2),
     Lineto(Vec2),
@@ -28,7 +28,7 @@ pub enum PathEl {
 }
 
 /// A segment of a Bézier path.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum PathSeg {
     Line(Line),
     Quad(QuadBez),

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -213,11 +213,9 @@ impl<'a> Iterator for BezPathSegs<'a> {
     type Item = PathSeg;
 
     fn next(&mut self) -> Option<PathSeg> {
-        while self.ix < self.c.len() {
-            let ix = self.ix;
-            let el = self.c[ix];
+        while let Some(el) = self.c.get(self.ix) {
             self.ix += 1;
-            match el {
+            match *el {
                 PathEl::Moveto(p) => {
                     self.start = Some(p);
                     self.last = Some(p);

--- a/src/line.rs
+++ b/src/line.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// A single line.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Line {
     pub p0: Vec2,
     pub p1: Vec2,
@@ -107,7 +107,7 @@ impl ParamCurveExtrema for Line {
 }
 
 /// A trivial "curve" that is just a constant.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct ConstVec2(Vec2);
 
 impl ParamCurve for ConstVec2 {


### PR DESCRIPTION
This series of commits contains a few improvements to the segment iterator.  I split the changes into small commits so it is easier to understand.  If some changes don't suit you, feel free to exclude these commits.

1. 9547e43cb96b51bd144313d4f8606efa86b757a7: A few types that should implement `Debug` didn't.
2. 710973600f27e0380e6e2b088af03c4284944bad: In my opinion it is unidiomatic Rust to include the index in the iterator by default.  As visible in your code, most of the time you just throw it away anyway ... If you do need it, you can easily add the index back using `path.segments().enumerate()`.
3. 354c392f42788f87f9643d0184a874a292931e7d: Just a small change, `slice::get()` behaves the same way as the previous implementation.
4. ad506cab9c193012524d794a809603484713d256: As we are iterating over a slice, we can use the slice-iterator instead of doing it on our own.
5. 8127083d3b8f239ff2f8497dd6725526e4b5306d: To quote the commit message:
  > Logically `start` and `last` should always have values.  This commit reflects this in code.  If no value for first could be found (because the first element is not a `PathEl::Moveto`), a `panic!` with a proper message will occur.
6. ea1a94af277ba07e4b529c15cb37e668ff2d05f1: I am not quite sure about this one.  I tried reducing code duplication, but some people might argue that the new version is harder to understand.  Your choice if you want to include it ...