### PR TITLE
Fix clippy breakage from rustc 1.44.0

### DIFF
--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -1,5 +1,7 @@
 //! Bézier paths (up to cubic).
 
+#![allow(clippy::many_single_char_names)]
+
 use std::iter::{Extend, FromIterator};
 use std::ops::{Mul, Range};
 

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -320,7 +320,7 @@ impl Div<f64> for Vec2 {
 impl DivAssign<f64> for Vec2 {
     #[inline]
     fn div_assign(&mut self, other: f64) {
-        *self *= other.recip();
+        self.mul_assign(other.recip());
     }
 }
 


### PR DESCRIPTION
I don't know we started having failures in BezPath, and I'm
also not of a mind to get too bothered trying to figure it out.