### PR TITLE
Be systematic in vector types

### DIFF
--- a/benches/quad_arclen.rs
+++ b/benches/quad_arclen.rs
@@ -10,7 +10,7 @@ use kurbo::{ParamCurve, ParamCurveArclen, ParamCurveDeriv, QuadBez};
 
 // Based on http://www.malczak.linuxpl.com/blog/quadratic-bezier-curve-length/
 fn quad_arclen_analytical(q: QuadBez) -> f64 {
-    let d2 = q.p0 - 2.0 * q.p1 + q.p2;
+    let d2 = q.p0.to_vec2() - 2.0 * q.p1.to_vec2() + q.p2.to_vec2();
     let a = d2.hypot2();
     let d1 = q.p1 - q.p0;
     let b = 2.0 * d2.dot(d1);
@@ -30,16 +30,19 @@ fn quad_arclen_analytical(q: QuadBez) -> f64 {
 /// Calculate arclength using Gauss-Legendre quadrature using formula from Behdad
 /// in https://github.com/Pomax/BezierInfo-2/issues/77
 fn gauss_arclen_3(q: QuadBez) -> f64 {
-    let v0 =
-        (-0.492943519233745 * q.p0 + 0.430331482911935 * q.p1 + 0.0626120363218102 * q.p2).hypot();
+    let v0 = (-0.492943519233745 * q.p0.to_vec2()
+        + 0.430331482911935 * q.p1.to_vec2()
+        + 0.0626120363218102 * q.p2.to_vec2())
+    .hypot();
     let v1 = ((q.p2 - q.p0) * 0.4444444444444444).hypot();
-    let v2 =
-        (-0.0626120363218102 * q.p0 - 0.430331482911935 * q.p1 + 0.492943519233745 * q.p2).hypot();
+    let v2 = (-0.0626120363218102 * q.p0.to_vec2() - 0.430331482911935 * q.p1.to_vec2()
+        + 0.492943519233745 * q.p2.to_vec2())
+    .hypot();
     v0 + v1 + v2
 }
 
 fn awesome_quad_arclen3(q: QuadBez, accuracy: f64, depth: usize) -> f64 {
-    let pm = (q.p0 + q.p2) / 2.0;
+    let pm = q.p0.midpoint(q.p2);
     let d1 = q.p1 - pm;
     let d = q.p2 - q.p0;
     let dhypot2 = d.hypot2();
@@ -63,7 +66,7 @@ fn gauss_arclen_n(q: QuadBez, coeffs: &[(f64, f64)]) -> f64 {
     let d = q.deriv();
     coeffs
         .iter()
-        .map(|(wi, xi)| wi * d.eval(0.5 * (xi + 1.0)).hypot())
+        .map(|(wi, xi)| wi * d.eval(0.5 * (xi + 1.0)).to_vec2().hypot())
         .sum::<f64>()
         * 0.5
 }
@@ -116,7 +119,7 @@ fn gauss_arclen_24(q: QuadBez) -> f64 {
 }
 
 fn awesome_quad_arclen7(q: QuadBez, accuracy: f64, depth: usize) -> f64 {
-    let pm = (q.p0 + q.p2) / 2.0;
+    let pm = q.p0.midpoint(q.p2);
     let d1 = q.p1 - pm;
     let d = q.p2 - q.p0;
     let dhypot2 = d.hypot2();

--- a/examples/arclen_accuracy.rs
+++ b/examples/arclen_accuracy.rs
@@ -15,16 +15,19 @@ use kurbo::common::{GAUSS_LEGENDRE_COEFFS_24, GAUSS_LEGENDRE_COEFFS_5, GAUSS_LEG
 /// Calculate arclength using Gauss-Legendre quadrature using formula from Behdad
 /// in https://github.com/Pomax/BezierInfo-2/issues/77
 fn gauss_arclen_3(q: QuadBez) -> f64 {
-    let v0 =
-        (-0.492943519233745 * q.p0 + 0.430331482911935 * q.p1 + 0.0626120363218102 * q.p2).hypot();
+    let v0 = (-0.492943519233745 * q.p0.to_vec2()
+        + 0.430331482911935 * q.p1.to_vec2()
+        + 0.0626120363218102 * q.p2.to_vec2())
+    .hypot();
     let v1 = ((q.p2 - q.p0) * 0.4444444444444444).hypot();
-    let v2 =
-        (-0.0626120363218102 * q.p0 - 0.430331482911935 * q.p1 + 0.492943519233745 * q.p2).hypot();
+    let v2 = (-0.0626120363218102 * q.p0.to_vec2() - 0.430331482911935 * q.p1.to_vec2()
+        + 0.492943519233745 * q.p2.to_vec2())
+    .hypot();
     v0 + v1 + v2
 }
 
 fn awesome_quad_arclen(q: QuadBez, accuracy: f64, depth: usize, count: &mut usize) -> f64 {
-    let pm = (q.p0 + q.p2) / 2.0;
+    let pm = q.p0.midpoint(q.p2);
     let d1 = q.p1 - pm;
     let d = q.p2 - q.p0;
     let dhypot2 = d.hypot2();
@@ -72,7 +75,7 @@ fn gauss_arclen_24(q: QuadBez) -> f64 {
 }
 
 fn awesome_quad_arclen7(q: QuadBez, accuracy: f64, depth: usize, count: &mut usize) -> f64 {
-    let pm = (q.p0 + q.p2) / 2.0;
+    let pm = q.p0.midpoint(q.p2);
     let d1 = q.p1 - pm;
     let d = q.p2 - q.p0;
     let dhypot2 = d.hypot2();
@@ -93,7 +96,7 @@ fn awesome_quad_arclen7(q: QuadBez, accuracy: f64, depth: usize, count: &mut usi
 }
 
 fn awesome_quad_arclen24(q: QuadBez, accuracy: f64, depth: usize, count: &mut usize) -> f64 {
-    let pm = (q.p0 + q.p2) / 2.0;
+    let pm = q.p0.midpoint(q.p2);
     let d1 = q.p1 - pm;
     let d = q.p2 - q.p0;
     let dhypot2 = d.hypot2();
@@ -115,7 +118,7 @@ fn awesome_quad_arclen24(q: QuadBez, accuracy: f64, depth: usize, count: &mut us
 
 // Based on http://www.malczak.linuxpl.com/blog/quadratic-bezier-curve-length/
 fn quad_arclen_analytical(q: QuadBez) -> f64 {
-    let d2 = q.p0 - 2.0 * q.p1 + q.p2;
+    let d2 = q.p0.to_vec2() - 2.0 * q.p1.to_vec2() + q.p2.to_vec2();
     let a = d2.hypot2();
     let d1 = q.p1 - q.p0;
     let c = d1.hypot2();

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -2,7 +2,7 @@
 
 use std::ops::{Mul, MulAssign};
 
-use crate::Vec2;
+use crate::{Point, Vec2};
 
 /// A 2D affine transform.
 #[derive(Clone, Copy, Debug)]
@@ -71,12 +71,12 @@ impl Default for Affine {
     }
 }
 
-impl Mul<Vec2> for Affine {
-    type Output = Vec2;
+impl Mul<Point> for Affine {
+    type Output = Point;
 
     #[inline]
-    fn mul(self, other: Vec2) -> Vec2 {
-        Vec2::new(
+    fn mul(self, other: Point) -> Point {
+        Point::new(
             self.0[0] * other.x + self.0[2] * other.y + self.0[4],
             self.0[1] * other.x + self.0[3] * other.y + self.0[5],
         )
@@ -154,22 +154,22 @@ impl From<mint::ColumnMatrix2x3<f64>> for Affine {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Affine, Vec2};
+    use crate::{Affine, Point};
     use std::f64::consts::PI;
 
-    fn assert_near(p0: Vec2, p1: Vec2) {
+    fn assert_near(p0: Point, p1: Point) {
         assert!((p1 - p0).hypot() < 1e-9, "{:?} != {:?}", p0, p1);
     }
 
     #[test]
     fn affine_basic() {
-        let p = Vec2::new(3.0, 4.0);
+        let p = Point::new(3.0, 4.0);
 
         assert_near(Affine::default() * p, p);
-        assert_near(Affine::scale(2.0) * p, Vec2::new(6.0, 8.0));
+        assert_near(Affine::scale(2.0) * p, Point::new(6.0, 8.0));
         assert_near(Affine::rotate(0.0) * p, p);
-        assert_near(Affine::rotate(PI / 2.0) * p, Vec2::new(-4.0, 3.0));
-        assert_near(Affine::translate((5.0, 6.0)) * p, Vec2::new(8.0, 10.0));
+        assert_near(Affine::rotate(PI / 2.0) * p, Point::new(-4.0, 3.0));
+        assert_near(Affine::translate((5.0, 6.0)) * p, Point::new(8.0, 10.0));
     }
 
     #[test]
@@ -177,10 +177,11 @@ mod tests {
         let a1 = Affine::new([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
         let a2 = Affine::new([0.1, 1.2, 2.3, 3.4, 4.5, 5.6]);
 
-        let px = Vec2::new(1.0, 0.0);
-        let py = Vec2::new(0.0, 1.0);
+        let px = Point::new(1.0, 0.0);
+        let py = Point::new(0.0, 1.0);
+        let pxy = Point::new(1.0, 1.0);
         assert_near(a1 * (a2 * px), (a1 * a2) * px);
         assert_near(a1 * (a2 * py), (a1 * a2) * py);
-        assert_near(a1 * (a2 * (px + py)), (a1 * a2) * (px + py));
+        assert_near(a1 * (a2 * pxy), (a1 * a2) * pxy);
     }
 }

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -3,13 +3,13 @@
 use std::f64::consts::{FRAC_PI_2, PI};
 use std::ops::{Add, Sub};
 
-use crate::{PathEl, Rect, Shape, Vec2};
+use crate::{PathEl, Point, Rect, Shape, Vec2};
 
 /// A circle.
 #[derive(Clone, Copy, Default, Debug)]
 pub struct Circle {
     /// The center.
-    pub center: Vec2,
+    pub center: Point,
     /// The radius.
     pub radius: f64,
 }
@@ -17,7 +17,7 @@ pub struct Circle {
 impl Circle {
     /// A new circle from center and radius.
     #[inline]
-    pub fn new(center: impl Into<Vec2>, radius: f64) -> Circle {
+    pub fn new(center: impl Into<Point>, radius: f64) -> Circle {
         Circle {
             center: center.into(),
             radius,
@@ -93,7 +93,7 @@ impl Shape for Circle {
         (2.0 * PI * self.radius).abs()
     }
 
-    fn winding(&self, pt: Vec2) -> i32 {
+    fn winding(&self, pt: Point) -> i32 {
         if (pt - self.center).hypot2() < self.radius.powi(2) {
             self.radius.signum() as i32
         } else {
@@ -123,7 +123,7 @@ impl Iterator for CirclePathIter {
         let ix = self.ix;
         self.ix += 1;
         if ix == 0 {
-            Some(PathEl::Moveto(Vec2::new(x + r, y)))
+            Some(PathEl::MoveTo(Point::new(x + r, y)))
         } else if ix <= self.n {
             let th1 = self.delta_th * (ix as f64);
             let th0 = th1 - self.delta_th;
@@ -133,13 +133,13 @@ impl Iterator for CirclePathIter {
             } else {
                 (th1.cos(), th1.sin())
             };
-            Some(PathEl::Curveto(
-                Vec2::new(x + r * (c0 - a * s0), y + r * (s0 + a * c0)),
-                Vec2::new(x + r * (c1 + a * s1), y + r * (s1 - a * c1)),
-                Vec2::new(x + r * c1, y + r * s1),
+            Some(PathEl::CurveTo(
+                Point::new(x + r * (c0 - a * s0), y + r * (s0 + a * c0)),
+                Point::new(x + r * (c1 + a * s1), y + r * (s1 - a * c1)),
+                Point::new(x + r * c1, y + r * s1),
             ))
         } else if ix == self.n + 1 {
-            Some(PathEl::Closepath)
+            Some(PathEl::ClosePath)
         } else {
             None
         }

--- a/src/point.rs
+++ b/src/point.rs
@@ -128,3 +128,19 @@ mod tests {
         );
     }
 }
+
+#[cfg(feature = "mint")]
+impl From<Point> for mint::Point2<f64> {
+    #[inline]
+    fn from(p: Point) -> mint::Point2<f64> {
+        mint::Point2 { x: p.x, y: p.y }
+    }
+}
+
+#[cfg(feature = "mint")]
+impl From<mint::Point2<f64>> for Point {
+    #[inline]
+    fn from(p: mint::Point2<f64>) -> Point {
+        Point { x: p.x, y: p.y }
+    }
+}

--- a/src/point.rs
+++ b/src/point.rs
@@ -18,6 +18,9 @@ impl Point {
     /// The point (0, 0).
     pub const ZERO: Point = Point::new(0., 0.);
 
+    /// The point at the origin; (0, 0).
+    pub const ORIGIN: Point = Point::new(0., 0.);
+
     /// Create a new `Point` with the provided `x` and `y` coordinates.
     #[inline]
     pub const fn new(x: f64, y: f64) -> Self {
@@ -28,6 +31,32 @@ impl Point {
     #[inline]
     pub fn to_vec2(self) -> Vec2 {
         Vec2::new(self.x, self.y)
+    }
+
+    /// Linearly interpolate between two points.
+    #[inline]
+    pub fn lerp(&self, other: Point, t: f64) -> Point {
+        self.to_vec2().lerp(other.to_vec2(), t).to_point()
+    }
+
+    /// Determine the midpoint of two points.
+    #[inline]
+    pub fn midpoint(&self, other: Point) -> Point {
+        Point::new(0.5 * (self.x + other.x), 0.5 * (self.y + other.y))
+    }
+}
+
+impl From<(f64, f64)> for Point {
+    #[inline]
+    fn from(v: (f64, f64)) -> Point {
+        Point { x: v.0, y: v.1 }
+    }
+}
+
+impl From<Point> for (f64, f64) {
+    #[inline]
+    fn from(v: Point) -> (f64, f64) {
+        (v.x, v.y)
     }
 }
 

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1,6 +1,6 @@
 //! A generic trait for shapes.
 
-use crate::{BezPath, Circle, Line, PathEl, Rect, Vec2};
+use crate::{BezPath, Circle, Line, PathEl, Point, Rect};
 
 /// A generic trait for open and closed shapes.
 pub trait Shape: Sized {
@@ -42,7 +42,7 @@ pub trait Shape: Sized {
     /// This method only produces meaningful results with closed shapes.
     ///
     /// TODO: figure out sign convention, see #4.
-    fn winding(&self, pt: Vec2) -> i32;
+    fn winding(&self, pt: Point) -> i32;
 
     /// The smallest rectangle that encloses the shape.
     fn bounding_box(&self) -> Rect;
@@ -92,7 +92,7 @@ impl<'a, T: Shape> Shape for &'a T {
         (*self).perimeter(accuracy)
     }
 
-    fn winding(&self, pt: Vec2) -> i32 {
+    fn winding(&self, pt: Point) -> i32 {
         (*self).winding(pt)
     }
 

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -6,9 +6,9 @@ use crate::{Point, Size};
 
 /// A 2D vector.
 ///
-/// This can be interpreted as a point in 2-space, a translation, a
-/// vector, or a complex number; the interpretation is not indicated
-/// in the type.
+/// This is intended primarily for a vector in the mathematical sense,
+/// but it can be interpreted as a translation, and converted to and
+/// from a point (vector relative to the origin) and size.
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
 pub struct Vec2 {
     pub x: f64,
@@ -226,21 +226,5 @@ impl From<mint::Vector2<f64>> for Vec2 {
     #[inline]
     fn from(p: mint::Vector2<f64>) -> Vec2 {
         Vec2 { x: p.x, y: p.y }
-    }
-}
-
-#[cfg(feature = "mint")]
-impl From<Point> for mint::Point2<f64> {
-    #[inline]
-    fn from(p: Point) -> mint::Point2<f64> {
-        mint::Point2 { x: p.x, y: p.y }
-    }
-}
-
-#[cfg(feature = "mint")]
-impl From<mint::Point2<f64>> for Point {
-    #[inline]
-    fn from(p: mint::Point2<f64>) -> Point {
-        Point { x: p.x, y: p.y }
     }
 }

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -2,6 +2,8 @@
 
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
+use crate::{Point, Size};
+
 /// A 2D vector.
 ///
 /// This can be interpreted as a point in 2-space, a translation, a
@@ -18,6 +20,18 @@ impl Vec2 {
     #[inline]
     pub fn new(x: f64, y: f64) -> Vec2 {
         Vec2 { x, y }
+    }
+
+    /// Convert this vector into a `Point`.
+    #[inline]
+    pub fn to_point(self) -> Point {
+        Point::new(self.x, self.y)
+    }
+
+    /// Convert this vector into a `Size`.
+    #[inline]
+    pub fn to_size(self) -> Size {
+        Size::new(self.x, self.y)
     }
 
     /// Dot product of two vectors.
@@ -71,7 +85,7 @@ impl Vec2 {
         }
     }
 
-    /// Linearly interpolate between two points.
+    /// Linearly interpolate between two vectors.
     #[inline]
     pub fn lerp(&self, other: Vec2, t: f64) -> Vec2 {
         *self + t * (other - *self)
@@ -212,5 +226,21 @@ impl From<mint::Vector2<f64>> for Vec2 {
     #[inline]
     fn from(p: mint::Vector2<f64>) -> Vec2 {
         Vec2 { x: p.x, y: p.y }
+    }
+}
+
+#[cfg(feature = "mint")]
+impl From<Point> for mint::Point2<f64> {
+    #[inline]
+    fn from(p: Point) -> mint::Point2<f64> {
+        mint::Point2 { x: p.x, y: p.y }
+    }
+}
+
+#[cfg(feature = "mint")]
+impl From<mint::Point2<f64>> for Point {
+    #[inline]
+    fn from(p: mint::Point2<f64>) -> Point {
+        Point { x: p.x, y: p.y }
     }
 }


### PR DESCRIPTION
Use `Point` and `Size` where appropriate instead of `Vec2`.

Also rename the bezpath ops to conform to Rust naming conventions (`move_to` rather than `moveto`, etc).