### PR TITLE
Better fmt::Display impls for Point & Size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kurbo"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"

--- a/src/point.rs
+++ b/src/point.rs
@@ -121,7 +121,11 @@ impl fmt::Debug for Point {
 
 impl fmt::Display for Point {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "({}, {})", self.x, self.y)
+        write!(formatter, "(")?;
+        fmt::Display::fmt(&self.x, formatter)?;
+        write!(formatter, ", ")?;
+        fmt::Display::fmt(&self.y, formatter)?;
+        write!(formatter, ")")
     }
 }
 
@@ -149,6 +153,15 @@ mod tests {
         let p1 = Point::new(-11., 1.);
         let p2 = Point::new(-7., -2.);
         assert_eq!(p1.distance(p2), 5.);
+    }
+
+    #[test]
+    fn display() {
+        let p = Point::new(0.12345, 9.87654);
+        assert_eq!(format!("{}", p), "(0.12345, 9.87654)");
+
+        let p = Point::new(0.12345, 9.87654);
+        assert_eq!(format!("{:.2}", p), "(0.12, 9.88)");
     }
 }
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -63,7 +63,11 @@ impl fmt::Debug for Size {
 
 impl fmt::Display for Size {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "({}×{})", self.width, self.height)
+        write!(formatter, "(")?;
+        fmt::Display::fmt(&self.width, formatter)?;
+        write!(formatter, "×")?;
+        fmt::Display::fmt(&self.height, formatter)?;
+        write!(formatter, ")")
     }
 }
 
@@ -81,5 +85,19 @@ impl From<Size> for (f64, f64) {
     #[inline]
     fn from(v: Size) -> (f64, f64) {
         (v.width, v.height)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display() {
+        let s = Size::new(-0.12345, 9.87654);
+        assert_eq!(format!("{}", s), "(-0.12345×9.87654)");
+
+        let s = Size::new(-0.12345, 9.87654);
+        assert_eq!(format!("{:+6.2}", s), "( -0.12× +9.88)");
     }
 }


### PR DESCRIPTION
These will now respect formatter arguments for percision, width,
printing the sign, etcetera.

I added this because I wanted to be able to print lower-precision points, and that didn't work with the default format syntax. Now it does.

I _think_ this is a major version bump, since it would theoretically change the behaviour of existing code? In which case I propose holding it back until we next do that for other reasons.