### PR TITLE
Handle exponential notation in svg numbers

### DIFF
--- a/src/svg.rs
+++ b/src/svg.rs
@@ -309,6 +309,25 @@ impl<'a> SvgLexer<'a> {
                 break;
             }
         }
+        if let Some(c) = self.get_byte() {
+            if c == b'e' || c == b'E' {
+                let mut c = self.get_byte().ok_or(SvgParseError::Wrong)?;
+                if c == b'-' || c == b'+' {
+                    c = self.get_byte().ok_or(SvgParseError::Wrong)?
+                }
+                if !(c >= b'0' && c <= b'9') {
+                    return Err(SvgParseError::Wrong);
+                }
+                while let Some(c) = self.get_byte() {
+                    if !(c >= b'0' && c <= b'9') {
+                        self.unget();
+                        break;
+                    }
+                }
+            } else {
+                self.unget();
+            }
+        }
         if digit_count > 0 {
             self.data[start..self.ix]
                 .parse()


### PR DESCRIPTION
It's valid for numbers in svg to be in exponential notation (eg 1e-3).
Fixing this lets us parse more files in the MPVG input set.