### PR TITLE
Minor tweaks to bezier paths

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,7 @@
+# This is the list of kurbo authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history in source control.
+Raph Levien
+Nicolas Silva

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,67 +1,202 @@
-Apache License
 
-Version 2.0, January 2004
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-http://www.apache.org/licenses/
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+   1. Definitions.
 
-1. Definitions.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-You must give any other recipients of the Work or Derivative Works a copy of this License; and
-You must cause any modified files to carry prominent notices stating that You changed the files; and
-You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
-If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
-5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-END OF TERMS AND CONDITIONS
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-Copyright 2016 Maik Klein
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-    http://www.apache.org/licenses/LICENSE-2.0
+   END OF TERMS AND CONDITIONS
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -21,13 +21,15 @@ Here we mention a few other curves libraries and touch on some of the decisions 
 
 * [vek] has both 2D and 3D Béziers among other things, and is tuned for game engines.
 
+Some code has been copied from lyon_geom with adaptation, thus the author of lyon_geom, Nicolas Silva, is credited in the [AUTHORS] file.
+
 ## More info
 
 To learn more about Bézier curves, [A Primer on Bézier Curves] by Pomax is indispensable.
 
 ## Contributing
 
-Contributions are welcome. The [Rust Code of Conduct] applies.
+Contributions are welcome. The [Rust Code of Conduct] applies. Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
 
 [Rust Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct
 [lyon_geom]: https://crates.io/crates/lyon_geom

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -197,6 +197,14 @@ impl Mul<BezPath> for Affine {
     }
 }
 
+impl<'a> Mul<&'a BezPath> for Affine {
+    type Output = BezPath;
+
+    fn mul(self, other: &BezPath) -> BezPath {
+        BezPath(other.0.iter().map(|&el| self * el).collect())
+    }
+}
+
 struct BezPathSegs<'a> {
     c: std::slice::Iter<'a, PathEl>,
     start: Vec2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2018 The kurbo Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! A garden of data structures for manipulating 2D curves.
 
 mod affine;

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -1,8 +1,28 @@
 //! SVG path representation.
 
+use std::f64::consts::PI;
 use std::io::Write;
 
 use crate::{BezPath, PathEl, Vec2};
