### PR TITLE
Enable trivially_copy_pass_by_ref clippy lint.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 #![allow(clippy::unreadable_literal)]
 #![allow(clippy::many_single_char_names)]
 #![allow(clippy::excessive_precision)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
 
 mod affine;
 mod arc;


### PR DESCRIPTION
Rust 1.44 moved the `trivially_copy_pass_by_ref` clippy lint to pedantic. As discussed on [zulip](https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/Scale.20clippy.20fail) let's turn it back on, at least for now.