### PR TITLE
Rationalize sign conventions

### DIFF
--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -393,12 +393,12 @@ impl PathSeg {
             if p.y < start.y || p.y >= end.y {
                 return 0;
             }
-            1
+            -1
         } else if end.y < start.y {
             if p.y < end.y || p.y >= start.y {
                 return 0;
             }
-            -1
+            1
         } else {
             return 0;
         };
@@ -490,8 +490,6 @@ impl Shape for BezPath {
     }
 
     /// Signed area.
-    ///
-    /// TODO: figure out sign convention, see #4.
     fn area(&self) -> f64 {
         self.elements().area()
     }
@@ -501,8 +499,6 @@ impl Shape for BezPath {
     }
 
     /// Winding number of point.
-    ///
-    /// TODO: figure out sign convention, see #4.
     fn winding(&self, pt: Point) -> i32 {
         self.elements().winding(pt)
     }
@@ -525,8 +521,6 @@ impl<'a> Shape for &'a [PathEl] {
     }
 
     /// Signed area.
-    ///
-    /// TODO: figure out sign convention, see #4.
     fn area(&self) -> f64 {
         BezPath::segments_of_slice(self).area()
     }
@@ -536,8 +530,6 @@ impl<'a> Shape for &'a [PathEl] {
     }
 
     /// Winding number of point.
-    ///
-    /// TODO: figure out sign convention, see #4.
     fn winding(&self, pt: Point) -> i32 {
         BezPath::segments_of_slice(self).winding(pt)
     }

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -95,7 +95,7 @@ impl Shape for Circle {
 
     fn winding(&self, pt: Point) -> i32 {
         if (pt - self.center).hypot2() < self.radius.powi(2) {
-            self.radius.signum() as i32
+            1
         } else {
             0
         }
@@ -143,5 +143,39 @@ impl Iterator for CirclePathIter {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Circle, Point, Shape};
+    use std::f64::consts::PI;
+
+    fn assert_approx_eq(x: f64, y: f64) {
+        // Note: we might want to be more rigorous in testing the accuracy
+        // of the conversion into Béziers. But this seems good enough.
+        assert!((x - y).abs() < 1e-7, "{} != {}", x, y);
+    }
+
+    #[test]
+    fn area_sign() {
+        let center = Point::new(5.0, 5.0);
+        let c = Circle::new(center, 5.0);
+        assert_approx_eq(c.area(), 25.0 * PI);
+
+        assert_eq!(c.winding(center), 1);
+
+        let p = c.into_bez_path(1e-9);
+        assert_approx_eq(c.area(), p.area());
+        assert_eq!(c.winding(center), p.winding(center));
+
+        let c_neg_radius = Circle::new(center, -5.0);
+        assert_approx_eq(c_neg_radius.area(), 25.0 * PI);
+
+        assert_eq!(c_neg_radius.winding(center), 1);
+
+        let p_neg_radius = c_neg_radius.into_bez_path(1e-9);
+        assert_approx_eq(c_neg_radius.area(), p_neg_radius.area());
+        assert_eq!(c_neg_radius.winding(center), p_neg_radius.winding(center));
     }
 }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -80,7 +80,7 @@ impl Rect {
         self.y1 - self.y0
     }
 
-    /// The origin of the vector.
+    /// The origin of the rectangle.
     ///
     /// This is the top left corner in a y-down space and with
     /// non-negative width and height.
@@ -310,5 +310,35 @@ impl Iterator for RectPathIter {
             5 => Some(PathEl::ClosePath),
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Point, Rect, Shape};
+
+    fn assert_approx_eq(x: f64, y: f64) {
+        assert!((x - y).abs() < 1e-7);
+    }
+
+    #[test]
+    fn area_sign() {
+        let r = Rect::new(0.0, 0.0, 10.0, 10.0);
+        let center = r.center();
+        assert_approx_eq(r.area(), 100.0);
+
+        assert_eq!(r.winding(center), 1);
+
+        let p = r.into_bez_path(1e-9);
+        assert_approx_eq(r.area(), p.area());
+        assert_eq!(r.winding(center), p.winding(center));
+
+        let r_flip = Rect::new(0.0, 10.0, 10.0, 0.0);
+        assert_approx_eq(r_flip.area(), -100.0);
+
+        assert_eq!(r_flip.winding(Point::new(5.0, 5.0)), -1);
+        let p_flip = r_flip.into_bez_path(1e-9);
+        assert_approx_eq(r_flip.area(), p_flip.area());
+        assert_eq!(r_flip.winding(center), p_flip.winding(center));
     }
 }

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -77,10 +77,9 @@ impl RoundedRect {
         self.rect
     }
 
-    /// The origin of the vector.
+    /// The origin of the rectangle.
     ///
-    /// This is the top left corner in a y-down space and with
-    /// non-negative width and height.
+    /// This is the top left corner in a y-down space.
     #[inline]
     pub fn origin(&self) -> Point {
         self.rect.origin()
@@ -308,5 +307,15 @@ mod tests {
 
         let rect = RoundedRect::new(-10.0, -20.0, 10.0, 20.0, 0.0); // rectangle
         assert_eq!(rect.winding(Point::new(10.0, 20.0)), 1); // bottom-right corner
+    }
+
+    #[test]
+    fn bez_conversion() {
+        let rect = RoundedRect::new(-5.0, -5.0, 10.0, 20.0, 5.0);
+        let p = rect.into_bez_path(1e-9);
+        // Note: could be more systematic about tolerance tightness.
+        let epsilon = 1e-7;
+        assert!((rect.area() - p.area()).abs() < epsilon);
+        assert_eq!(p.winding(Point::new(0.0, 0.0)), 1);
     }
 }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -49,7 +49,10 @@ pub trait Shape: Sized {
     ///
     /// This method only produces meaningful results with closed shapes.
     ///
-    /// TODO: figure out sign convention, see #4.
+    /// The convention for positive area is that y increases when x is
+    /// positive. Thus, it is clockwise when down is increasing y (the
+    /// usual convention for graphics), and anticlockwise when
+    /// up is increasing y (the usual convention for math).
     fn area(&self) -> f64;
 
     /// Total length of perimeter.
@@ -59,7 +62,12 @@ pub trait Shape: Sized {
     ///
     /// This method only produces meaningful results with closed shapes.
     ///
-    /// TODO: figure out sign convention, see #4.
+    /// The sign of the winding number is consistent with that of [`area`],
+    /// meaning it is +1 when the point is inside a positive area shape
+    /// and -1 when it is inside a negative area shape. Of course, greater
+    /// magnitude values are also possible when the shape is more complex.
+    ///
+    /// [`area`]: #tymethod.area
     fn winding(&self, pt: Point) -> i32;
 
     /// The smallest rectangle that encloses the shape.


### PR DESCRIPTION
Document sign conventions in Shape. Add tests to confirm this is
indeed the behavior. Fix broken cases. Some doc touchup.

Fixes #4