### PR TITLE
Add Rect::is_empty and Size::{area, is_empty}

### DIFF
--- a/src/rect.rs
+++ b/src/rect.rs
@@ -154,6 +154,14 @@ impl Rect {
         self.width() * self.height()
     }
 
+    /// Whether this rectangle has zero area.
+    ///
+    /// Note: a rectangle with negative area is not considered empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.area() == 0.0
+    }
+
     /// The center point of the rectangle.
     #[inline]
     pub fn center(&self) -> Point {

--- a/src/size.rs
+++ b/src/size.rs
@@ -52,6 +52,20 @@ impl Size {
         self.width.min(self.height)
     }
 
+    /// The area covered by this size.
+    #[inline]
+    pub fn area(self) -> f64 {
+        self.width * self.height
+    }
+
+    /// Whether this size has zero area.
+    ///
+    /// Note: a size with negative area is not considered empty.
+    #[inline]
+    pub fn is_empty(self) -> bool {
+        self.area() == 0.0
+    }
+
     /// Returns a new size bounded by `min` and `max.`
     ///
     /// # Examples


### PR DESCRIPTION
This adds `is_empty` to `Rect` and `Size` as discussed in #134. I also added `Size::area` to implement `is_empty` in terms of it.