### PR TITLE
Add more PartialEq support.

### DIFF
--- a/src/affine.rs
+++ b/src/affine.rs
@@ -5,7 +5,7 @@ use std::ops::{Mul, MulAssign};
 use crate::{Point, Rect, Vec2};
 
 /// A 2D affine transform.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Affine([f64; 6]);
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -4,7 +4,7 @@ use crate::{PathEl, Point, Vec2};
 use std::f64::consts::{FRAC_PI_2, PI};
 
 /// A single arc segment.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Arc {
     /// The arc's centre point.

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -6,7 +6,7 @@ use std::ops::{Add, Sub};
 use crate::{PathEl, Point, Rect, Shape, Vec2};
 
 /// A circle.
-#[derive(Clone, Copy, Default, Debug)]
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Circle {
     /// The center.

--- a/src/insets.rs
+++ b/src/insets.rs
@@ -102,7 +102,7 @@ use crate::{Rect, Size};
 /// [`Rect`]: struct.Rect.html
 /// [`Insets`]: struct.Insets.html
 /// [`Rect::abs`]: struct.Rect.html#method.abs
-#[derive(Clone, Copy, Default, Debug)]
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Insets {
     /// The minimum x coordinate (left edge).

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -7,7 +7,7 @@ use crate::common::FloatExt;
 use crate::{Insets, PathEl, Point, RoundedRect, Shape, Size, Vec2};
 
 /// A rectangle.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rect {
     /// The minimum x coordinate (left edge).

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -13,7 +13,7 @@ use std::f64::consts::{FRAC_PI_2, PI};
 ///
 /// [`Rect`]: struct.Rect.html
 /// [`to_rounded_rect`]: struct.Rect.html#method.to_rounded_rect
-#[derive(Clone, Copy, Default, Debug)]
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RoundedRect {
     /// Coordinates of the rectangle.


### PR DESCRIPTION
Half the shapes already have `PartialEq` support. I wanted it for `Rect` but it wasn't there so that's why I made this PR. However I added it to a bunch of others that didn't have it either.

There's the usual `f64` comparison issues, but I think if it's fine to have it for `Size` then at minimum that should also apply for `Rect`.