### PR TITLE
Add arithmetic between Points and f64s.

### DIFF
--- a/src/point.rs
+++ b/src/point.rs
@@ -199,6 +199,38 @@ impl SubAssign<Vec2> for Point {
     }
 }
 
+impl Add<(f64, f64)> for Point {
+    type Output = Point;
+
+    #[inline]
+    fn add(self, (x, y): (f64, f64)) -> Self {
+        Point::new(self.x + x, self.y + y)
+    }
+}
+
+impl AddAssign<(f64, f64)> for Point {
+    #[inline]
+    fn add_assign(&mut self, (x, y): (f64, f64)) {
+        *self = Point::new(self.x + x, self.y + y)
+    }
+}
+
+impl Sub<(f64, f64)> for Point {
+    type Output = Point;
+
+    #[inline]
+    fn sub(self, (x, y): (f64, f64)) -> Self {
+        Point::new(self.x - x, self.y - y)
+    }
+}
+
+impl SubAssign<(f64, f64)> for Point {
+    #[inline]
+    fn sub_assign(&mut self, (x, y): (f64, f64)) {
+        *self = Point::new(self.x - x, self.y - y)
+    }
+}
+
 impl Sub<Point> for Point {
     type Output = Vec2;
 


### PR DESCRIPTION
This PR adds some convenience functions for adding (f64, f64) to a point.

Potential reasons not to do this: less type safety than using Vec2? I don't think this is an issue, but other opinions may differ.