+
+// Note: the SVG arc logic is heavily adapted from https://github.com/nical/lyon
+struct SvgArc {
+    pub from: Vec2,
+    pub to: Vec2,
+    pub radii: Vec2,
+    pub x_rotation: f64,
+    pub large_arc: bool,
+    pub sweep: bool,
+}
+
+// TODO: consider adding this to the public API.
+struct Arc {
+    pub center: Vec2,
+    pub radii: Vec2,
+    pub start_angle: f64,
+    pub sweep_angle: f64,
+    pub x_rotation: f64,
+}
 
 impl BezPath {
     /// Convert the path to an SVG path string representation.
@@ -34,14 +54,36 @@ impl BezPath {
         let mut lexer = SvgLexer::new(data);
         let mut path = BezPath::new();
         let mut last_cmd = 0;
+        let mut last_ctrl = None;
         while let Some(c) = lexer.get_cmd(last_cmd) {
             if c == b'm' || c == b'M' {
-                let pt = lexer.get_number_pair()?;
+                let pt = lexer.get_maybe_relative(c)?;
                 path.moveto(pt);
                 lexer.last_pt = pt;
+                last_ctrl = Some(pt);
                 last_cmd = c - (b'M' - b'L');
             } else if c == b'l' || c == b'L' {
                 let pt = lexer.get_maybe_relative(c)?;
+                path.lineto(pt);
+                lexer.last_pt = pt;
+                last_cmd = c;
+            } else if c == b'h' || c == b'H' {
+                let mut x = lexer.get_number()?;
+                lexer.opt_comma();
+                if c == b'h' {
+                    x += lexer.last_pt.x;
+                }
+                let pt = Vec2::new(x, lexer.last_pt.y);
+                path.lineto(pt);
+                lexer.last_pt = pt;
+                last_cmd = c;
+            } else if c == b'v' || c == b'V' {
+                let mut y = lexer.get_number()?;
+                lexer.opt_comma();
+                if c == b'v' {
+                    y += lexer.last_pt.y;
+                }
+                let pt = Vec2::new(lexer.last_pt.x, y);
                 path.lineto(pt);
                 lexer.last_pt = pt;
                 last_cmd = c;
@@ -50,7 +92,40 @@ impl BezPath {
                 let p2 = lexer.get_maybe_relative(c)?;
                 let p3 = lexer.get_maybe_relative(c)?;
                 path.curveto(p1, p2, p3);
+                last_ctrl = Some(p2);
                 lexer.last_pt = p3;
+                last_cmd = c;
+            } else if c == b's' || c == b'S' {
+                let p1 = match last_ctrl {
+                    Some(ctrl) => 2.0 * lexer.last_pt - ctrl,
+                    None => lexer.last_pt,
+                };
+                let p2 = lexer.get_maybe_relative(c)?;
+                let p3 = lexer.get_maybe_relative(c)?;
+                path.curveto(p1, p2, p3);
+                last_ctrl = Some(p2);
+                lexer.last_pt = p3;
+                last_cmd = c;
+            } else if c == b'a' || c == b'A' {
+                let radii = lexer.get_number_pair()?;
+                let x_rotation = lexer.get_number()?;
+                lexer.opt_comma();
+                let large_arc = lexer.get_number()?;
+                lexer.opt_comma();
+                let sweep = lexer.get_number()?;
+                lexer.opt_comma();
+                let p = lexer.get_maybe_relative(c)?;
+                let svg_arc = SvgArc {
+                    from: lexer.last_pt,
+                    to: p,
+                    radii,
+                    x_rotation,
+                    large_arc: large_arc != 0.0,
+                    sweep: sweep != 0.0,
+                };
+                let arc = Arc::from_svg_arc(&svg_arc);
+                arc.append_to_path(&mut path, 0.1);
+                lexer.last_pt = p;
                 last_cmd = c;
             } else if c == b'z' || c == b'Z' {
                 path.closepath();
@@ -171,6 +246,109 @@ impl<'a> SvgLexer<'a> {
             }
         }
     }
+}
+
+impl Arc {
+    fn from_svg_arc(arc: &SvgArc) -> Arc {
+        let mut rx = arc.radii.x.abs();
+        let mut ry = arc.radii.y.abs();
+
+        let xr = arc.x_rotation % (2.0 * PI);
+        let cos_phi = xr.cos();
+        let sin_phi = xr.sin();
+        let hd_x = (arc.from.x - arc.to.x) * 0.5;
+        let hd_y = (arc.from.y - arc.to.y) * 0.5;
+        let hs_x = (arc.from.x + arc.to.x) * 0.5;
+        let hs_y = (arc.from.y + arc.to.y) * 0.5;
+
+        // F6.5.1
+        let p = Vec2::new(
+            cos_phi * hd_x + sin_phi * hd_y,
+            -sin_phi * hd_x + cos_phi * hd_y,
+        );
+
+        // Sanitize the radii.
+        // If rf > 1 it means the radii are too small for the arc to
+        // possibly connect the end points. In this situation we scale
+        // them up according to the formula provided by the SVG spec.
+
+        // F6.6.2
+        let rf = p.x * p.x / (rx * rx) + p.y * p.y / (ry * ry);
+        if rf > 1.0 {
+            let scale = rf.sqrt();
+            rx *= scale;
+            ry *= scale;
+        }
+
+        let rxry = rx * ry;
+        let rxpy = rx * p.y;
+        let rypx = ry * p.x;
+        let sum_of_sq = rxpy * rxpy + rypx * rypx;
+
+        debug_assert_ne!(sum_of_sq, 0.0);
+
+        // F6.5.2
+        let sign_coe = if arc.large_arc == arc.sweep {
+            -1.0
+        } else {
+            1.0
+        };
+        let coe = sign_coe * ((rxry * rxry - sum_of_sq) / sum_of_sq).abs().sqrt();
+        let transformed_cx = coe * rxpy / ry;
+        let transformed_cy = -coe * rypx / rx;
+
+        // F6.5.3
+        let center = Vec2::new(
+            cos_phi * transformed_cx - sin_phi * transformed_cy + hs_x,
+            sin_phi * transformed_cx + cos_phi * transformed_cy + hs_y,
+        );
+
+        let start_v = Vec2::new((p.x - transformed_cx) / rx, (p.y - transformed_cy) / ry);
+        let end_v = Vec2::new((-p.x - transformed_cx) / rx, (-p.y - transformed_cy) / ry);
+
+        let start_angle = start_v.atan2();
+
+        let mut sweep_angle = (end_v.atan2() - start_angle) % (2.0 * PI);
+
+        if arc.sweep && sweep_angle < 0.0 {
+            sweep_angle += 2.0 * PI;
+        } else if !arc.sweep && sweep_angle > 0.0 {
+            sweep_angle -= 2.0 * PI;
+        }
+
+        Arc {
+            center,
+            radii: Vec2::new(rx, ry),
+            start_angle,
+            sweep_angle: sweep_angle,
+            x_rotation: arc.x_rotation,
+        }
+    }
+
+    fn get_angle(&self, t: f64) -> f64 {
+        self.start_angle + t * self.sweep_angle
+    }
+
+    fn append_to_path(&self, path: &mut BezPath, _tolerance: f64) {
+        // TODO: it's cheesy to do linear flattening, figure out curve math
+        let n = 5;
+        let recip_n = (n as f64).recip();
+        for i in 0..n {
+            let t = (i + 1) as f64 * recip_n;
+            path.lineto(
+                self.center + sample_ellipse(self.radii, self.x_rotation, self.get_angle(t)),
+            );
+        }
+    }
+}
+
+fn sample_ellipse(radii: Vec2, x_rotation: f64, angle: f64) -> Vec2 {
+    let u = radii.x * angle.cos();
+    let v = radii.y * angle.sin();
+    Vec2::new(
+        u * x_rotation.cos() - v * x_rotation.sin(),
+        u * x_rotation.sin() + v * x_rotation.cos(),
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Allow multiplication by affine to take a BezPath by reference.

Add "A", "S", "H", "V" commands to SVG path parsing. The SVG arc logic is adapted from lyon_geom. Thus, Nicolas is credited in the AUTHORS file (and there's a bit of bureaucracy around attribution).

Note that the arc flattening is very crude. I'll probably update this PR with a more refined version.