### PR TITLE
Add aspect ratio function to some types.

### DIFF
--- a/src/rect.rs
+++ b/src/rect.rs
@@ -429,6 +429,16 @@ impl Rect {
         Ellipse::from_rect(self)
     }
 
+    /// The aspect ratio of the `Rect`.
+    ///
+    /// This is defined as the height divided by the width. It measures the "squareness" of the
+    /// rectangle (a value of `1` is square). If the width is `0` the output will be `sign(y1 - y0)
+    /// * infinity`. If The width and height are `0`, the result will be `NaN`.
+    #[inline]
+    pub fn aspect_ratio(&self) -> f64 {
+        self.size().aspect_ratio()
+    }
+
     /// Returns the largest possible `Rect` that is fully contained in `self` with the given
     /// `aspect_ratio`.
     ///
@@ -701,5 +711,11 @@ mod tests {
         case([0.0, 0.0, 0.0, 20.0], 0.0, [0.0, 10.0, 0.0, 10.0]);
         // everything zero
         case([0.0, 0.0, 0.0, 0.0], 0.0, [0.0, 0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn aspect_ratio() {
+        let test = Rect::new(0.0, 0.0, 1.0, 1.0);
+        assert!((test.aspect_ratio() - 1.0).abs() < 1e-6);
     }
 }

--- a/src/size.rs
+++ b/src/size.rs
@@ -178,6 +178,14 @@ impl Size {
         Size::new(self.width.trunc(), self.height.trunc())
     }
 
+    /// Returns the aspect ratio of a rectangle with the given size.
+    ///
+    /// If the width is `0`, the output will be `sign(self.height) * infinity`. If The width and
+    /// height are `0`, then the output will be `NaN`.
+    pub fn aspect_ratio(self) -> f64 {
+        self.height / self.width
+    }
+
     /// Convert this `Size` into a [`Rect`] with origin `(0.0, 0.0)`.
     ///
     /// [`Rect`]: struct.Rect.html
@@ -337,5 +345,11 @@ mod tests {
 
         let s = Size::new(-0.12345, 9.87654);
         assert_eq!(format!("{:+6.2}", s), "( -0.12× +9.88)");
+    }
+
+    #[test]
+    fn aspect_ratio() {
+        let s = Size::new(1.0, 1.0);
+        assert!((s.aspect_ratio() - 1.0).abs() < 1e-6);
     }
 }


### PR DESCRIPTION
These are some more helper methods for the basic types. They would be useful in my case for trying to match a given aspect ratio when constraining during layout.