### PR TITLE
Restructured path handling in Shape and segments iterator

### DIFF
--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -8,9 +8,9 @@ fn main() {
     println!("<html>");
     println!("<body>");
     println!("<svg height=\"800\" width=\"800\">");
-    let path = circle.into_bez_path(1e-3).to_svg();
+    let path = circle.to_path(1e-3).to_svg();
     println!("  <path d=\"{}\" stroke=\"black\" fill=\"none\" />", path);
-    let path = circle.into_bez_path(1.0).to_svg();
+    let path = circle.to_path(1.0).to_svg();
     println!("  <path d=\"{}\" stroke=\"red\" fill=\"none\" />", path);
     println!("</svg>");
     println!("</body>");

--- a/examples/ellipse.rs
+++ b/examples/ellipse.rs
@@ -9,9 +9,9 @@ fn main() {
     println!("<html>");
     println!("<body>");
     println!("<svg height=\"800\" width=\"800\" style=\"background-color: #999\">");
-    let path = ellipse.into_bez_path(1e-3).to_svg();
+    let path = ellipse.to_path(1e-3).to_svg();
     println!("  <path d=\"{}\" stroke=\"black\" fill=\"none\" />", path);
-    let path = ellipse.into_bez_path(1.0).to_svg();
+    let path = ellipse.to_path(1.0).to_svg();
     println!("  <path d=\"{}\" stroke=\"red\" fill=\"none\" />", path);
     println!("</svg>");
     println!("</body>");

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -148,17 +148,17 @@ impl Shape for Arc {
     /// https://en.wikipedia.org/wiki/Ellipse#Circumference)
     #[inline]
     fn perimeter(&self, accuracy: f64) -> f64 {
-        self.to_path(0.1).perimeter(accuracy)
+        self.to_path_segments(0.1).perimeter(accuracy)
     }
 
     /// Note: shape isn't closed so a point's winding number is not well defined.
     #[inline]
     fn winding(&self, pt: Point) -> i32 {
-        self.to_path(0.1).winding(pt)
+        self.to_path_segments(0.1).winding(pt)
     }
 
     #[inline]
     fn bounding_box(&self) -> Rect {
-        self.to_path(0.1).bounding_box()
+        self.to_path_segments(0.1).bounding_box()
     }
 }

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -129,9 +129,9 @@ fn rotate_pt(pt: Vec2, angle: f64) -> Vec2 {
 }
 
 impl Shape for Arc {
-    type BezPathIter = iter::Chain<iter::Once<PathEl>, ArcAppendIter>;
+    type PathElementsIter = iter::Chain<iter::Once<PathEl>, ArcAppendIter>;
 
-    fn to_bez_path(&self, tolerance: f64) -> Self::BezPathIter {
+    fn to_path_elements(&self, tolerance: f64) -> Self::PathElementsIter {
         let p0 = sample_ellipse(self.radii, self.x_rotation, self.start_angle);
         iter::once(PathEl::MoveTo(self.center + p0)).chain(self.append_iter(tolerance))
     }
@@ -148,20 +148,17 @@ impl Shape for Arc {
     /// https://en.wikipedia.org/wiki/Ellipse#Circumference)
     #[inline]
     fn perimeter(&self, accuracy: f64) -> f64 {
-        self.clone()
-            .into_bez_path(0.1)
-            .elements()
-            .perimeter(accuracy)
+        self.to_path(0.1).perimeter(accuracy)
     }
 
     /// Note: shape isn't closed so a point's winding number is not well defined.
     #[inline]
     fn winding(&self, pt: Point) -> i32 {
-        self.clone().into_bez_path(0.1).elements().winding(pt)
+        self.to_path(0.1).winding(pt)
     }
 
     #[inline]
     fn bounding_box(&self) -> Rect {
-        self.clone().into_bez_path(0.1).elements().bounding_box()
+        self.to_path(0.1).bounding_box()
     }
 }

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -131,7 +131,7 @@ fn rotate_pt(pt: Vec2, angle: f64) -> Vec2 {
 impl Shape for Arc {
     type PathElementsIter = iter::Chain<iter::Once<PathEl>, ArcAppendIter>;
 
-    fn to_path_elements(&self, tolerance: f64) -> Self::PathElementsIter {
+    fn path_elements(&self, tolerance: f64) -> Self::PathElementsIter {
         let p0 = sample_ellipse(self.radii, self.x_rotation, self.start_angle);
         iter::once(PathEl::MoveTo(self.center + p0)).chain(self.append_iter(tolerance))
     }
@@ -148,17 +148,17 @@ impl Shape for Arc {
     /// https://en.wikipedia.org/wiki/Ellipse#Circumference)
     #[inline]
     fn perimeter(&self, accuracy: f64) -> f64 {
-        self.to_path_segments(0.1).perimeter(accuracy)
+        self.path_segments(0.1).perimeter(accuracy)
     }
 
     /// Note: shape isn't closed so a point's winding number is not well defined.
     #[inline]
     fn winding(&self, pt: Point) -> i32 {
-        self.to_path_segments(0.1).winding(pt)
+        self.path_segments(0.1).winding(pt)
     }
 
     #[inline]
     fn bounding_box(&self) -> Rect {
-        self.to_path_segments(0.1).bounding_box()
+        self.path_segments(0.1).bounding_box()
     }
 }

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -521,7 +521,7 @@ impl<I: Iterator<Item = PathEl>> Iterator for Segments<I> {
     fn next(&mut self) -> Option<PathSeg> {
         while let Some(el) = self.elements.next() {
             // We first need to check whether this is the first
-            // elements we see.
+            // path element we see to fill in the start position.
             let (start, last) = self.start_last.get_or_insert_with(|| {
                 let point = match el {
                     PathEl::MoveTo(p) => p,
@@ -565,22 +565,22 @@ impl<I: Iterator<Item = PathEl>> Segments<I> {
     /// the total error is `accuracy` times the number of Bézier segments.
 
     // TODO: pub? Or is this subsumed by method of &[PathEl]?
-    fn arclen(self, accuracy: f64) -> f64 {
+    pub(crate) fn perimeter(self, accuracy: f64) -> f64 {
         self.map(|seg| seg.arclen(accuracy)).sum()
     }
 
     // Same
-    fn area(self) -> f64 {
+    pub(crate) fn area(self) -> f64 {
         self.map(|seg| seg.signed_area()).sum()
     }
 
     // Same
-    fn winding(self, p: Point) -> i32 {
+    pub(crate) fn winding(self, p: Point) -> i32 {
         self.map(|seg| seg.winding(p)).sum()
     }
 
     // Same
-    fn bounding_box(self) -> Rect {
+    pub(crate) fn bounding_box(self) -> Rect {
         let mut bbox: Option<Rect> = None;
         for seg in self {
             let seg_bb = seg.bounding_box();
@@ -969,7 +969,7 @@ impl<'a> Shape for &'a [PathEl] {
     }
 
     fn perimeter(&self, accuracy: f64) -> f64 {
-        segments(self.iter().copied()).arclen(accuracy)
+        segments(self.iter().copied()).perimeter(accuracy)
     }
 
     /// Winding number of point.

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -912,7 +912,7 @@ impl From<QuadBez> for PathSeg {
 impl Shape for BezPath {
     type PathElementsIter = std::vec::IntoIter<PathEl>;
 
-    fn to_path_elements(&self, _tolerance: f64) -> Self::PathElementsIter {
+    fn path_elements(&self, _tolerance: f64) -> Self::PathElementsIter {
         self.0.clone().into_iter()
     }
 
@@ -955,7 +955,7 @@ impl<'a> Shape for &'a [PathEl] {
     type PathElementsIter = std::iter::Cloned<std::slice::Iter<'a, PathEl>>;
 
     #[inline]
-    fn to_path_elements(&self, _tolerance: f64) -> Self::PathElementsIter {
+    fn path_elements(&self, _tolerance: f64) -> Self::PathElementsIter {
         self.iter().cloned()
     }
 

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -910,10 +910,18 @@ impl From<QuadBez> for PathSeg {
 }
 
 impl Shape for BezPath {
-    type BezPathIter = std::vec::IntoIter<PathEl>;
+    type PathElementsIter = std::vec::IntoIter<PathEl>;
 
-    fn to_bez_path(&self, _tolerance: f64) -> Self::BezPathIter {
-        self.clone().0.into_iter()
+    fn to_path_elements(&self, _tolerance: f64) -> Self::PathElementsIter {
+        self.0.clone().into_iter()
+    }
+
+    fn to_path(&self, _tolerance: f64) -> BezPath {
+        self.clone()
+    }
+
+    fn into_path(self, _tolerance: f64) -> BezPath {
+        self
     }
 
     /// Signed area.
@@ -944,11 +952,15 @@ impl Shape for BezPath {
 ///
 /// If the slice starts with `LineTo`, `QuadTo`, or `CurveTo`, it will be treated as a `MoveTo`.
 impl<'a> Shape for &'a [PathEl] {
-    type BezPathIter = std::iter::Cloned<std::slice::Iter<'a, PathEl>>;
+    type PathElementsIter = std::iter::Cloned<std::slice::Iter<'a, PathEl>>;
 
     #[inline]
-    fn to_bez_path(&self, _tolerance: f64) -> Self::BezPathIter {
+    fn to_path_elements(&self, _tolerance: f64) -> Self::PathElementsIter {
         self.iter().cloned()
+    }
+
+    fn to_path(&self, _tolerance: f64) -> BezPath {
+        BezPath::from_vec(self.to_vec())
     }
 
     /// Signed area.

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -85,7 +85,7 @@ pub struct CirclePathIter {
 impl Shape for Circle {
     type PathElementsIter = CirclePathIter;
 
-    fn to_path_elements(&self, tolerance: f64) -> CirclePathIter {
+    fn path_elements(&self, tolerance: f64) -> CirclePathIter {
         let scaled_err = self.radius.abs() / tolerance;
         let (n, arm_len) = if scaled_err < 1.0 / 1.9608e-4 {
             // Solution from http://spencermortensen.com/articles/bezier-circle/
@@ -240,7 +240,7 @@ type CircleSegmentPathIter = std::iter::Chain<
 impl Shape for CircleSegment {
     type PathElementsIter = CircleSegmentPathIter;
 
-    fn to_path_elements(&self, tolerance: f64) -> CircleSegmentPathIter {
+    fn path_elements(&self, tolerance: f64) -> CircleSegmentPathIter {
         iter::once(PathEl::MoveTo(point_on_circle(
             self.center,
             self.inner_radius,

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -83,9 +83,9 @@ pub struct CirclePathIter {
 }
 
 impl Shape for Circle {
-    type BezPathIter = CirclePathIter;
+    type PathElementsIter = CirclePathIter;
 
-    fn to_bez_path(&self, tolerance: f64) -> CirclePathIter {
+    fn to_path_elements(&self, tolerance: f64) -> CirclePathIter {
         let scaled_err = self.radius.abs() / tolerance;
         let (n, arm_len) = if scaled_err < 1.0 / 1.9608e-4 {
             // Solution from http://spencermortensen.com/articles/bezier-circle/
@@ -238,9 +238,9 @@ type CircleSegmentPathIter = std::iter::Chain<
 >;
 
 impl Shape for CircleSegment {
-    type BezPathIter = CircleSegmentPathIter;
+    type PathElementsIter = CircleSegmentPathIter;
 
-    fn to_bez_path(&self, tolerance: f64) -> CircleSegmentPathIter {
+    fn to_path_elements(&self, tolerance: f64) -> CircleSegmentPathIter {
         iter::once(PathEl::MoveTo(point_on_circle(
             self.center,
             self.inner_radius,
@@ -337,7 +337,7 @@ mod tests {
 
         assert_eq!(c.winding(center), 1);
 
-        let p = c.into_bez_path(1e-9);
+        let p = c.to_path(1e-9);
         assert_approx_eq(c.area(), p.area());
         assert_eq!(c.winding(center), p.winding(center));
 
@@ -346,7 +346,7 @@ mod tests {
 
         assert_eq!(c_neg_radius.winding(center), 1);
 
-        let p_neg_radius = c_neg_radius.into_bez_path(1e-9);
+        let p_neg_radius = c_neg_radius.to_path(1e-9);
         assert_approx_eq(c_neg_radius.area(), p_neg_radius.area());
         assert_eq!(c_neg_radius.winding(center), p_neg_radius.winding(center));
     }

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -156,9 +156,9 @@ impl From<Circle> for Ellipse {
 }
 
 impl Shape for Ellipse {
-    type BezPathIter = iter::Chain<iter::Once<PathEl>, ArcAppendIter>;
+    type PathElementsIter = iter::Chain<iter::Once<PathEl>, ArcAppendIter>;
 
-    fn to_bez_path(&self, tolerance: f64) -> Self::BezPathIter {
+    fn to_path_elements(&self, tolerance: f64) -> Self::PathElementsIter {
         let (radii, x_rotation) = self.inner.svd();
         Arc {
             center: self.center(),
@@ -167,7 +167,7 @@ impl Shape for Ellipse {
             sweep_angle: 2.0 * PI,
             x_rotation,
         }
-        .to_bez_path(tolerance)
+        .to_path_elements(tolerance)
     }
 
     #[inline]
@@ -184,10 +184,7 @@ impl Shape for Ellipse {
         // https://www.mathematica-journal.com/2009/11/23/on-the-perimeter-of-an-ellipse/
         // and https://en.wikipedia.org/wiki/Ellipse#Circumference
         //
-        self.clone()
-            .into_bez_path(0.1)
-            .elements()
-            .perimeter(accuracy)
+        self.to_path(0.1).perimeter(accuracy)
     }
 
     fn winding(&self, pt: Point) -> i32 {
@@ -253,7 +250,7 @@ mod tests {
 
         assert_eq!(e.winding(center), 1);
 
-        let p = e.into_bez_path(1e-9);
+        let p = e.to_path(1e-9);
         assert_approx_eq(e.area(), p.area());
         assert_eq!(e.winding(center), p.winding(center));
 
@@ -262,7 +259,7 @@ mod tests {
 
         assert_eq!(e_neg_radius.winding(center), 1);
 
-        let p_neg_radius = e_neg_radius.into_bez_path(1e-9);
+        let p_neg_radius = e_neg_radius.to_path(1e-9);
         assert_approx_eq(e_neg_radius.area(), p_neg_radius.area());
         assert_eq!(e_neg_radius.winding(center), p_neg_radius.winding(center));
     }

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -158,7 +158,7 @@ impl From<Circle> for Ellipse {
 impl Shape for Ellipse {
     type PathElementsIter = iter::Chain<iter::Once<PathEl>, ArcAppendIter>;
 
-    fn to_path_elements(&self, tolerance: f64) -> Self::PathElementsIter {
+    fn path_elements(&self, tolerance: f64) -> Self::PathElementsIter {
         let (radii, x_rotation) = self.inner.svd();
         Arc {
             center: self.center(),
@@ -167,7 +167,7 @@ impl Shape for Ellipse {
             sweep_angle: 2.0 * PI,
             x_rotation,
         }
-        .to_path_elements(tolerance)
+        .path_elements(tolerance)
     }
 
     #[inline]
@@ -184,7 +184,7 @@ impl Shape for Ellipse {
         // https://www.mathematica-journal.com/2009/11/23/on-the-perimeter-of-an-ellipse/
         // and https://en.wikipedia.org/wiki/Ellipse#Circumference
         //
-        self.to_path_segments(0.1).perimeter(accuracy)
+        self.path_segments(0.1).perimeter(accuracy)
     }
 
     fn winding(&self, pt: Point) -> i32 {

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -184,7 +184,7 @@ impl Shape for Ellipse {
         // https://www.mathematica-journal.com/2009/11/23/on-the-perimeter-of-an-ellipse/
         // and https://en.wikipedia.org/wiki/Ellipse#Circumference
         //
-        self.to_path(0.1).perimeter(accuracy)
+        self.to_path_segments(0.1).perimeter(accuracy)
     }
 
     fn winding(&self, pt: Point) -> i32 {

--- a/src/line.rs
+++ b/src/line.rs
@@ -190,7 +190,7 @@ impl Shape for Line {
     type PathElementsIter = LinePathIter;
 
     #[inline]
-    fn to_path_elements(&self, _tolerance: f64) -> LinePathIter {
+    fn path_elements(&self, _tolerance: f64) -> LinePathIter {
         LinePathIter { line: *self, ix: 0 }
     }
 

--- a/src/line.rs
+++ b/src/line.rs
@@ -187,10 +187,10 @@ pub struct LinePathIter {
 }
 
 impl Shape for Line {
-    type BezPathIter = LinePathIter;
+    type PathElementsIter = LinePathIter;
 
     #[inline]
-    fn to_bez_path(&self, _tolerance: f64) -> LinePathIter {
+    fn to_path_elements(&self, _tolerance: f64) -> LinePathIter {
         LinePathIter { line: *self, ix: 0 }
     }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -542,9 +542,9 @@ pub struct RectPathIter {
 }
 
 impl Shape for Rect {
-    type BezPathIter = RectPathIter;
+    type PathElementsIter = RectPathIter;
 
-    fn to_bez_path(&self, _tolerance: f64) -> RectPathIter {
+    fn to_path_elements(&self, _tolerance: f64) -> RectPathIter {
         RectPathIter { rect: *self, ix: 0 }
     }
 
@@ -653,7 +653,7 @@ mod tests {
 
         assert_eq!(r.winding(center), 1);
 
-        let p = r.into_bez_path(1e-9);
+        let p = r.to_path(1e-9);
         assert_approx_eq(r.area(), p.area());
         assert_eq!(r.winding(center), p.winding(center));
 
@@ -661,7 +661,7 @@ mod tests {
         assert_approx_eq(r_flip.area(), -100.0);
 
         assert_eq!(r_flip.winding(Point::new(5.0, 5.0)), -1);
-        let p_flip = r_flip.into_bez_path(1e-9);
+        let p_flip = r_flip.to_path(1e-9);
         assert_approx_eq(r_flip.area(), p_flip.area());
         assert_eq!(r_flip.winding(center), p_flip.winding(center));
     }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -544,7 +544,7 @@ pub struct RectPathIter {
 impl Shape for Rect {
     type PathElementsIter = RectPathIter;
 
-    fn to_path_elements(&self, _tolerance: f64) -> RectPathIter {
+    fn path_elements(&self, _tolerance: f64) -> RectPathIter {
         RectPathIter { rect: *self, ix: 0 }
     }
 

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -119,7 +119,7 @@ pub struct RoundedRectPathIter {
 impl Shape for RoundedRect {
     type PathElementsIter = RoundedRectPathIter;
 
-    fn to_path_elements(&self, tolerance: f64) -> RoundedRectPathIter {
+    fn path_elements(&self, tolerance: f64) -> RoundedRectPathIter {
         let radius = self.radius();
         let radii = Vec2 {
             x: self.radius,

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -117,9 +117,9 @@ pub struct RoundedRectPathIter {
 }
 
 impl Shape for RoundedRect {
-    type BezPathIter = RoundedRectPathIter;
+    type PathElementsIter = RoundedRectPathIter;
 
-    fn to_bez_path(&self, tolerance: f64) -> RoundedRectPathIter {
+    fn to_path_elements(&self, tolerance: f64) -> RoundedRectPathIter {
         let radius = self.radius();
         let radii = Vec2 {
             x: self.radius,
@@ -329,7 +329,7 @@ mod tests {
     #[test]
     fn bez_conversion() {
         let rect = RoundedRect::new(-5.0, -5.0, 10.0, 20.0, 5.0);
-        let p = rect.into_bez_path(1e-9);
+        let p = rect.to_path(1e-9);
         // Note: could be more systematic about tolerance tightness.
         let epsilon = 1e-7;
         assert!((rect.area() - p.area()).abs() < epsilon);

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -4,10 +4,11 @@ use crate::{segments, BezPath, Circle, Line, PathEl, Point, Rect, RoundedRect, S
 
 /// A generic trait for open and closed shapes.
 pub trait Shape: Sized {
-    /// The iterator resulting from `to_path_elements`.
+    /// The iterator resulting from `path_elements`.
     type PathElementsIter: Iterator<Item = PathEl>;
 
-    /// Convert to an iterator over Bézier path _elements_.
+    /// Returns an iterator over this shape expressed as Bézier path
+    /// _elements_.
     ///
     /// Callers should exhaust the `as_` methods first, as those are
     /// likely to be more efficient; in the general case, this
@@ -27,7 +28,7 @@ pub trait Shape: Sized {
     /// iterators from complex shapes without cloning.
     ///
     /// [GAT's]: https://github.com/rust-lang/rust/issues/44265
-    fn to_path_elements(&self, tolerance: f64) -> Self::PathElementsIter;
+    fn path_elements(&self, tolerance: f64) -> Self::PathElementsIter;
 
     /// Convert to a Bézier path.
     ///
@@ -35,9 +36,9 @@ pub trait Shape: Sized {
     /// shape and the resulting path are to be retained.
     ///
     /// The `tolerance` parameter is the same as for
-    /// [`to_path_elements()`](#tymethod.to_path_elements).
+    /// [`path_elements()`](#tymethod.path_elements).
     fn to_path(&self, tolerance: f64) -> BezPath {
-        self.to_path_elements(tolerance).collect()
+        self.path_elements(tolerance).collect()
     }
 
     /// Convert into a Bézier path.
@@ -46,17 +47,18 @@ pub trait Shape: Sized {
     /// shape is already a [`BezPath`](struct.BezPath.html).
     ///
     /// The `tolerance` parameter is the same as for
-    /// [`to_path_elements()`](#tymethod.to_path_elements).
+    /// [`path_elements()`](#tymethod.path_elements).
     fn into_path(self, tolerance: f64) -> BezPath {
         self.to_path(tolerance)
     }
 
-    /// Convert to an iterator over Bézier path _segments_.
+    /// Returns an iterator over this shape expressed as Bézier path
+    /// _segments_.
     ///
     /// The allocation behaviour and `tolerance` parameter are the
-    /// same as for [`to_path_elements()`](#tymethod.to_path_elements).
-    fn to_path_segments(&self, tolerance: f64) -> Segments<Self::PathElementsIter> {
-        segments(self.to_path_elements(tolerance))
+    /// same as for [`path_elements()`](#tymethod.path_elements).
+    fn path_segments(&self, tolerance: f64) -> Segments<Self::PathElementsIter> {
+        segments(self.path_elements(tolerance))
     }
 
     /// Signed area.
@@ -122,16 +124,16 @@ pub trait Shape: Sized {
 impl<'a, T: Shape> Shape for &'a T {
     type PathElementsIter = T::PathElementsIter;
 
-    fn to_path_elements(&self, tolerance: f64) -> Self::PathElementsIter {
-        (*self).to_path_elements(tolerance)
+    fn path_elements(&self, tolerance: f64) -> Self::PathElementsIter {
+        (*self).path_elements(tolerance)
     }
 
     fn to_path(&self, tolerance: f64) -> BezPath {
         (*self).to_path(tolerance)
     }
 
-    fn to_path_segments(&self, tolerance: f64) -> Segments<Self::PathElementsIter> {
-        (*self).to_path_segments(tolerance)
+    fn path_segments(&self, tolerance: f64) -> Segments<Self::PathElementsIter> {
+        (*self).path_segments(tolerance)
     }
 
     fn area(&self) -> f64 {


### PR DESCRIPTION
This implements the plans laid out in #136.

`BezPathSegs` got a bit refactored and renamed to `Segments` created by the public `segments` function.

`Shape` gets the following changes:
- `BezPathIter` -> `PathElementsIter`
- `to_bez_path` -> `to_path_elements`
- `into_bez_path` -> `into_path` and `BezPath` actually uses this for zero-cost conversion
- adds new `to_path` that takes `&self`

Apart from updating the primitive shapes to the new `Shape` interface, I was able to make some functions for `Arc` and `Ellipse` zero-allocation by using methods directly in `Segments` instead of creating an intermediate `BezPath`. I marked the methods on `Segments` as `pub(crate)` for now, but maybe (as a previous TODO also already indicated) it would be a good idea to make them fully public.

Note: This contains breaking changes and needs kurbo `0.7`.