### PR TITLE
bugfix + a regression test

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -2,6 +2,29 @@
 
 use arrayvec::ArrayVec;
 
+/// Find real roots of a polynomial up to order of 3.
+/// Returns values of x for which c0 + c1 x + c2 x² + c3 x³ = 0, allowing for the coefficients
+/// to be equal to 0.
+pub(crate) fn solve_poly_3(c0: f64, c1: f64, c2: f64, c3: f64) -> ArrayVec<[f64; 3]> {
+    if c3 != 0. {
+        return solve_cubic(c0, c1, c2, c3);
+    };
+
+    let mut roots = ArrayVec::new();
+
+    if c2 != 0. {
+        for root in solve_quadratic(c0, c1, c2) {
+            roots.push(root);
+        }
+    } else if c1 != 0. {
+        roots.push(-c0 / c1);
+    } else if c0 == 0. {
+        roots.push(0.);
+    };
+
+    return roots;
+}
+
 /// Find real roots of cubic equation.
 ///
 /// Assumes c3 is nonzero.


### PR DESCRIPTION
Fixes #57. Three notes:
1. Testing if the coefficients are equal to `0.` prevents `NaN` from appearing in case of lower order polynomials but does not prevent significant precision issues if the coefficient is very close to 0.
2. Returning 0 as the solution when all coefficients are 0 is somewhat arbitrary, but I expect it to cause more good than harm in most cases.
3. I made the `solve_poly_3` method `pub(crate)`. In general, I don't see the reason to expose rootfinding procedures from a curve crate - in other words, I would also make `solve_cubic` and `solve_quadratic` `pub(crate)` and hide the `common` module from the public API altogether.