### PR TITLE
In BezPath::from_svg, support S/s after l/L/v/V/h/H

### DIFF
--- a/src/svg.rs
+++ b/src/svg.rs
@@ -83,6 +83,7 @@ impl BezPath {
                 let pt = lexer.get_maybe_relative(c)?;
                 path.line_to(pt);
                 lexer.last_pt = pt;
+                last_ctrl = Some(pt);
                 last_cmd = c;
             } else if c == b'h' || c == b'H' {
                 let mut x = lexer.get_number()?;
@@ -93,6 +94,7 @@ impl BezPath {
                 let pt = Point::new(x, lexer.last_pt.y);
                 path.line_to(pt);
                 lexer.last_pt = pt;
+                last_ctrl = Some(pt);
                 last_cmd = c;
             } else if c == b'v' || c == b'V' {
                 let mut y = lexer.get_number()?;
@@ -103,6 +105,7 @@ impl BezPath {
                 let pt = Point::new(lexer.last_pt.x, y);
                 path.line_to(pt);
                 lexer.last_pt = pt;
+                last_ctrl = Some(pt);
                 last_cmd = c;
             } else if c == b'q' || c == b'Q' {
                 let p1 = lexer.get_maybe_relative(c)?;
@@ -170,6 +173,7 @@ impl BezPath {
                     }
                 }
 
+                last_ctrl = Some(p);
                 lexer.last_pt = p;
                 last_cmd = c;
             } else if c == b'z' || c == b'Z' {


### PR DESCRIPTION
According to
https://www.w3.org/TR/svg-paths/#PathDataCubicBezierCommands, when
processing shorthand curves, "If there is no previous command or if the
previous command was not an C, c, S or s, assume the first control point
is coincident with the current point." This PR adopts that assumption.

One example of an SVG path that was not loaded correctly before, but is
loaded correctly with this PR is the 16th down flag in the Bravura font:

"M272 -796c-6 -13 -13 -17 -20 -17c-14 0 -22 13 -22 26c0 3 0 5 1 9c5 30 8
60 8 89c0 52 -9 101 -32 149c-69 140 -140 142 -202 144h-5v397s11 1 17
1s18 -2 20 -13c17 -106 73 -122 127 -180c72 -78 98 -106 108 -174c2 -12 3
-23 3 -36c0 -61 -22 -121 -25 -127 c-1 -3 -1 -5 -1 -7c0 -4 1 -6 1 -9c18
-37 29 -78 29 -120v-22c0 -48 -3 -105 -7 -110zM209 -459c2 -3 4 -4 7 -4c5
0 12 3 13 6c5 8 5 18 7 26c1 7 1 13 1 20c0 32 -9 63 -27 89c-33 49 -87 105
-148 105h-8c-8 0 -14 -6 -14 -10c0 -1 0 -2 1 -3c21 -82 67 -106 114 -160
c21 -24 38 -44 54 -69z"

Note that "s" follows "h-5v397" in this example.