### PR TITLE
Implement FromIterator<PathEl> for BezPath

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kurbo"
-version = "0.5.5"
+version = "0.5.6"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"


### PR DESCRIPTION
This allows the user to `collect()` a BezPath from any iterator
of PathEls.

I wanted to document this but wasn't sure of the best place, so
I added a note to the from_vec method, which is a place someone
might look if they were wanting to create a path from an iterator
currently.

This patch also includes another small iteration-related tweak:
it deprecates the `IntoIterator` impl for &BezPath (a borrowed
BezPath) in favor of a simple `iter` method.

This will allow us to add a by-value IntoIterator impl at some
point in the future, and better matches the patterns in libstd.