### PR TITLE
Add Rect::to_rounded_rect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kurbo"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -2,7 +2,7 @@
 
 use std::ops::{Add, Sub};
 
-use crate::{Insets, PathEl, Point, Shape, Size, Vec2};
+use crate::{Insets, PathEl, Point, RoundedRect, Shape, Size, Vec2};
 
 /// A rectangle.
 #[derive(Clone, Copy, Default, Debug)]
@@ -241,6 +241,15 @@ impl Rect {
             self.x1.round(),
             self.y1.round(),
         )
+    }
+
+    /// Creates a new [`RoundedRect`] from this `Rect` and the provided
+    /// corner radius.
+    ///
+    /// [`RoundedRect`]: struct.RoundedRect.html
+    #[inline]
+    pub fn to_rounded_rect(self, radius: f64) -> RoundedRect {
+        RoundedRect::from_rect(self, radius)
     }
 }
 


### PR DESCRIPTION
Another little ergonomics helper. The advantage of this over other
ways to construct a rounded rect is that it frees you needing
to bring RoundedRect into scope in the very common case that you
want to construct a RoundedRect from an existing Rect.