### PR TITLE
Add ceil/floor/trunc/expand to various shapes.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -4,6 +4,45 @@
 
 use arrayvec::ArrayVec;
 
+/// Adds convenience methods to `f32` and `f64`.
+pub trait FloatExt<T> {
+    /// Rounds to the nearest integer away from zero,
+    /// unless the provided value is already an integer.
+    ///
+    /// It is to `ceil` what `trunc` is to `floor`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::common::FloatExt;
+    ///
+    /// let f = 3.7_f64;
+    /// let g = 3.0_f64;
+    /// let h = -3.7_f64;
+    /// let i = -5.1_f32;
+    ///
+    /// assert_eq!(f.expand(), 4.0);
+    /// assert_eq!(g.expand(), 3.0);
+    /// assert_eq!(h.expand(), -4.0);
+    /// assert_eq!(i.expand(), -6.0);
+    /// ```
+    fn expand(&self) -> T;
+}
+
+impl FloatExt<f64> for f64 {
+    #[inline]
+    fn expand(&self) -> f64 {
+        self.abs().ceil().copysign(*self)
+    }
+}
+
+impl FloatExt<f32> for f32 {
+    #[inline]
+    fn expand(&self) -> f32 {
+        self.abs().ceil().copysign(*self)
+    }
+}
+
 /// Find real roots of cubic equation.
 ///
 /// The implementation is not (yet) fully robust, but it does handle the case

--- a/src/point.rs
+++ b/src/point.rs
@@ -56,6 +56,20 @@ impl Point {
     pub fn round(self) -> Point {
         Point::new(self.x.round(), self.y.round())
     }
+
+    /// A new `Point`, with `x` and `y` rounded up to the nearest integer,
+    /// unless they are already an integer.
+    #[inline]
+    pub fn ceil(self) -> Point {
+        Point::new(self.x.ceil(), self.y.ceil())
+    }
+
+    /// A new `Point`, with `x` and `y` rounded down to the nearest integer,
+    /// unless they are already an integer.
+    #[inline]
+    pub fn floor(self) -> Point {
+        Point::new(self.x.floor(), self.y.floor())
+    }
 }
 
 impl From<(f64, f64)> for Point {

--- a/src/point.rs
+++ b/src/point.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
+use crate::common::FloatExt;
 use crate::Vec2;
 
 /// A 2D point.
@@ -51,24 +52,103 @@ impl Point {
         (self - other).hypot()
     }
 
-    /// A new `Point`, with each of x and y rounded to the nearest integer value.
+    /// Returns a new `Point`,
+    /// with `x` and `y` rounded to the nearest integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Point;
+    /// let a = Point::new(3.3, 3.6).round();
+    /// let b = Point::new(3.0, -3.1).round();
+    /// assert_eq!(a.x, 3.0);
+    /// assert_eq!(a.y, 4.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -3.0);
+    /// ```
     #[inline]
     pub fn round(self) -> Point {
         Point::new(self.x.round(), self.y.round())
     }
 
-    /// A new `Point`, with `x` and `y` rounded up to the nearest integer,
+    /// Returns a new `Point`,
+    /// with `x` and `y` rounded up to the nearest integer,
     /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Point;
+    /// let a = Point::new(3.3, 3.6).ceil();
+    /// let b = Point::new(3.0, -3.1).ceil();
+    /// assert_eq!(a.x, 4.0);
+    /// assert_eq!(a.y, 4.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -3.0);
+    /// ```
     #[inline]
     pub fn ceil(self) -> Point {
         Point::new(self.x.ceil(), self.y.ceil())
     }
 
-    /// A new `Point`, with `x` and `y` rounded down to the nearest integer,
+    /// Returns a new `Point`,
+    /// with `x` and `y` rounded down to the nearest integer,
     /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Point;
+    /// let a = Point::new(3.3, 3.6).floor();
+    /// let b = Point::new(3.0, -3.1).floor();
+    /// assert_eq!(a.x, 3.0);
+    /// assert_eq!(a.y, 3.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -4.0);
+    /// ```
     #[inline]
     pub fn floor(self) -> Point {
         Point::new(self.x.floor(), self.y.floor())
+    }
+
+    /// Returns a new `Point`,
+    /// with `x` and `y` rounded away from zero to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Point;
+    /// let a = Point::new(3.3, 3.6).expand();
+    /// let b = Point::new(3.0, -3.1).expand();
+    /// assert_eq!(a.x, 4.0);
+    /// assert_eq!(a.y, 4.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -4.0);
+    /// ```
+    #[inline]
+    pub fn expand(self) -> Point {
+        Point::new(self.x.expand(), self.y.expand())
+    }
+
+    /// Returns a new `Point`,
+    /// with `x` and `y` rounded towards zero to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Point;
+    /// let a = Point::new(3.3, 3.6).trunc();
+    /// let b = Point::new(3.0, -3.1).trunc();
+    /// assert_eq!(a.x, 3.0);
+    /// assert_eq!(a.y, 3.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -3.0);
+    /// ```
+    #[inline]
+    pub fn trunc(self) -> Point {
+        Point::new(self.x.trunc(), self.y.trunc())
     }
 }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 use std::ops::{Add, Sub};
 
