### PR TITLE
Add GitHub actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,134 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  rustfmt:
+    runs-on: ubuntu-latest
+    name: cargo fmt
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt
+          override: true
+
+      - name: install rustfmt
+        run: rustup component add rustfmt
+
+      - name: cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  test-stable:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, windows-2019, ubuntu-latest]
+    name: cargo clippy+test
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          profile: minimal
+          override: true
+
+      - name: cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-features --all-targets -- -D warnings
+
+      - name: cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
+
+  test-stable-wasm:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, windows-2019, ubuntu-latest]
+
+    name: cargo clippy+test (wasm32)
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          components: clippy
+          profile: minimal
+          override: true
+
+      - name: cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-features --all-targets --target wasm32-unknown-unknown -- -D warnings
+
+      # TODO: Find a way to make tests work. Until then the tests are merely compiled.
+      - name: cargo test compile
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features --no-run --target wasm32-unknown-unknown
+
+  test-nightly:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, windows-2019, ubuntu-latest]
+    name: cargo test nightly
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
+
+  check-docs:
+    name: Docs
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, windows-2019, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: cargo doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --all-features --document-private-items

--- a/benches/cubic_arclen.rs
+++ b/benches/cubic_arclen.rs
@@ -1,5 +1,6 @@
 //! Benchmarks of cubic arclength approaches.
 
+#![cfg(nightly)]
 #![feature(test)]
 extern crate test;
 use test::Bencher;

--- a/benches/quad_arclen.rs
+++ b/benches/quad_arclen.rs
@@ -2,6 +2,7 @@
 
 // TODO: organize so there's less cut'n'paste from arclen_accuracy example.
 
+#![cfg(nightly)]
 #![feature(test)]
 extern crate test;
 use test::Bencher;

--- a/benches/rect_expand.rs
+++ b/benches/rect_expand.rs
@@ -1,3 +1,4 @@
+#![cfg(nightly)]
 #![feature(test)]
 extern crate test;
 use test::Bencher;

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+# The default clippy value for this is 8 bytes, which is chosen to improve performance on 32-bit.
+# Given that kurbo is being designed for the future and already even mobile phones have 64-bit CPUs,
+# it makes sense to optimize for 64-bit and accept the performance hits on 32-bit.
+# 16 bytes is the number of bytes that fits into two 64-bit CPU registers.
+trivial-copy-size-limit = 16

--- a/examples/arclen_accuracy.rs
+++ b/examples/arclen_accuracy.rs
@@ -2,6 +2,8 @@
 
 // Lots of stuff is commented out or was just something to try.
 #![allow(unused)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::many_single_char_names)]
 
 // TODO: make more functionality accessible from command line rather than uncommenting.
 
@@ -241,6 +243,6 @@ fn main() {
             println!("{} {} {}", x, y, (est_err/error.abs() + 1e-15).log10());
             */
         }
-        println!("");
+        println!();
     }
 }

