### PR TITLE
Change Rect's expand/trunc to more useful methods.

### DIFF
--- a/benches/rect_expand.rs
+++ b/benches/rect_expand.rs
@@ -1,0 +1,48 @@
+#![feature(test)]
+extern crate test;
+use test::Bencher;
+
+use kurbo::Rect;
+
+// In positive space
+static RECT_POS: Rect = Rect::new(3.3, 3.6, 5.6, 4.1);
+// In both positive and negative space
+static RECT_PAN: Rect = Rect::new(-3.3, -3.6, 5.6, 4.1);
+// In negative space
+static RECT_NEG: Rect = Rect::new(-5.6, -4.1, -3.3, -3.6);
+// In positive space reverse
+static RECT_POR: Rect = Rect::new(5.6, 4.1, 3.3, 3.6);
+// In both positive and negative space reverse
+static RECT_PNR: Rect = Rect::new(5.6, 4.1, -3.3, -3.6);
+// In negative space reverse
+static RECT_NER: Rect = Rect::new(-3.3, -3.6, -5.6, -4.1);
+// In positive space mixed
+static RECT_POM: Rect = Rect::new(3.3, 4.1, 5.6, 3.6);
+// In both positive and negative space mixed
+static RECT_PNM: Rect = Rect::new(-3.3, 4.1, 5.6, -3.6);
+// In negative space mixed
+static RECT_NEM: Rect = Rect::new(-5.6, -3.6, -3.3, -4.1);
+
+#[inline]
+fn expand(rects: &[Rect; 9]) {
+    test::black_box(rects[0].expand());
+    test::black_box(rects[1].expand());
+    test::black_box(rects[2].expand());
+
+    test::black_box(rects[3].expand());
+    test::black_box(rects[4].expand());
+    test::black_box(rects[5].expand());
+
+    test::black_box(rects[6].expand());
+    test::black_box(rects[7].expand());
+    test::black_box(rects[8].expand());
+}
+
+#[bench]
+fn bench_expand(b: &mut Bencher) {
+    // Creating the array here to prevent the compiler from optimizing all of it to NOP.
+    let rects: [Rect; 9] = [
+        RECT_POS, RECT_PAN, RECT_NEG, RECT_POR, RECT_PNR, RECT_NER, RECT_POM, RECT_PNM, RECT_NEM,
+    ];
+    b.iter(|| expand(&rects));
+}


### PR DESCRIPTION
I added the `expand` / `trunc` methods to various shapes back in #93. They've been quite useful, especially for `Size` in my personal usage. However the implementations for `Rect` were naive. Although their behavior was correctly documented and so not a bug per se, I think the behavior is questionable. That is to say, it's not the `Rect` itself that gets expanded or truncated, its the individual coordinates.

While working on DPI improvements in druid I found a need for methods that `expand` the `Rect` itself, not its coordinates. I also found an existing usage of `Rect::expand` in the [GTK druid-shell code](https://github.com/xi-editor/druid/blob/ec6ac8717bc06e8c3860d8baf3ffac1946026719/druid-shell/src/platform/gtk/window.rs#L537). That specific usage expects the `Rect` itself to be expanded and so is buggy right now.

I also found usage of `Rect::expand` in the blurred rects in piet, [here](https://github.com/linebender/piet/blob/c54ef804ee45dd6e6fd937dbf05012a3812216c7/piet-cairo/src/blurred_rect.rs#L22) and [here](https://github.com/linebender/piet/blob/c54ef804ee45dd6e6fd937dbf05012a3812216c7/piet-direct2d/src/lib.rs#L432). I haven't really analyzed the blurred rects code to know if it expects the coordinates to be expanded or the `Rect` itself. I would imagine the `Rect` itself, but perhaps @raphlinus can chime in here.

This PR changes the behavior of `Rect::expand` and `Rect::trunc` to what I think are less surprising and more useful methods. They perform their action on the `Rect` itself.

I made the following illustration to show the change in behavior:

![kurbo-rect](https://user-images.githubusercontent.com/754881/81061013-46343f80-8edc-11ea-99ae-e12d50d37c64.png)

These new functions also support a reversed orientation `Rect`, e.g. `Rect::new(10, 10, 5, 5)`. That is supported via two `if` statements. As a pleasant surprise LLVM seems to optimize the branches away. I made three different implementations of the functions, two of them branchless. Benchmarks showed no improvement over the much simpler `if` version and after briefly inspecting the assembly it seemed like an optimization success story indeed. I kept the bench code in the PR, but I can delete it if we don't expect future optimization attempts and want to keep the repository clean.