+use crate::common::FloatExt;
 use crate::{Insets, PathEl, Point, RoundedRect, Shape, Size, Vec2};
 
 /// A rectangle.
@@ -225,6 +226,52 @@ impl Rect {
             self.y0.round(),
             self.x1.round(),
             self.y1.round(),
+        )
+    }
+
+    /// A new `Rect`, with each coordinate value rounded away from zero
+    /// to the nearest integer, unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Rect;
+    /// let rect = Rect::new(3.3, 3.6, 3.0, -3.1).expand();
+    /// assert_eq!(rect.x0, 4.0);
+    /// assert_eq!(rect.y0, 4.0);
+    /// assert_eq!(rect.x1, 3.0);
+    /// assert_eq!(rect.y1, -4.0);
+    /// ```
+    #[inline]
+    pub fn expand(self) -> Rect {
+        Rect::new(
+            self.x0.expand(),
+            self.y0.expand(),
+            self.x1.expand(),
+            self.y1.expand(),
+        )
+    }
+
+    /// A new `Rect`, with each coordinate value rounded towards zero
+    /// to the nearest integer, unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Rect;
+    /// let rect = Rect::new(3.3, 3.6, 3.0, -3.1).trunc();
+    /// assert_eq!(rect.x0, 3.0);
+    /// assert_eq!(rect.y0, 3.0);
+    /// assert_eq!(rect.x1, 3.0);
+    /// assert_eq!(rect.y1, -3.0);
+    /// ```
+    #[inline]
+    pub fn trunc(self) -> Rect {
+        Rect::new(
+            self.x0.trunc(),
+            self.y0.trunc(),
+            self.x1.trunc(),
+            self.y1.trunc(),
         )
     }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -218,7 +218,19 @@ impl Rect {
         )
     }
 
-    /// A new `Rect`, with each coordinate value rounded to the nearest integer.
+    /// Returns a new `Rect`,
+    /// with each coordinate value rounded to the nearest integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Rect;
+    /// let rect = Rect::new(3.3, 3.6, 3.0, -3.1).round();
+    /// assert_eq!(rect.x0, 3.0);
+    /// assert_eq!(rect.y0, 4.0);
+    /// assert_eq!(rect.x1, 3.0);
+    /// assert_eq!(rect.y1, -3.0);
+    /// ```
     #[inline]
     pub fn round(self) -> Rect {
         Rect::new(
@@ -229,8 +241,57 @@ impl Rect {
         )
     }
 
-    /// A new `Rect`, with each coordinate value rounded away from zero
-    /// to the nearest integer, unless they are already an integer.
+    /// Returns a new `Rect`,
+    /// with each coordinate value rounded up to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Rect;
+    /// let rect = Rect::new(3.3, 3.6, 3.0, -3.1).ceil();
+    /// assert_eq!(rect.x0, 4.0);
+    /// assert_eq!(rect.y0, 4.0);
+    /// assert_eq!(rect.x1, 3.0);
+    /// assert_eq!(rect.y1, -3.0);
+    /// ```
+    #[inline]
+    pub fn ceil(self) -> Rect {
+        Rect::new(
+            self.x0.ceil(),
+            self.y0.ceil(),
+            self.x1.ceil(),
+            self.y1.ceil(),
+        )
+    }
+
+    /// Returns a new `Rect`,
+    /// with each coordinate value rounded down to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Rect;
+    /// let rect = Rect::new(3.3, 3.6, 3.0, -3.1).floor();
+    /// assert_eq!(rect.x0, 3.0);
+    /// assert_eq!(rect.y0, 3.0);
+    /// assert_eq!(rect.x1, 3.0);
+    /// assert_eq!(rect.y1, -4.0);
+    /// ```
+    #[inline]
+    pub fn floor(self) -> Rect {
+        Rect::new(
+            self.x0.floor(),
+            self.y0.floor(),
+            self.x1.floor(),
+            self.y1.floor(),
+        )
+    }
+
+    /// Returns a new `Rect`,
+    /// with each coordinate value rounded away from zero to the nearest integer,
+    /// unless they are already an integer.
     ///
     /// # Examples
     ///
@@ -252,8 +313,9 @@ impl Rect {
         )
     }
 
