### PR TITLE
Impl Into<Size> for Vec2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kurbo"
-version = "0.5.10"
+version = "0.5.11"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"

--- a/src/size.rs
+++ b/src/size.rs
@@ -295,6 +295,14 @@ impl From<Size> for (f64, f64) {
     }
 }
 
+//FIXME: remove for 0.6.0 https://github.com/linebender/kurbo/issues/95
+impl Into<Size> for Vec2 {
+    #[inline]
+    fn into(self) -> Size {
+        self.to_size()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This is a hotfix to the fact that 9738f43 broke our stable API.

This  should be removed for 0.6.0.

closes #95 