### PR TITLE
Fix pathological behaviour when computing the arc length of a degenerate bezier

### DIFF
--- a/benches/cubic_arclen.rs
+++ b/benches/cubic_arclen.rs
@@ -25,6 +25,12 @@ fn bench_cubic_arclen_1e_6(b: &mut Bencher) {
 }
 
 #[bench]
+fn bench_cubic_arclen_degenerate(b: &mut Bencher) {
+    let c = CubicBez::new((0.0, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0));
+    b.iter(|| test::black_box(c).arclen(1e-6))
+}
+
+#[bench]
 fn bench_cubic_arclen_1e_7(b: &mut Bencher) {
     let c = CubicBez::new((0.0, 0.0), (1.0 / 3.0, 0.0), (2.0 / 3.0, 1.0), (1.0, 1.0));
     b.iter(|| test::black_box(c).arclen(1e-7))

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -157,7 +157,19 @@ impl ParamCurveArclen for CubicBez {
                 rec(&c0, accuracy * 0.5, depth + 1) + rec(&c1, accuracy * 0.5, depth + 1)
             }
         }
-        rec(self, accuracy, 0)
+
+        // Check if the bezier curve is degenerate, or almost degenerate
+        // A degenerate curve where all points are identical will cause infinite recursion in the rec function (well, until MAX_DEPTH at least) in all branches.
+        // This test will in addition be true if the bezier curve is just a simple line (i.e. p0=p1 and p2=p3).
+        // The constant 0.5 has not been mathematically proven to be small enough, but from empirical tests
+        // a value of about 0.87 should be enough. Thus 0.5 is a conservative value.
+        // See https://github.com/linebender/kurbo/pull/100 for more info.
+        if (self.p1 - self.p0).hypot2() + (self.p2 - self.p3).hypot2() <= 0.5 * accuracy * accuracy
+        {
+            (self.p0 - self.p3).hypot()
+        } else {
+            rec(self, accuracy, 0)
+        }
     }
 }
 


### PR DESCRIPTION
Before
```
test bench_cubic_arclen_1e_4            ... bench:         281 ns/iter (+/- 28)
test bench_cubic_arclen_1e_5            ... bench:         281 ns/iter (+/- 20)
test bench_cubic_arclen_1e_6            ... bench:         608 ns/iter (+/- 26)
test bench_cubic_arclen_degenerate      ... bench:   5,914,628 ns/iter (+/- 243,332)
```

After
```
test bench_cubic_arclen_1e_4            ... bench:         277 ns/iter (+/- 8)
test bench_cubic_arclen_1e_5            ... bench:         280 ns/iter (+/- 38)
test bench_cubic_arclen_1e_6            ... bench:         600 ns/iter (+/- 41)
test bench_cubic_arclen_degenerate      ... bench:           6 ns/iter (+/- 0)
```

Fixes #99.