-    /// A new `Rect`, with each coordinate value rounded towards zero
-    /// to the nearest integer, unless they are already an integer.
+    /// Returns a new `Rect`,
+    /// with each coordinate value rounded towards zero to the nearest integer,
+    /// unless they are already an integer.
     ///
     /// # Examples
     ///

--- a/src/size.rs
+++ b/src/size.rs
@@ -1,8 +1,10 @@
 //! A 2D size.
 
-use crate::{Rect, Vec2};
 use std::fmt;
 use std::ops::{Mul, MulAssign};
+
+use crate::common::FloatExt;
+use crate::{Rect, Vec2};
 
 /// A 2D size.
 #[derive(Clone, Copy, Default, PartialEq)]
@@ -50,25 +52,103 @@ impl Size {
         Vec2::new(self.width, self.height)
     }
 
-    /// A new `Size`, with each of width and height rounded to the nearest
-    /// integer value.
+    /// Returns a new `Size`,
+    /// with `width` and `height` rounded to the nearest integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Size;
+    /// let size_pos = Size::new(3.3, 3.6).round();
+    /// assert_eq!(size_pos.width, 3.0);
+    /// assert_eq!(size_pos.height, 4.0);
+    /// let size_neg = Size::new(-3.3, -3.6).round();
+    /// assert_eq!(size_neg.width, -3.0);
+    /// assert_eq!(size_neg.height, -4.0);
+    /// ```
     #[inline]
     pub fn round(self) -> Size {
         Size::new(self.width.round(), self.height.round())
     }
 
-    /// A new `Size`, with `width` and `height` rounded up to the nearest integer,
+    /// Returns a new `Size`,
+    /// with `width` and `height` rounded up to the nearest integer,
     /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Size;
+    /// let size_pos = Size::new(3.3, 3.6).ceil();
+    /// assert_eq!(size_pos.width, 4.0);
+    /// assert_eq!(size_pos.height, 4.0);
+    /// let size_neg = Size::new(-3.3, -3.6).ceil();
+    /// assert_eq!(size_neg.width, -3.0);
+    /// assert_eq!(size_neg.height, -3.0);
+    /// ```
     #[inline]
     pub fn ceil(self) -> Size {
         Size::new(self.width.ceil(), self.height.ceil())
     }
 
-    /// A new `Size`, with `width` and `height` rounded down to the nearest integer,
+    /// Returns a new `Size`,
+    /// with `width` and `height` rounded down to the nearest integer,
     /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Size;
+    /// let size_pos = Size::new(3.3, 3.6).floor();
+    /// assert_eq!(size_pos.width, 3.0);
+    /// assert_eq!(size_pos.height, 3.0);
+    /// let size_neg = Size::new(-3.3, -3.6).floor();
+    /// assert_eq!(size_neg.width, -4.0);
+    /// assert_eq!(size_neg.height, -4.0);
+    /// ```
     #[inline]
     pub fn floor(self) -> Size {
         Size::new(self.width.floor(), self.height.floor())
+    }
+
+    /// Returns a new `Size`,
+    /// with `width` and `height` rounded away from zero to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Size;
+    /// let size_pos = Size::new(3.3, 3.6).expand();
+    /// assert_eq!(size_pos.width, 4.0);
+    /// assert_eq!(size_pos.height, 4.0);
+    /// let size_neg = Size::new(-3.3, -3.6).expand();
+    /// assert_eq!(size_neg.width, -4.0);
+    /// assert_eq!(size_neg.height, -4.0);
+    /// ```
+    #[inline]
+    pub fn expand(self) -> Size {
+        Size::new(self.width.expand(), self.height.expand())
+    }
+
+    /// Returns a new `Size`,
+    /// with `width` and `height` rounded down towards zero the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Size;
+    /// let size_pos = Size::new(3.3, 3.6).trunc();
+    /// assert_eq!(size_pos.width, 3.0);
+    /// assert_eq!(size_pos.height, 3.0);
+    /// let size_neg = Size::new(-3.3, -3.6).trunc();
+    /// assert_eq!(size_neg.width, -3.0);
+    /// assert_eq!(size_neg.height, -3.0);
+    /// ```
+    #[inline]
+    pub fn trunc(self) -> Size {
+        Size::new(self.width.trunc(), self.height.trunc())
     }
 
     /// Convert this `Size` into a [`Rect`] with origin `(0.0, 0.0)`.

--- a/src/size.rs
+++ b/src/size.rs
@@ -57,6 +57,20 @@ impl Size {
         Size::new(self.width.round(), self.height.round())
     }
 
