### PR TITLE
Add Rect::min_x/y & max_x/y

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kurbo"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -100,6 +100,30 @@ impl Rect {
         self.y1 - self.y0
     }
 
+    /// Returns the minimum value for the x-coordinate of the rectangle.
+    #[inline]
+    pub fn min_x(&self) -> f64 {
+        self.x0.min(self.x1)
+    }
+
+    /// Returns the maximum value for the x-coordinate of the rectangle.
+    #[inline]
+    pub fn max_x(&self) -> f64 {
+        self.x0.max(self.x1)
+    }
+
+    /// Returns the minimum value for the y-coordinate of the rectangle.
+    #[inline]
+    pub fn min_y(&self) -> f64 {
+        self.y0.min(self.y1)
+    }
+
+    /// Returns the maximum value for the y-coordinate of the rectangle.
+    #[inline]
+    pub fn max_y(&self) -> f64 {
+        self.y0.max(self.y1)
+    }
+
     /// The origin of the rectangle.
     ///
     /// This is the top left corner in a y-down space and with


### PR DESCRIPTION
Was just doing some drawing code in runebender and wanted this; in the general case you could use `x0/x1/y0/y1` directly, but these methods are more robust when dealing with negative width or height, and I find them more readable when writing UI code.