--- a/examples/cubic_arclen.rs
+++ b/examples/cubic_arclen.rs
@@ -2,6 +2,8 @@
 
 // Lots of stuff is commented out or was just something to try.
 #![allow(unused)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::many_single_char_names)]
 
 use kurbo::common::*;
 use kurbo::{
@@ -108,6 +110,7 @@ fn est_gauss11_error_2(c: CubicBez) -> f64 {
         .sum::<f64>()
 }
 
+#[allow(clippy::neg_cmp_op_on_partial_ord)]
 fn est_max_curvature(c: CubicBez) -> f64 {
     let n = 100;
     let mut max = 0.0;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+max_width = 100
+use_field_init_shorthand = true
+newline_style = "Unix"

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -107,7 +107,7 @@ impl BezPath {
 
     /// Returns an iterator over the path's elements.
     pub fn iter(&self) -> impl Iterator<Item = PathEl> + '_ {
-        self.0.iter().map(|e| *e)
+        self.0.iter().copied()
     }
 
     /// Iterate over the path segments.
@@ -189,7 +189,7 @@ impl BezPath {
     }
 
     // TODO: expose as pub method? Maybe should be a trait so slice.segments() works?
-    fn segments_of_slice<'a>(slice: &'a [PathEl]) -> BezPathSegs<'a> {
+    fn segments_of_slice(slice: &[PathEl]) -> BezPathSegs {
         let first = match slice.get(0) {
             Some(PathEl::MoveTo(p)) => *p,
             Some(PathEl::LineTo(p)) => *p,

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -299,10 +299,10 @@ impl Shape for CircleSegment {
             return 0;
         }
         let dist2 = (pt - self.center).hypot2();
-        if dist2 < self.outer_radius.powi(2) && dist2 > self.inner_radius.powi(2) {
-            1
-        } else if dist2 < self.inner_radius.powi(2) && dist2 > self.outer_radius.powi(2) {
+        if (dist2 < self.outer_radius.powi(2) && dist2 > self.inner_radius.powi(2)) ||
             // case where outer_radius < inner_radius
+            (dist2 < self.inner_radius.powi(2) && dist2 > self.outer_radius.powi(2))
+        {
             1
         } else {
             0

--- a/src/common.rs
+++ b/src/common.rs
@@ -257,7 +257,7 @@ mod tests {
     fn test_solve_quadratic() {
         verify(
             solve_quadratic(-5.0, 0.0, 1.0),
-            &[-5.0f64.sqrt(), 5.0f64.sqrt()],
+            &[-(5.0f64.sqrt()), 5.0f64.sqrt()],
         );
         verify(solve_quadratic(5.0, 0.0, 1.0), &[]);
         verify(solve_quadratic(5.0, 1.0, 0.0), &[-5.0]);

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -353,6 +353,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn cubicbez_signed_area_linear() {
         // y = 1 - x
         let c = CubicBez::new(
@@ -426,10 +427,8 @@ mod tests {
         let c = CubicBez::new((0.0, 0.0), (1.0 / 3.0, 0.0), (2.0 / 3.0, 0.0), (1.0, 1.0));
         for i in 0..10 {
             let accuracy = 0.1f64.powi(i);
-            let mut _count = 0;
             let mut worst: f64 = 0.0;
-            for (t0, t1, q) in c.to_quads(accuracy) {
-                _count += 1;
+            for (_count, (t0, t1, q)) in c.to_quads(accuracy).enumerate() {
                 let epsilon = 1e-12;
                 assert!((q.start() - c.eval(t0)).hypot() < epsilon);
                 assert!((q.end() - c.eval(t1)).hypot() < epsilon);

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -104,6 +104,7 @@ impl Add<Vec2> for Ellipse {
 
     /// In this context adding a `Vec2` applies the corresponding translation to the eliipse.
     #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, v: Vec2) -> Ellipse {
         Ellipse {
             inner: Affine::translate(v) * self.inner,

--- a/src/insets.rs
+++ b/src/insets.rs
@@ -252,6 +252,7 @@ impl Add<Rect> for Insets {
     type Output = Rect;
 
     #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, other: Rect) -> Rect {
         let other = other.abs();
         Rect::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,9 @@
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::many_single_char_names)]
+#![allow(clippy::excessive_precision)]
 
 mod affine;
 mod arc;

--- a/src/point.rs
+++ b/src/point.rs
@@ -240,6 +240,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn distance() {
         let p1 = Point::new(0., 10.);
         let p2 = Point::new(0., 5.);

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -427,7 +427,7 @@ impl Arc {
         let rypx = ry * p.x;
         let sum_of_sq = rxpy * rxpy + rypx * rypx;
 
-        debug_assert_ne!(sum_of_sq, 0.0);
+        debug_assert!(sum_of_sq != 0.0);
 
         // F6.5.2
         let sign_coe = if arc.large_arc == arc.sweep {
@@ -493,6 +493,7 @@ mod tests {
 
     // Regression test for #51
     #[test]
+    #[allow(clippy::float_cmp)]
     fn test_parse_svg_arc_pie() {
         let path = BezPath::from_svg("M 100 100 h 25 a 25 25 0 1 0 -25 25 z").unwrap();
         // Approximate figures, but useful for regression testing
@@ -576,11 +577,9 @@ mod tests {
             let should_follow: bool = rand::random();
             let kind = rng.gen_range(0, 3);
 
-            let first = if should_follow && position.is_some() {
-                position.unwrap()
-            } else {
-                Point::new(rng.gen(), rng.gen())
-            };
+            let first = position
+                .filter(|_| should_follow)
+                .unwrap_or_else(|| Point::new(rng.gen(), rng.gen()));
 
             let element: PathSeg = match kind {
                 0 => Line::new(first, Point::new(rng.gen(), rng.gen())).into(),

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -49,7 +49,7 @@ impl Vec2 {
 
     /// Dot product of two vectors.
     #[inline]
-    pub fn dot(&self, other: Vec2) -> f64 {
+    pub fn dot(self, other: Vec2) -> f64 {
         self.x * other.x + self.y * other.y
     }
 
@@ -57,20 +57,20 @@ impl Vec2 {
     ///
     /// This is signed so that (0, 1) × (1, 0) = 1.
     #[inline]
-    pub fn cross(&self, other: Vec2) -> f64 {
+    pub fn cross(self, other: Vec2) -> f64 {
         self.x * other.y - self.y * other.x
     }
 
     /// Magnitude of vector.
     #[inline]
-    pub fn hypot(&self) -> f64 {
+    pub fn hypot(self) -> f64 {
         self.x.hypot(self.y)
     }
 
     /// Magnitude squared of vector.
     #[inline]
-    pub fn hypot2(&self) -> f64 {
-        self.dot(*self)
+    pub fn hypot2(self) -> f64 {
+        self.dot(self)
     }
 
     /// Angle of vector.
@@ -78,7 +78,7 @@ impl Vec2 {
     /// If the vector is interpreted as a complex number, this is the argument.
     /// The angle is expressed in radians.
     #[inline]
-    pub fn atan2(&self) -> f64 {
+    pub fn atan2(self) -> f64 {
         self.y.atan2(self.x)
     }
 
@@ -102,8 +102,8 @@ impl Vec2 {
 
     /// Linearly interpolate between two vectors.
     #[inline]
-    pub fn lerp(&self, other: Vec2, t: f64) -> Vec2 {
-        *self + t * (other - *self)
+    pub fn lerp(self, other: Vec2, t: f64) -> Vec2 {
+        self + t * (other - self)
     }
 
     /// Returns a vector of magnitude 1.0 with the same angle as `self`; i.e.
@@ -311,6 +311,7 @@ impl Div<f64> for Vec2 {
     ///
     /// This is more efficient but has different roundoff behavior than division.
     #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn div(self, other: f64) -> Vec2 {
         self * other.recip()
     }


### PR DESCRIPTION
This PR adds a GitHub actions script that is an adaptation of the reasonably tested druid script.
It checks for format, docs, clippy, and tests. Platform wise Windows/macOS/Ubuntu + wasm32.
The `rustfmt.toml` and `clippy.toml` files are also taken from druid and are rather basic.

Clippy doesn't like a lot of what's being done here, but I wanted to keep changes minimal. For now I added a bunch of allow tags, especially for unreadable literals and short variable names. There's always the option to gradually remove the tags in the future. Meanwhile it would be good to let clippy catch some other issues.