### PR TITLE
Only install rustfmt on stable runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rust:
 
 cache: cargo
 before_script:
-  - rustup component add rustfmt
+  - if [[ "$TRAVIS_RUST_VERSION" = stable ]]; then rustup component add rustfmt; fi
 script:
   - if [[ "$TRAVIS_RUST_VERSION" = stable ]]; then cargo fmt --all -- --check; fi
   - RUSTFLAGS="-D warnings" cargo check --all || exit


### PR DESCRIPTION
This fixes travis errors, as it's gone missing on nightly.