+    /// A new `Size`, with `width` and `height` rounded up to the nearest integer,
+    /// unless they are already an integer.
+    #[inline]
+    pub fn ceil(self) -> Size {
+        Size::new(self.width.ceil(), self.height.ceil())
+    }
+
+    /// A new `Size`, with `width` and `height` rounded down to the nearest integer,
+    /// unless they are already an integer.
+    #[inline]
+    pub fn floor(self) -> Size {
+        Size::new(self.width.floor(), self.height.floor())
+    }
+
     /// Convert this `Size` into a [`Rect`] with origin `(0.0, 0.0)`.
     ///
     /// [`Rect`]: struct.Rect.html

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
+use crate::common::FloatExt;
 use crate::{Point, Size};
 
 /// A 2D vector.
@@ -108,44 +109,103 @@ impl Vec2 {
         self / self.hypot()
     }
 
-    /// Returns a new `Vec2` with each of `x` and `y` rounded to the nearest integer.
-    #[inline]
-    pub fn round(self) -> Vec2 {
-        Vec2::new(self.x.round(), self.y.round())
-    }
-
-    /// Returns a new `Vec2` where each of `x` and `y`, with a non-zero fractional
-    /// part is rounded up to the nearest integer.
+    /// Returns a new `Vec2`,
+    /// with `x` and `y` rounded to the nearest integer.
     ///
     /// # Examples
     ///
     /// ```
     /// use kurbo::Vec2;
+    /// let a = Vec2::new(3.3, 3.6).round();
+    /// let b = Vec2::new(3.0, -3.1).round();
+    /// assert_eq!(a.x, 3.0);
+    /// assert_eq!(a.y, 4.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -3.0);
+    /// ```
+    #[inline]
+    pub fn round(self) -> Vec2 {
+        Vec2::new(self.x.round(), self.y.round())
+    }
+
+    /// Returns a new `Vec2`,
+    /// with `x` and `y` rounded up to the nearest integer,
+    /// unless they are already an integer.
     ///
-    /// let v = Vec2::new(5.0, -1.1);
-    /// let ceil_v = v.ceil();
-    /// assert_eq!((ceil_v.x, ceil_v.y), (5.0, -1.0));
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Vec2;
+    /// let a = Vec2::new(3.3, 3.6).ceil();
+    /// let b = Vec2::new(3.0, -3.1).ceil();
+    /// assert_eq!(a.x, 4.0);
+    /// assert_eq!(a.y, 4.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -3.0);
     /// ```
     #[inline]
     pub fn ceil(self) -> Vec2 {
         Vec2::new(self.x.ceil(), self.y.ceil())
     }
 
-    /// Returns a new `Vec2` where each of `x` and `y`, with a non-zero fractional
-    /// part is rounded down to the nearest integer.
+    /// Returns a new `Vec2`,
+    /// with `x` and `y` rounded down to the nearest integer,
+    /// unless they are already an integer.
     ///
     /// # Examples
     ///
     /// ```
     /// use kurbo::Vec2;
-    ///
-    /// let v = Vec2::new(4.9, -1.1);
-    /// let floor_v = v.floor();
-    /// assert_eq!((floor_v.x, floor_v.y), (4.0, -2.0));
+    /// let a = Vec2::new(3.3, 3.6).floor();
+    /// let b = Vec2::new(3.0, -3.1).floor();
+    /// assert_eq!(a.x, 3.0);
+    /// assert_eq!(a.y, 3.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -4.0);
     /// ```
     #[inline]
     pub fn floor(self) -> Vec2 {
         Vec2::new(self.x.floor(), self.y.floor())
+    }
+
+    /// Returns a new `Vec2`,
+    /// with `x` and `y` rounded away from zero to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Vec2;
+    /// let a = Vec2::new(3.3, 3.6).expand();
+    /// let b = Vec2::new(3.0, -3.1).expand();
+    /// assert_eq!(a.x, 4.0);
+    /// assert_eq!(a.y, 4.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -4.0);
+    /// ```
+    #[inline]
+    pub fn expand(self) -> Vec2 {
+        Vec2::new(self.x.expand(), self.y.expand())
+    }
+
+    /// Returns a new `Vec2`,
+    /// with `x` and `y` rounded towards zero to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kurbo::Vec2;
+    /// let a = Vec2::new(3.3, 3.6).trunc();
+    /// let b = Vec2::new(3.0, -3.1).trunc();
+    /// assert_eq!(a.x, 3.0);
+    /// assert_eq!(a.y, 3.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -3.0);
+    /// ```
+    #[inline]
+    pub fn trunc(self) -> Vec2 {
+        Vec2::new(self.x.trunc(), self.y.trunc())
     }
 }
 


### PR DESCRIPTION
This PR adds:
* `ceil` and `floor` methods to `Point` and `Size`
* `kurbo::common::FloatExt` trait which adds the `expand` method to `f32` and `f64`
* `expand` and `trunc` methods to `Rect`

All of these methods will make it easier to quantize druid layout to integers.