### PR TITLE
Add 'euclid' feature for interop with euclid crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,18 @@ arrayvec = "0.4.10"
 version = "0.5.1"
 optional = true
 
+[dependencies.euclid-crate]
+package = "euclid"
+version = "0.19.9"
+optional = true
+
+[dependencies.num-traits]
+version = "0.2.8"
+optional = true
+
+[features]
+euclid = ["euclid-crate", "num-traits"]
+
 # This is used for research but not really needed; maybe refactor.
 [dev-dependencies]
 rand = "0.6"

--- a/src/euclid.rs
+++ b/src/euclid.rs
@@ -1,0 +1,153 @@
+//! Conversions and helpers for working with the [Euclid crate][].
+//!
+//!
+//! - [Euclid crate]: https://docs.rs/euclid/
+
+use euclid_crate as euclid;
+
+// Rect
+
+impl<T, U> From<euclid::TypedRect<T, U>> for crate::Rect
+where
+    T: num_traits::Float + num_traits::AsPrimitive<f64>,
+{
+    fn from(src: euclid::TypedRect<T, U>) -> crate::Rect {
+        crate::Rect::new(
+            src.min_x().as_(),
+            src.min_y().as_(),
+            src.max_x().as_(),
+            src.max_y().as_(),
+        )
+    }
+}
+
+impl<T, U> From<&euclid::TypedRect<T, U>> for crate::Rect
+where
+    T: num_traits::Float + num_traits::AsPrimitive<f64>,
+{
+    fn from(src: &euclid::TypedRect<T, U>) -> crate::Rect {
+        crate::Rect::new(
+            src.min_x().as_(),
+            src.min_y().as_(),
+            src.max_x().as_(),
+            src.max_y().as_(),
+        )
+    }
+}
+
+// Point2D
+
+impl<T, U> From<euclid::TypedPoint2D<T, U>> for crate::Vec2
+where
+    T: num_traits::Float + num_traits::AsPrimitive<f64>,
+{
+    fn from(src: euclid::TypedPoint2D<T, U>) -> crate::Vec2 {
+        crate::Vec2::new(src.x.as_(), src.y.as_())
+    }
+}
+
+impl<T, U> From<&euclid::TypedPoint2D<T, U>> for crate::Vec2
+where
+    T: num_traits::Float + num_traits::AsPrimitive<f64>,
+{
+    fn from(src: &euclid::TypedPoint2D<T, U>) -> crate::Vec2 {
+        crate::Vec2::new(src.x.as_(), src.y.as_())
+    }
+}
+
+//Size2D
+
+impl<T, U> From<euclid::TypedSize2D<T, U>> for crate::Vec2
+where
+    T: num_traits::Float + num_traits::AsPrimitive<f64>,
+{
+    fn from(src: euclid::TypedSize2D<T, U>) -> crate::Vec2 {
+        crate::Vec2::new(src.width.as_(), src.height.as_())
+    }
+}
+
+impl<T, U> From<&euclid::TypedSize2D<T, U>> for crate::Vec2
+where
+    T: num_traits::Float + num_traits::AsPrimitive<f64>,
+{
+    fn from(src: &euclid::TypedSize2D<T, U>) -> crate::Vec2 {
+        crate::Vec2::new(src.width.as_(), src.height.as_())
+    }
+}
+
+// Vector2D
+
+impl<T, U> From<euclid::TypedVector2D<T, U>> for crate::Vec2
+where
+    T: num_traits::Float + num_traits::AsPrimitive<f64>,
+{
+    fn from(src: euclid::TypedVector2D<T, U>) -> crate::Vec2 {
+        crate::Vec2::new(src.x.as_(), src.y.as_())
+    }
+}
+
+impl<T, U> From<&euclid::TypedVector2D<T, U>> for crate::Vec2
+where
+    T: num_traits::Float + num_traits::AsPrimitive<f64>,
+{
+    fn from(src: &euclid::TypedVector2D<T, U>) -> crate::Vec2 {
+        crate::Vec2::new(src.x.as_(), src.y.as_())
+    }
+}
+
+impl<T, U> crate::Shape for euclid::TypedRect<T, U>
+where
+    T: num_traits::Float + num_traits::AsPrimitive<f64>,
+{
+    type BezPathIter = crate::rect::RectPathIter;
+
+    fn to_bez_path(&self, _tolerance: f64) -> crate::rect::RectPathIter {
+        let rect = *self;
+        crate::rect::RectPathIter {
+            rect: rect.into(),
+            ix: 0,
+        }
+    }
+
+    // It's a bit of duplication having both this and the impl method, but
+    // removing that would require using the trait. We'll leave it for now.
+    #[inline]
+    fn area(&self) -> f64 {
+        self.area().as_()
+    }
+
+    #[inline]
+    fn perimeter(&self, _accuracy: f64) -> f64 {
+        2.0 * (self.size.width.abs() + self.size.height.abs()).as_()
+    }
+
+    //FIXME: @raph, is this logic right? I suspect I'm missing a subtlety
+    #[inline]
+    fn winding(&self, pt: crate::Vec2) -> i32 {
+        let xmin = self.min_x().as_();
+        let xmax = self.max_x().as_();
+        let ymin = self.min_y().as_();
+        let ymax = self.max_y().as_();
+        if pt.x >= xmin && pt.x < xmax && pt.y >= ymin && pt.y < ymax {
+            if (self.size.width.as_() > 0.) ^ (self.size.height.as_() > 0.) {
+                -1
+            } else {
+                1
+            }
+        } else {
+            0
+        }
+    }
+
+    #[inline]
+    fn bounding_box(&self) -> crate::Rect {
+        let rect: crate::Rect = self.into();
+        rect.abs()
+    }
+
+    #[inline]
+    fn as_rect(&self) -> Option<crate::Rect> {
+        let rect: crate::Rect = self.into();
+        Some(rect)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ mod bezpath;
 mod circle;
 pub mod common;
 mod cubicbez;
+#[cfg(feature = "euclid")]
+mod euclid;
 mod line;
 mod param_curve;
 mod quadbez;

--- a/src/line.rs
+++ b/src/line.rs
@@ -19,7 +19,7 @@ pub struct Line {
 
 impl Line {
     #[inline]
-    pub fn new<V: Into<Vec2>>(p0: V, p1: V) -> Line {
+    pub fn new(p0: impl Into<Vec2>, p1: impl Into<Vec2>) -> Line {
         Line {
             p0: p0.into(),
             p1: p1.into(),

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -28,7 +28,9 @@ impl Rect {
     ///
     /// The result will have non-negative width and height.
     #[inline]
-    pub fn from_points(p0: Vec2, p1: Vec2) -> Rect {
+    pub fn from_points(p0: impl Into<Vec2>, p1: impl Into<Vec2>) -> Rect {
+        let p0 = p0.into();
+        let p1 = p1.into();
         Rect {
             x0: p0.x,
             y0: p0.y,
@@ -42,7 +44,9 @@ impl Rect {
     ///
     /// The result will have non-negative width and height.
     #[inline]
-    pub fn from_origin_size(origin: Vec2, size: Vec2) -> Rect {
+    pub fn from_origin_size(origin: impl Into<Vec2>, size: impl Into<Vec2>) -> Rect {
+        let origin = origin.into();
+        let size = size.into();
         Rect::from_points(origin, origin + size)
     }
 
@@ -212,8 +216,8 @@ impl Sub<Vec2> for Rect {
 
 #[doc(hidden)]
 pub struct RectPathIter {
-    rect: Rect,
-    ix: usize,
+    pub(crate) rect: Rect,
+    pub(crate) ix: usize,
 }
 
 impl Shape for Rect {

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -85,6 +85,16 @@ impl From<(f64, f64)> for Vec2 {
     }
 }
 
+impl From<(f32, f32)> for Vec2 {
+    #[inline]
+    fn from(v: (f32, f32)) -> Vec2 {
+        Vec2 {
+            x: v.0.into(),
+            y: v.1.into(),
+        }
+    }
+}
+
 impl From<Vec2> for (f64, f64) {
     #[inline]
     fn from(v: Vec2) -> (f64, f64) {


### PR DESCRIPTION
This also adds a bunch of conversion implementations, as well
as implementing `Shape` for euclid::Rect.

It also makes a few call sites that take `Vec2` more flexible, and impls `From<(f32, f32)> for Vec2`, which is maybe questionable but seems low-stakes.