### PR TITLE
Add missing circle shape conversion for references

### DIFF
--- a/src/shape.rs
+++ b/src/shape.rs
@@ -100,6 +100,10 @@ impl<'a, T: Shape> Shape for &'a T {
         (*self).bounding_box()
     }
 
+    fn as_circle(&self) -> Option<Circle> {
+        (*self).as_circle()
+    }
+
     fn as_line(&self) -> Option<Line> {
         (*self).as_line()
     }


### PR DESCRIPTION
`as_circle` uses the default implementation otherwise which would always return `None`.

`Circle` -> Some(Circle)
`&Circle` -> None