### PR TITLE
Add TranslateScale

### DIFF
--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -8,7 +8,7 @@ use crate::common::{solve_cubic, solve_quadratic};
 use crate::MAX_EXTREMA;
 use crate::{
     Affine, CubicBez, Line, ParamCurve, ParamCurveArclen, ParamCurveArea, ParamCurveExtrema,
-    ParamCurveNearest, Point, QuadBez, Rect, Shape,
+    ParamCurveNearest, Point, QuadBez, Rect, Shape, TranslateScale,
 };
 
 /// A path that can Bézier segments up to cubic, possibly with multiple subpaths.
@@ -198,6 +198,36 @@ impl Mul<BezPath> for Affine {
 }
 
 impl<'a> Mul<&'a BezPath> for Affine {
+    type Output = BezPath;
+
+    fn mul(self, other: &BezPath) -> BezPath {
+        BezPath(other.0.iter().map(|&el| self * el).collect())
+    }
+}
+
+impl Mul<PathEl> for TranslateScale {
+    type Output = PathEl;
+
+    fn mul(self, other: PathEl) -> PathEl {
+        match other {
+            PathEl::MoveTo(p) => PathEl::MoveTo(self * p),
+            PathEl::LineTo(p) => PathEl::LineTo(self * p),
+            PathEl::QuadTo(p1, p2) => PathEl::QuadTo(self * p1, self * p2),
+            PathEl::CurveTo(p1, p2, p3) => PathEl::CurveTo(self * p1, self * p2, self * p3),
+            PathEl::ClosePath => PathEl::ClosePath,
+        }
+    }
+}
+
+impl Mul<BezPath> for TranslateScale {
+    type Output = BezPath;
+
+    fn mul(self, other: BezPath) -> BezPath {
+        BezPath(other.0.iter().map(|&el| self * el).collect())
+    }
+}
+
+impl<'a> Mul<&'a BezPath> for TranslateScale {
     type Output = BezPath;
 
     fn mul(self, other: &BezPath) -> BezPath {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ mod rounded_rect;
 mod shape;
 mod size;
 mod svg;
+mod translate_scale;
 mod vec2;
 
 pub use crate::affine::*;
@@ -45,4 +46,5 @@ pub use crate::rounded_rect::*;
 pub use crate::shape::*;
 pub use crate::size::*;
 pub use crate::svg::*;
+pub use crate::translate_scale::*;
 pub use crate::vec2::*;

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -18,9 +18,12 @@ pub struct Rect {
 }
 
 impl Rect {
+    /// The empty rectangle at the origin.
+    pub const ZERO: Rect = Rect::new(0., 0., 0., 0.);
+
     /// A new rectangle from minimum and maximum coordinates.
     #[inline]
-    pub fn new(x0: f64, y0: f64, x1: f64, y1: f64) -> Rect {
+    pub const fn new(x0: f64, y0: f64, x1: f64, y1: f64) -> Rect {
         Rect { x0, y0, x1, y1 }
     }
 

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -72,6 +72,11 @@ impl RoundedRect {
         self.radius
     }
 
+    /// The (non-rounded) rectangle.
+    pub fn rect(&self) -> Rect {
+        self.rect
+    }
+
     /// The origin of the vector.
     ///
     /// This is the top left corner in a y-down space and with

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -1,0 +1,158 @@
+//! A transformation that includes both scale and translation.
+
+use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
+
+use crate::{Affine, Circle, Point, Rect, Vec2};
+
+/// A transformation including scaling and translation.
+#[derive(Clone, Copy, Debug)]
+pub struct TranslateScale {
+    translation: Vec2,
+    scale: f64,
+}
+
+impl TranslateScale {
+    /// Create a new transformation from translation and scale.
+    #[inline]
+    pub fn new(translation: Vec2, scale: f64) -> TranslateScale {
+        TranslateScale { translation, scale }
+    }
+
+    /// Create a new transformation with scale only.
+    #[inline]
+    pub fn scale(s: f64) -> TranslateScale {
+        TranslateScale::new(Vec2::ZERO, s)
+    }
+
+    /// Create a new transformation with translation only.
+    #[inline]
+    pub fn translate(t: Vec2) -> TranslateScale {
+        TranslateScale::new(t, 1.0)
+    }
+
+    /// Decompose transformation into translation and scale.
+    pub fn as_tuple(self) -> (Vec2, f64) {
+        (self.translation, self.scale)
+    }
+}
+
+impl Default for TranslateScale {
+    #[inline]
+    fn default() -> TranslateScale {
+        TranslateScale::scale(1.0)
+    }
+}
+
+impl From<TranslateScale> for Affine {
+    fn from(ts: TranslateScale) -> Affine {
+        let TranslateScale { translation, scale } = ts;
+        Affine::new([scale, 0.0, 0.0, scale, translation.x, translation.y])
+    }
+}
+
+impl Mul<Point> for TranslateScale {
+    type Output = Point;
+
+    #[inline]
+    fn mul(self, other: Point) -> Point {
+        (self.scale * other.to_vec2()).to_point() + self.translation
+    }
+}
+
+impl Mul for TranslateScale {
+    type Output = TranslateScale;
+
+    #[inline]
+    fn mul(self, other: TranslateScale) -> TranslateScale {
+        TranslateScale {
+            translation: self.translation + self.scale * other.translation,
+            scale: self.scale * other.scale,
+        }
+    }
+}
+
+impl MulAssign for TranslateScale {
+    #[inline]
+    fn mul_assign(&mut self, other: TranslateScale) {
+        *self = self.mul(other);
+    }
+}
+
+impl Mul<TranslateScale> for f64 {
+    type Output = TranslateScale;
+
+    #[inline]
+    fn mul(self, other: TranslateScale) -> TranslateScale {
+        TranslateScale {
+            translation: other.translation * self,
+            scale: other.scale * self,
+        }
+    }
+}
+
+impl Add<Vec2> for TranslateScale {
+    type Output = TranslateScale;
+
+    #[inline]
+    fn add(self, other: Vec2) -> TranslateScale {
+        TranslateScale {
+            translation: self.translation + other,
+            scale: self.scale,
+        }
+    }
+}
+
+impl Add<TranslateScale> for Vec2 {
+    type Output = TranslateScale;
+
+    #[inline]
+    fn add(self, other: TranslateScale) -> TranslateScale {
+        other + self
+    }
+}
+
+impl AddAssign<Vec2> for TranslateScale {
+    #[inline]
+    fn add_assign(&mut self, other: Vec2) {
+        *self = self.add(other);
+    }
+}
+
+impl Sub<Vec2> for TranslateScale {
+    type Output = TranslateScale;
+
+    #[inline]
+    fn sub(self, other: Vec2) -> TranslateScale {
+        TranslateScale {
+            translation: self.translation - other,
+            scale: self.scale,
+        }
+    }
+}
+
+impl SubAssign<Vec2> for TranslateScale {
+    #[inline]
+    fn sub_assign(&mut self, other: Vec2) {
+        *self = self.sub(other);
+    }
+}
+
+impl Mul<Circle> for TranslateScale {
+    type Output = Circle;
+
+    #[inline]
+    fn mul(self, other: Circle) -> Circle {
+        Circle::new(self * other.center, self.scale * other.radius)
+    }
+}
+
+impl Mul<Rect> for TranslateScale {
+    type Output = Rect;
+
+    #[inline]
+    fn mul(self, other: Rect) -> Rect {
+        let pt0 = self * Point::new(other.x0, other.y0);
+        let pt1 = self * Point::new(other.x1, other.y1);
+        (pt0, pt1).into()
+    }
+}

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -23,10 +23,13 @@ use crate::{Affine, Circle, CubicBez, Line, Point, QuadBez, Rect, RoundedRect, V
 /// `TranslateScale * Point` is defined but not the other way around.
 ///
 /// Also note that multiplication is not commutative. Thus,
-/// `2.0 * TranslateScale::translate(Vec2::new(1.0, 0.0))` has a
-/// translation of (2, 0), while
-/// `TranslateScale::translate(Vec2::new(1.0, 0.0)) * 2.0` has a
-/// translation of (1, 0). (Both have a scale of 2).
+/// `TranslateScale::scale(2.0) * TranslateScale::translate(Vec2::new(1.0, 0.0))`
+/// has a translation of (2, 0), while
+/// `TranslateScale::translate(Vec2::new(1.0, 0.0)) * TranslateScale::scale(2.0)`
+/// has a translation of (1, 0). (Both have a scale of 2; also note that
+/// the first case can be written
+/// `2.0 * TranslateScale::translate(Vec2::new(1.0, 0.0))` as this case
+/// has an implicit conversion).
 ///
 /// This transformation is less powerful than `Affine`, but can be applied
 /// to more primitives, especially including [`Rect`](struct.Rect.html).
@@ -66,7 +69,7 @@ impl TranslateScale {
     /// left or right) results in the identity transform
     /// (modulo floating point rounding errors).
     ///
-    /// Panics when scale is zero.
+    /// Produces NaN values when scale is zero.
     pub fn inverse(self) -> TranslateScale {
         let scale_recip = self.scale.recip();
         TranslateScale {
@@ -126,18 +129,6 @@ impl Mul<TranslateScale> for f64 {
         TranslateScale {
             translation: other.translation * self,
             scale: other.scale * self,
-        }
-    }
-}
-
-impl Mul<f64> for TranslateScale {
-    type Output = TranslateScale;
-
-    #[inline]
-    fn mul(self, other: f64) -> TranslateScale {
-        TranslateScale {
-            translation: self.translation,
-            scale: self.scale * other,
         }
     }
 }

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -2,7 +2,7 @@
 
 use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 
-use crate::{Affine, Circle, Point, Rect, Vec2};
+use crate::{Affine, Circle, CubicBez, Line, Point, QuadBez, Rect, RoundedRect, Vec2};
 
 /// A transformation including scaling and translation.
 ///
@@ -27,6 +27,9 @@ use crate::{Affine, Circle, Point, Rect, Vec2};
 /// translation of (2, 0), while
 /// `TranslateScale::translate(Vec2::new(1.0, 0.0)) * 2.0` has a
 /// translation of (1, 0). (Both have a scale of 2).
+///
+/// This transformation is less powerful than `Affine`, but can be applied
+/// to more primitives, especially including [`Rect`](struct.Rect.html).
 #[derive(Clone, Copy, Debug)]
 pub struct TranslateScale {
     translation: Vec2,
@@ -195,6 +198,15 @@ impl Mul<Circle> for TranslateScale {
     }
 }
 
+impl Mul<Line> for TranslateScale {
+    type Output = Line;
+
+    #[inline]
+    fn mul(self, other: Line) -> Line {
+        Line::new(self * other.p0, self * other.p1)
+    }
+}
+
 impl Mul<Rect> for TranslateScale {
     type Output = Rect;
 
@@ -203,6 +215,38 @@ impl Mul<Rect> for TranslateScale {
         let pt0 = self * Point::new(other.x0, other.y0);
         let pt1 = self * Point::new(other.x1, other.y1);
         (pt0, pt1).into()
+    }
+}
+
+impl Mul<RoundedRect> for TranslateScale {
+    type Output = RoundedRect;
+
+    #[inline]
+    fn mul(self, other: RoundedRect) -> RoundedRect {
+        RoundedRect::from_rect(self * other.rect(), self.scale * other.radius())
+    }
+}
+
+impl Mul<QuadBez> for TranslateScale {
+    type Output = QuadBez;
+
+    #[inline]
+    fn mul(self, other: QuadBez) -> QuadBez {
+        QuadBez::new(self * other.p0, self * other.p1, self * other.p2)
+    }
+}
+
+impl Mul<CubicBez> for TranslateScale {
+    type Output = CubicBez;
+
+    #[inline]
+    fn mul(self, other: CubicBez) -> CubicBez {
+        CubicBez::new(
+            self * other.p0,
+            self * other.p1,
+            self * other.p2,
+            self * other.p3,
+        )
     }
 }
 

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -16,9 +16,12 @@ pub struct Vec2 {
 }
 
 impl Vec2 {
+    /// The vector (0, 0).
+    pub const ZERO: Vec2 = Vec2::new(0., 0.);
+
     /// Create a new vector.
     #[inline]
-    pub fn new(x: f64, y: f64) -> Vec2 {
+    pub const fn new(x: f64, y: f64) -> Vec2 {
         Vec2 { x, y }
     }
 


### PR DESCRIPTION
Adds a transform that does translation and uniform scale only, and is
thus suitable for transforming Rect and Circle types.

Also fixes #34 because I needed ZERO.