### PR TITLE
Derive PartialEq for more primitive types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kurbo"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -6,7 +6,7 @@ use std::ops::{Add, Sub};
 use crate::{PathEl, Point, Rect, Shape, Vec2};
 
 /// A circle.
-#[derive(Clone, Copy, Default, Debug)]
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
 pub struct Circle {
     /// The center.
     pub center: Point,

--- a/src/line.rs
+++ b/src/line.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// A single line.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Line {
     pub p0: Point,
     pub p1: Point,

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -5,7 +5,7 @@ use std::ops::{Add, Sub};
 use crate::{PathEl, Point, Shape, Size, Vec2};
 
 /// A rectangle.
-#[derive(Clone, Copy, Default, Debug)]
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
 pub struct Rect {
     /// The minimum x coordinate (left edge).
     pub x0: f64,

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -7,7 +7,7 @@ use std::f64::consts::{FRAC_PI_2, PI};
 ///
 /// By construction the rounded rectangle will have
 /// non-negative dimensions and radius clamped to half size of the rect.
-#[derive(Clone, Copy, Default, Debug)]
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
 pub struct RoundedRect {
     /// Coordinates of the rectangle.
     rect: Rect,


### PR DESCRIPTION
I at least want this for `Rect`, added some others while I was in there, not sure if there's anything tricky to consider here.