### PR TITLE
Fix incorrect SVG arc parsing

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -18,6 +18,7 @@ impl Arc {
     ///
     /// The generated elemets can be append to an existing bezier path.
     pub fn append_iter(&self, tolerance: f64) -> ArcAppendIter {
+        let sign = self.sweep_angle.signum();
         let scaled_err = self.radii.x.max(self.radii.y) / tolerance;
         // Number of subdivisions per circle based on error tolerance.
         // Note: this may slightly underestimate the error for quadrants.
@@ -25,7 +26,7 @@ impl Arc {
         let n = (n_err * self.sweep_angle.abs() * (1.0 / (2.0 * PI))).ceil();
         let angle_step = self.sweep_angle / n;
         let n = n as usize;
-        let arm_len = (4.0 / 3.0) * (0.25 * angle_step).abs().tan();
+        let arm_len = (4.0 / 3.0) * (0.25 * angle_step).abs().tan() * sign;
         let angle0 = self.start_angle;
         let p0 = sample_ellipse(self.radii, self.x_rotation, angle0);
 

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -351,7 +351,7 @@ impl Arc {
 
 #[cfg(test)]
 mod tests {
-    use crate::BezPath;
+    use crate::{BezPath, Shape};
 
     #[test]
     fn test_parse_svg() {
@@ -363,5 +363,14 @@ mod tests {
     fn test_parse_svg_arc() {
         let path = BezPath::from_svg("M 100 100 A 25 25 0 1 0 -25 25 z").unwrap();
         assert_eq!(path.segments().count(), 3);
+    }
+
+    // Regression test for #51
+    #[test]
+    fn test_parse_svg_arc_pie() {
+        let path = BezPath::from_svg("M 100 100 h 25 a 25 25 0 1 0 -25 25 z").unwrap();
+        // Approximate figures, but useful for regression testing
+        assert_eq!(path.area().round(), -1473.0);
+        assert_eq!(path.perimeter(1e-6).round(), 168.0);
     }
 }


### PR DESCRIPTION
The arc part of the fix in #16 got lost when the arc logic was refactored
in #18. This patch reinstates it and adds a basic test.

Fixes #51