### PR TITLE
Be more permissive in segments_of_slice.

### DIFF
--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -118,7 +118,10 @@ impl BezPath {
     fn segments_of_slice<'a>(slice: &'a [PathEl]) -> BezPathSegs<'a> {
         let first = match slice.get(0) {
             Some(PathEl::MoveTo(ref p)) => *p,
-            Some(_) => panic!("First element has to be a PathEl::Moveto!"),
+            Some(PathEl::LineTo(ref p)) => *p,
+            Some(PathEl::QuadTo(_, ref p2)) => *p2,
+            Some(PathEl::CurveTo(_, _, ref p3)) => *p3,
+            Some(PathEl::ClosePath) => panic!("Can't start a segment on a ClosePath"),
             None => Default::default(),
         };
 
@@ -569,6 +572,10 @@ impl Shape for BezPath {
     }
 }
 
+/// Implements [`Shape`] for a slice of [`PathEl`], provided that the first element of the slice is
+/// not a `PathEl::ClosePath`. If it is, several of these functions will panic.
+///
+/// If the slice starts with `LineTo`, `QuadTo`, or `CurveTo`, it will be treated as a `MoveTo`.
 impl<'a> Shape for &'a [PathEl] {
     type BezPathIter = std::iter::Cloned<std::slice::Iter<'a, PathEl>>;
 

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -117,10 +117,10 @@ impl BezPath {
     // TODO: expose as pub method? Maybe should be a trait so slice.segments() works?
     fn segments_of_slice<'a>(slice: &'a [PathEl]) -> BezPathSegs<'a> {
         let first = match slice.get(0) {
-            Some(PathEl::MoveTo(ref p)) => *p,
-            Some(PathEl::LineTo(ref p)) => *p,
-            Some(PathEl::QuadTo(_, ref p2)) => *p2,
-            Some(PathEl::CurveTo(_, _, ref p3)) => *p3,
+            Some(PathEl::MoveTo(p)) => *p,
+            Some(PathEl::LineTo(p)) => *p,
+            Some(PathEl::QuadTo(_, p2)) => *p2,
+            Some(PathEl::CurveTo(_, _, p3)) => *p3,
             Some(PathEl::ClosePath) => panic!("Can't start a segment on a ClosePath"),
             None => Default::default(),
         };


### PR DESCRIPTION
My use-case is this: I have a druid program that allows for some free-hand drawing. I want to find a bounding box for the part of the curve that was drawn since the last frame. It would be very convenient if I could just slice the current curve and call `bounding_box` on the slice, but it panics if the part of the curve since the last frame doesn't start with a `MoveTo`.