### PR TITLE
Add BezPath flattening

### DIFF
--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -117,7 +117,58 @@ impl BezPath {
 
     /// Flatten the path, invoking the callback repeatedly.
     ///
-    /// The callback is only invoked with lines.
+    /// Flattening is the action of approximating a curve with a succession of line segments.
+    ///
+    /// <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 30" height="30mm" width="120mm">
+    ///   <path d="M26.7 24.94l.82-11.15M44.46 5.1L33.8 7.34" fill="none" stroke="#55d400" stroke-width=".5"/>
+    ///   <path d="M26.7 24.94c.97-11.13 7.17-17.6 17.76-19.84M75.27 24.94l1.13-5.5 2.67-5.48 4-4.42L88 6.7l5.02-1.6" fill="none" stroke="#000"/>
+    ///   <path d="M77.57 19.37a1.1 1.1 0 0 1-1.08 1.08 1.1 1.1 0 0 1-1.1-1.08 1.1 1.1 0 0 1 1.08-1.1 1.1 1.1 0 0 1 1.1 1.1" color="#000" fill="none" stroke="#030303" stroke-linecap="round" stroke-opacity=".5"/>
+    ///   <path d="M77.57 19.37a1.1 1.1 0 0 1-1.08 1.08 1.1 1.1 0 0 1-1.1-1.08 1.1 1.1 0 0 1 1.08-1.1 1.1 1.1 0 0 1 1.1 1.1" color="#000" fill="#fff"/>
+    ///   <path d="M80.22 13.93a1.1 1.1 0 0 1-1.1 1.1 1.1 1.1 0 0 1-1.08-1.1 1.1 1.1 0 0 1 1.1-1.08 1.1 1.1 0 0 1 1.08 1.08" color="#000" fill="none" stroke="#030303" stroke-linecap="round" stroke-opacity=".5"/>
+    ///   <path d="M80.22 13.93a1.1 1.1 0 0 1-1.1 1.1 1.1 1.1 0 0 1-1.08-1.1 1.1 1.1 0 0 1 1.1-1.08 1.1 1.1 0 0 1 1.08 1.08" color="#000" fill="#fff"/>
+    ///   <path d="M84.08 9.55a1.1 1.1 0 0 1-1.08 1.1 1.1 1.1 0 0 1-1.1-1.1 1.1 1.1 0 0 1 1.1-1.1 1.1 1.1 0 0 1 1.08 1.1" color="#000" fill="none" stroke="#030303" stroke-linecap="round" stroke-opacity=".5"/>
+    ///   <path d="M84.08 9.55a1.1 1.1 0 0 1-1.08 1.1 1.1 1.1 0 0 1-1.1-1.1 1.1 1.1 0 0 1 1.1-1.1 1.1 1.1 0 0 1 1.08 1.1" color="#000" fill="#fff"/>
+    ///   <path d="M89.1 6.66a1.1 1.1 0 0 1-1.08 1.1 1.1 1.1 0 0 1-1.08-1.1 1.1 1.1 0 0 1 1.08-1.08 1.1 1.1 0 0 1 1.1 1.08" color="#000" fill="none" stroke="#030303" stroke-linecap="round" stroke-opacity=".5"/>
+    ///   <path d="M89.1 6.66a1.1 1.1 0 0 1-1.08 1.1 1.1 1.1 0 0 1-1.08-1.1 1.1 1.1 0 0 1 1.08-1.08 1.1 1.1 0 0 1 1.1 1.08" color="#000" fill="#fff"/>
+    ///   <path d="M94.4 5a1.1 1.1 0 0 1-1.1 1.1A1.1 1.1 0 0 1 92.23 5a1.1 1.1 0 0 1 1.08-1.08A1.1 1.1 0 0 1 94.4 5" color="#000" fill="none" stroke="#030303" stroke-linecap="round" stroke-opacity=".5"/>
+    ///   <path d="M94.4 5a1.1 1.1 0 0 1-1.1 1.1A1.1 1.1 0 0 1 92.23 5a1.1 1.1 0 0 1 1.08-1.08A1.1 1.1 0 0 1 94.4 5" color="#000" fill="#fff"/>
+    ///   <path d="M76.44 25.13a1.1 1.1 0 0 1-1.1 1.1 1.1 1.1 0 0 1-1.08-1.1 1.1 1.1 0 0 1 1.1-1.1 1.1 1.1 0 0 1 1.08 1.1" color="#000" fill="none" stroke="#030303" stroke-linecap="round" stroke-opacity=".5"/>
+    ///   <path d="M76.44 25.13a1.1 1.1 0 0 1-1.1 1.1 1.1 1.1 0 0 1-1.08-1.1 1.1 1.1 0 0 1 1.1-1.1 1.1 1.1 0 0 1 1.08 1.1" color="#000" fill="#fff"/>
+    ///   <path d="M27.78 24.9a1.1 1.1 0 0 1-1.08 1.08 1.1 1.1 0 0 1-1.1-1.08 1.1 1.1 0 0 1 1.1-1.1 1.1 1.1 0 0 1 1.08 1.1" color="#000" fill="none" stroke="#030303" stroke-linecap="round" stroke-opacity=".5"/>
+    ///   <path d="M27.78 24.9a1.1 1.1 0 0 1-1.08 1.08 1.1 1.1 0 0 1-1.1-1.08 1.1 1.1 0 0 1 1.1-1.1 1.1 1.1 0 0 1 1.08 1.1" color="#000" fill="#fff"/>
+    ///   <path d="M45.4 5.14a1.1 1.1 0 0 1-1.08 1.1 1.1 1.1 0 0 1-1.1-1.1 1.1 1.1 0 0 1 1.1-1.08 1.1 1.1 0 0 1 1.1 1.08" color="#000" fill="none" stroke="#030303" stroke-linecap="round" stroke-opacity=".5"/>
+    ///   <path d="M45.4 5.14a1.1 1.1 0 0 1-1.08 1.1 1.1 1.1 0 0 1-1.1-1.1 1.1 1.1 0 0 1 1.1-1.08 1.1 1.1 0 0 1 1.1 1.08" color="#000" fill="#fff"/>
+    ///   <path d="M28.67 13.8a1.1 1.1 0 0 1-1.1 1.08 1.1 1.1 0 0 1-1.08-1.08 1.1 1.1 0 0 1 1.08-1.1 1.1 1.1 0 0 1 1.1 1.1" color="#000" fill="none" stroke="#030303" stroke-linecap="round" stroke-opacity=".5"/>
+    ///   <path d="M28.67 13.8a1.1 1.1 0 0 1-1.1 1.08 1.1 1.1 0 0 1-1.08-1.08 1.1 1.1 0 0 1 1.08-1.1 1.1 1.1 0 0 1 1.1 1.1" color="#000" fill="#fff"/>
+    ///   <path d="M35 7.32a1.1 1.1 0 0 1-1.1 1.1 1.1 1.1 0 0 1-1.08-1.1 1.1 1.1 0 0 1 1.1-1.1A1.1 1.1 0 0 1 35 7.33" color="#000" fill="none" stroke="#030303" stroke-linecap="round" stroke-opacity=".5"/>
+    ///   <path d="M35 7.32a1.1 1.1 0 0 1-1.1 1.1 1.1 1.1 0 0 1-1.08-1.1 1.1 1.1 0 0 1 1.1-1.1A1.1 1.1 0 0 1 35 7.33" color="#000" fill="#fff"/>
+    ///   <text style="line-height:6.61458302px" x="35.74" y="284.49" font-size="5.29" font-family="Sans" letter-spacing="0" word-spacing="0" fill="#b3b3b3" stroke-width=".26" transform="translate(19.595 -267)">
+    ///     <tspan x="35.74" y="284.49" font-size="10.58">→</tspan>
+    ///   </text>
+    /// </svg>
+    ///
+    /// The tolerance value controls the maximum distance between the curved input
+    /// segments and their polyline approximations. (In technical terms, this is the
+    /// Hausdorff distance). The algorithm attempts to bound this distance between
+    /// by `tolerance` but this is not absolutely guaranteed. The appropriate value
+    /// depends on the use, but for antialiasted rendering, a value of 0.25 has been
+    /// determined to give good results. The number of segments tends to scale as the
+    /// inverse square root of tolerance.
+    ///
+    /// <svg viewBox="0 0 47.5 13.2" height="100" width="350" xmlns="http://www.w3.org/2000/svg">
+    ///   <path d="M-2.44 9.53c16.27-8.5 39.68-7.93 52.13 1.9" fill="none" stroke="#dde9af" stroke-width="4.6"/>
+    ///   <path d="M-1.97 9.3C14.28 1.03 37.36 1.7 49.7 11.4" fill="none" stroke="#00d400" stroke-width=".57" stroke-linecap="round" stroke-dasharray="4.6, 2.291434"/>
+    ///   <path d="M-1.94 10.46L6.2 6.08l28.32-1.4 15.17 6.74" fill="none" stroke="#000" stroke-width=".6"/>
+    ///   <path d="M6.83 6.57a.9.9 0 0 1-1.25.15.9.9 0 0 1-.15-1.25.9.9 0 0 1 1.25-.15.9.9 0 0 1 .15 1.25" color="#000" stroke="#000" stroke-width=".57" stroke-linecap="round" stroke-opacity=".5"/>
+    ///   <path d="M35.35 5.3a.9.9 0 0 1-1.25.15.9.9 0 0 1-.15-1.25.9.9 0 0 1 1.25-.15.9.9 0 0 1 .15 1.24" color="#000" stroke="#000" stroke-width=".6" stroke-opacity=".5"/>
+    ///   <g fill="none" stroke="#ff7f2a" stroke-width=".26">
+    ///     <path d="M20.4 3.8l.1 1.83M19.9 4.28l.48-.56.57.52M21.02 5.18l-.5.56-.6-.53" stroke-width=".2978872"/>
+    ///   </g>
+    /// </svg>
+    ///
+    /// The callback will be called in order with each element of the generated
+    /// path. Because the result is made of polylines, these will be straight-line
+    /// path elements only, no curves.
     ///
     /// This algorithm is based on the blog post [Flattening quadratic Béziers]
     /// but with some refinements. For one, there is a more careful approximation
@@ -132,6 +183,7 @@ impl BezPath {
     /// functionality but works with slices and other [`PathEl`] iterators.
     ///
     /// [Flattening quadratic Béziers]: https://raphlinus.github.io/graphics/curves/2019/12/23/flatten-quadbez.html
+    /// [`PathEl`]: enum.PathEl.html
     pub fn flatten(&self, tolerance: f64, callback: impl FnMut(PathEl)) {
         flatten(self, tolerance, callback);
     }
@@ -296,6 +348,7 @@ pub fn flatten(
                     // estimate for the number of subdivisions for the cubic.
                     // Also retain these parameters for later.
                     let iter = c.to_quads(tolerance * TO_QUAD_TOL);
+                    quad_buf.clear();
                     quad_buf.reserve(iter.size_hint().0);
                     let sqrt_remain_tol = sqrt_tol * (1.0 - TO_QUAD_TOL).sqrt();
                     let mut sum = 0.0;
@@ -327,7 +380,6 @@ pub fn flatten(
                         }
                         val_sum += params.val;
                     }
-                    quad_buf.clear();
                     callback(PathEl::LineTo(p3));
                 }
                 last_pt = Some(p3);

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -49,6 +49,9 @@ impl CubicBez {
     ///
     /// Note that the resulting quadratic Béziers are not in general G1 continuous;
     /// they are optimized for minimizing distance error.
+    ///
+    /// Also note that this iterator may produce zero quadratics when the control points
+    /// are equally spaced and co-linear.
     #[inline]
     pub fn to_quads(&self, accuracy: f64) -> impl Iterator<Item = (f64, f64, QuadBez)> {
         // The maximum error, as a vector from the cubic to the best approximating
@@ -266,6 +269,11 @@ impl Iterator for ToQuads {
         let result = QuadBez::new(seg.p0, ((p1x2 + p2x2) / 4.0).to_point(), seg.p3);
         self.i += 1;
         Some((t0, t1, result))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.n - self.i;
+        (remaining, Some(remaining))
     }
 }
 

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -26,8 +26,8 @@ pub struct CubicBez {
 /// An iterator which produces quadratic Bézier segments.
 struct ToQuads {
     c: CubicBez,
-    max_hypot2: f64,
-    t: f64,
+    i: usize,
+    n: usize,
 }
 
 impl CubicBez {
@@ -51,14 +51,24 @@ impl CubicBez {
     /// they are optimized for minimizing distance error.
     #[inline]
     pub fn to_quads(&self, accuracy: f64) -> impl Iterator<Item = (f64, f64, QuadBez)> {
+        // The maximum error, as a vector from the cubic to the best approximating
+        // quadratic, is proportional to the third derivative, which is constant
+        // across the segment. Thus, the error scales down as the third power of
+        // the number of subdivisions. Our strategy then is to subdivide `t` evenly.
+        //
+        // This is an overestimate of the error because only the component
+        // perpendicular to the first derivative is important. But the simplicity is
+        // appealing.
+
         // This magic number is the square of 36 / sqrt(3).
         // See: http://caffeineowl.com/graphics/2d/vectorial/cubic2quad01.html
         let max_hypot2 = 432.0 * accuracy * accuracy;
-        ToQuads {
-            c: *self,
-            max_hypot2,
-            t: 0.0,
-        }
+        let p1x2 = 3.0 * self.p1.to_vec2() - self.p0.to_vec2();
+        let p2x2 = 3.0 * self.p2.to_vec2() - self.p3.to_vec2();
+        let err = (p2x2 - p1x2).hypot2();
+        let n = (err / max_hypot2).powf(1. / 6.0).ceil() as usize;
+
+        ToQuads { c: *self, n, i: 0 }
     }
 }
 
@@ -245,30 +255,17 @@ impl Iterator for ToQuads {
     type Item = (f64, f64, QuadBez);
 
     fn next(&mut self) -> Option<(f64, f64, QuadBez)> {
-        let t0 = self.t;
-        let mut t1 = 1.0;
-        if t0 == t1 {
+        if self.i == self.n {
             return None;
         }
-        loop {
-            let seg = self.c.subsegment(t0..t1);
-            // Compute error for candidate quadratic.
-            let p1x2 = 3.0 * seg.p1.to_vec2() - seg.p0.to_vec2();
-            let p2x2 = 3.0 * seg.p2.to_vec2() - seg.p3.to_vec2();
-            let err = (p2x2 - p1x2).hypot2();
-            if err < self.max_hypot2 {
-                let result = QuadBez::new(seg.p0, ((p1x2 + p2x2) / 4.0).to_point(), seg.p3);
-                self.t = t1;
-                return Some((t0, t1, result));
-            } else {
-                let shrink = if t1 == 1.0 && err < 64.0 * self.max_hypot2 {
-                    0.5
-                } else {
-                    0.999_999 * (self.max_hypot2 / err).powf(1. / 6.0)
-                };
-                t1 = t0 + shrink * (t1 - t0);
-            }
-        }
+        let t0 = self.i as f64 / self.n as f64;
+        let t1 = (self.i + 1) as f64 / self.n as f64;
+        let seg = self.c.subsegment(t0..t1);
+        let p1x2 = 3.0 * seg.p1.to_vec2() - seg.p0.to_vec2();
+        let p2x2 = 3.0 * seg.p2.to_vec2() - seg.p3.to_vec2();
+        let result = QuadBez::new(seg.p0, ((p1x2 + p2x2) / 4.0).to_point(), seg.p3);
+        self.i += 1;
+        Some((t0, t1, result))
     }
 }
 


### PR DESCRIPTION
This implements the fancy flattening algorithm that I've been blogging about. It also simplifies the cubic to quadratic conversion and cleans up iterator conversions around `BezPath`.
