### PR TITLE
Clean up intra-crate docs now they are stable.

### DIFF
--- a/src/affine.rs
+++ b/src/affine.rs
@@ -33,7 +33,7 @@ impl Affine {
     /// [Wikipedia](https://en.wikipedia.org/wiki/Affine_transformation)
     /// formulation of affine transformation as augmented matrix. The
     /// idea is that `(A * B) * v == A * (B * v)`, where `*` is the
-    /// [`Mul`](https://doc.rust-lang.org/std/ops/trait.Mul.html) trait.
+    /// [`Mul`](std::ops::Mul) trait.
     #[inline]
     pub const fn new(c: [f64; 6]) -> Affine {
         Affine(c)

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -81,15 +81,11 @@ use crate::{
 /// for things like subdividing
 ///
 /// [A Primer on Bézier Curves]: https://pomax.github.io/bezierinfo/
-/// [`PathEl`]: enum.PathEl.html
-/// [`PathSeg`]: enum.PathSeg.html
-/// [`QuadBez`]: struct.QuadBez.html
-/// [`CubicBez`]: struct.CubicBez.html
-/// [`iter`]: #method.iter
-/// [`segments`]: #method.segments
-/// [`flatten`]: #method.flatten
-/// [`intersect_line`]: #method.intersect_line
-/// [`segments` free function]: function.segments.html
+/// [`iter`]: BezPath::iter
+/// [`segments`]: BezPath::segments
+/// [`flatten`]: BezPath::flatten
+/// [`intersect_line`]: PathSeg::intersect_line
+/// [`segments` free function]: segments
 /// [`FromIterator<PathEl>`]: std::iter::FromIterator
 /// [`Extend<PathEl>`]: std::iter::Extend
 #[derive(Clone, Default, Debug)]
@@ -130,10 +126,6 @@ pub enum PathSeg {
 /// An intersection of a [`Line`] and a [`PathSeg`].
 ///
 /// This can be generated with the [`PathSeg::intersect_line`] method.
-///
-/// [`Line`]: struct.Line.html
-/// [`PathSeg`]: enum.PathSeg.html
-/// [`PathSeg::intersect_line`]: enum.PathSeg.html#method.intersect_line
 #[derive(Debug, Clone, Copy)]
 pub struct LineIntersection {
     /// The 'time' that the intersection occurs, on the line.
@@ -279,18 +271,17 @@ impl BezPath {
     ///
     /// TODO: write a paper explaining this in more detail.
     ///
-    /// Note: the [`flatten`](fn.flatten.html) function provides the same
+    /// Note: the [`flatten`] function provides the same
     /// functionality but works with slices and other [`PathEl`] iterators.
     ///
     /// [Flattening quadratic Béziers]: https://raphlinus.github.io/graphics/curves/2019/12/23/flatten-quadbez.html
-    /// [`PathEl`]: enum.PathEl.html
     pub fn flatten(&self, tolerance: f64, callback: impl FnMut(PathEl)) {
         flatten(self, tolerance, callback);
     }
 
     /// Get the segment at the given element index.
     ///
-    /// The element index counts [`PathEl`](enum.PathEl.html) elements, so
+    /// The element index counts [`PathEl`] elements, so
     /// for example includes an initial `Moveto`.
     pub fn get_seg(&self, ix: usize) -> Option<PathSeg> {
         if ix == 0 || ix >= self.0.len() {
@@ -370,7 +361,7 @@ const TO_QUAD_TOL: f64 = 0.1;
 
 /// Flatten the path, invoking the callback repeatedly.
 ///
-/// See [`BezPath::flatten`](struct.BezPath.html#method.flatten) for more discussion.
+/// See [`BezPath::flatten`] for more discussion.
 /// This signature is a bit more general, allowing flattening of `&[PathEl]` slices
 /// and other iterators yielding `PathEl`.
 pub fn flatten(
@@ -547,7 +538,7 @@ impl<'a> Mul<&'a BezPath> for TranslateScale {
 /// Transform an iterator over path elements into one over path
 /// segments.
 ///
-/// See also [`BezPath::segments`](struct.BezPath.html#method.segments).
+/// See also [`BezPath::segments`].
 /// This signature is a bit more general, allowing `&[PathEl]` slices
 /// and other iterators yielding `PathEl`.
 pub fn segments<I>(elements: I) -> Segments<I::IntoIter>
@@ -562,7 +553,7 @@ where
 
 /// An iterator that transforms path elements to path segments.
 ///
-/// This struct is created by the [`segments`](fn.segments.html) function.
+/// This struct is created by the [`segments`] function.
 pub struct Segments<I: Iterator<Item = PathEl>> {
     elements: I,
     start_last: Option<(Point, Point)>,

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -29,8 +29,6 @@ impl Circle {
     }
 
     /// Create a [`CircleSegment`] by cutting out parts of this circle.
-    ///
-    /// [`CircleSegment`]: struct.CircleSegment.html
     pub fn segment(self, inner_radius: f64, start_angle: f64, sweep_angle: f64) -> CircleSegment {
         CircleSegment {
             center: self.center,

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -29,8 +29,6 @@ impl Ellipse {
     ///
     /// Rotation is clockwise in a y-down coordinate system. For more on
     /// rotation, see [`Affine::rotate`].
-    ///
-    /// [`Affine::rotate`]: Affine::rotate
     #[inline]
     pub fn new(center: impl Into<Point>, radii: impl Into<Vec2>, x_rotation: f64) -> Ellipse {
         let Point { x: cx, y: cy } = center.into();
@@ -45,8 +43,7 @@ impl Ellipse {
     /// This ellipse is always axis-aligned; to apply rotation you can call
     /// [`with_rotation`] with the result.
     ///
-    /// [`Rect`]: struct.Rect.html
-    /// [`with_rotation`]: #method.with_rotation
+    /// [`with_rotation`]: Ellipse::with_rotation
     #[inline]
     pub fn from_rect(rect: Rect) -> Self {
         let center = rect.center().to_vec2();
@@ -83,8 +80,6 @@ impl Ellipse {
     ///
     /// The rotation is clockwise, for a y-down coordinate system. For more
     /// on rotation, See [`Affine::rotate`].
-    ///
-    /// [`Affine::rotate`]: Affine::rotate
     #[must_use]
     pub fn with_rotation(self, rotation: f64) -> Ellipse {
         let scale = self.inner.svd().0;

--- a/src/insets.rs
+++ b/src/insets.rs
@@ -98,10 +98,6 @@ use crate::{Rect, Size};
 /// assert_eq!(insets2.x_value(), insets.x_value());
 /// assert_eq!(insets2.y_value(), insets.y_value());
 /// ```
-///
-/// [`Rect`]: struct.Rect.html
-/// [`Insets`]: struct.Insets.html
-/// [`Rect::abs`]: struct.Rect.html#method.abs
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Insets {
@@ -200,9 +196,8 @@ impl Insets {
     /// assert_eq!(insets.size(), Size::new(insets.x_value(), insets.y_value()));
     /// ```
     ///
-    /// [`Size`]: struct.Size.html
-    /// [`x_value`]: #method.x_value
-    /// [`y_value`]: #method.y_value
+    /// [`x_value`]: Insets::x_value
+    /// [`y_value`]: Insets::y_value
     pub fn size(self) -> Size {
         Size::new(self.x_value(), self.y_value())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,6 @@
 //! let hit = closest_perimeter_point(circle, hit_point).unwrap();
 //! assert!(hit.distance(expectation) <= DESIRED_ACCURACY);
 //! ```
-//!
-//! [`Shape`]: trait.Shape.html
-//! [`Point`]: struct.Point.html
 //! [`Piet`]: https://docs.rs/piet
 //! [`Druid`]: https://docs.rs/druid
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -86,8 +86,6 @@ impl Rect {
     /// assert_eq!(inset_rect.x0, -2.0);
     /// assert_eq!(inset_rect.x1, 12.0);
     /// ```
-    ///
-    /// [`Insets`]: struct.Insets.html
     #[inline]
     pub fn inset(self, insets: impl Into<Insets>) -> Rect {
         self + insets.into()
@@ -422,16 +420,12 @@ impl Rect {
 
     /// Creates a new [`RoundedRect`] from this `Rect` and the provided
     /// corner radius.
-    ///
-    /// [`RoundedRect`]: struct.RoundedRect.html
     #[inline]
     pub fn to_rounded_rect(self, radius: f64) -> RoundedRect {
         RoundedRect::from_rect(self, radius)
     }
 
     /// Returns the [`Ellipse`] that is bounded by this `Rect`.
-    ///
-    /// [`Ellipse`]: struct.Ellipse.html
     #[inline]
     pub fn to_ellipse(self) -> Ellipse {
         Ellipse::from_rect(self)

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -11,8 +11,7 @@ use std::f64::consts::{FRAC_PI_2, PI};
 /// The easiest way to create a `RoundedRect` is often to create a [`Rect`],
 /// and then call [`to_rounded_rect`].
 ///
-/// [`Rect`]: struct.Rect.html
-/// [`to_rounded_rect`]: struct.Rect.html#method.to_rounded_rect
+/// [`to_rounded_rect`]: Rect::to_rounded_rect
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RoundedRect {
@@ -36,8 +35,6 @@ impl RoundedRect {
     /// The result will have non-negative width, height and radius.
     ///
     /// See also [`Rect::to_rounded_rect`], which offers the same utility.
-    ///
-    /// [`Rect::to_rounded_rect`]: struct.Rect.html#method.to_rounded_rect
     #[inline]
     pub fn from_rect(rect: Rect, radius: f64) -> RoundedRect {
         let rect = rect.abs();
@@ -52,8 +49,6 @@ impl RoundedRect {
     /// A new rectangle from two [`Point`]s.
     ///
     /// The result will have non-negative width, height and radius.
-    ///
-    /// [`Point`]: struct.Point.html
     #[inline]
     pub fn from_points(p0: impl Into<Point>, p1: impl Into<Point>, radius: f64) -> RoundedRect {
         Rect::from_points(p0, p1).to_rounded_rect(radius)

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -8,14 +8,13 @@ use crate::{segments, BezPath, Circle, Line, PathEl, Point, Rect, RoundedRect, S
 /// general geometry functionality like computing [`area`], [`bounding_box`]es,
 /// and [`winding`] number.
 ///
-/// [`BezPath`]: struct.BezPath.html
-/// [`area`]: #tymethod.area
-/// [`bounding_box`]: #tymethod.bounding_box
-/// [`winding`]: #tymethod.winding
+/// [`area`]: Shape::area
+/// [`bounding_box`]: Shape::bounding_box
+/// [`winding`]: Shape::winding
 pub trait Shape: Sized {
     /// The iterator returned by the [`path_elements`] method.
     ///
-    /// [`path_elements`]: #tymethod.path_elements
+    /// [`path_elements`]: Shape::path_elements
     type PathElementsIter: Iterator<Item = PathEl>;
 
     /// Returns an iterator over this shape expressed as [`PathEl`]s;
@@ -48,9 +47,9 @@ pub trait Shape: Sized {
     /// iterators from complex shapes without cloning.
     ///
     /// [GAT's]: https://github.com/rust-lang/rust/issues/44265
-    /// [`as_rect`]: #tymethod.as_rect
-    /// [`as_line`]: #tymethod.as_line
-    /// [`to_path`]: #tymethod.to_path
+    /// [`as_rect`]: Shape::as_rect
+    /// [`as_line`]: Shape::as_line
+    /// [`to_path`]: Shape::to_path
     fn path_elements(&self, tolerance: f64) -> Self::PathElementsIter;
 
     /// Convert to a Bézier path.
@@ -64,7 +63,7 @@ pub trait Shape: Sized {
     ///
     /// The `tolerance` parameter is the same as for [`path_elements`].
     ///
-    /// [`path_elements`]: #tymethod.path_elements
+    /// [`path_elements`]: Shape::path_elements
     fn to_path(&self, tolerance: f64) -> BezPath {
         self.path_elements(tolerance).collect()
     }
@@ -77,10 +76,11 @@ pub trait Shape: Sized {
     /// Convert into a Bézier path.
     ///
     /// This allocates in the general case, but is zero-cost if the
-    /// shape is already a [`BezPath`](struct.BezPath.html).
+    /// shape is already a [`BezPath`].
     ///
-    /// The `tolerance` parameter is the same as for
-    /// [`path_elements()`](#tymethod.path_elements).
+    /// The `tolerance` parameter is the same as for [`path_elements()`].
+    ///
+    /// [`path_elements()`]: Shape::path_elements
     fn into_path(self, tolerance: f64) -> BezPath {
         self.to_path(tolerance)
     }
@@ -95,9 +95,10 @@ pub trait Shape: Sized {
     /// _segments_ ([`PathSeg`]s).
     ///
     /// The allocation behaviour and `tolerance` parameter are the
-    /// same as for [`path_elements()`](#tymethod.path_elements).
+    /// same as for [`path_elements()`]
     ///
-    /// [`PathSeg`]: enum.PathSeg.html
+    /// [`PathSeg`]: crate::PathSeg
+    /// [`path_elements()`]: Shape::path_elements
     fn path_segments(&self, tolerance: f64) -> Segments<Self::PathElementsIter> {
         segments(self.path_elements(tolerance))
     }
@@ -125,15 +126,13 @@ pub trait Shape: Sized {
     /// and -1 when it is inside a negative area shape. Of course, greater
     /// magnitude values are also possible when the shape is more complex.
     ///
-    /// [`area`]: #tymethod.area
+    /// [`area`]: Shape::area
     /// [winding number]: https://mathworld.wolfram.com/ContourWindingNumber.html
     fn winding(&self, pt: Point) -> i32;
 
     /// Returns `true` if the [`Point`] is inside this shape.
     ///
     /// This is only meaningful for closed shapes.
-    ///
-    /// [`Point`]: struct.Point.html
     fn contains(&self, pt: Point) -> bool {
         self.winding(pt) != 0
     }

--- a/src/size.rs
+++ b/src/size.rs
@@ -86,8 +86,6 @@ impl Size {
 
     /// Convert this size into a [`Vec2`], with `width` mapped to `x` and `height`
     /// mapped to `y`.
-    ///
-    /// [`Vec2`]: struct.Vec2.html
     #[inline]
     pub const fn to_vec2(self) -> Vec2 {
         Vec2::new(self.width, self.height)
@@ -201,8 +199,6 @@ impl Size {
     }
 
     /// Convert this `Size` into a [`Rect`] with origin `(0.0, 0.0)`.
-    ///
-    /// [`Rect`]: struct.Rect.html
     #[inline]
     pub const fn to_rect(self) -> Rect {
         Rect::new(0., 0., self.width, self.height)
@@ -210,8 +206,6 @@ impl Size {
 
     /// Convert this `Size` into a [`RoundedRect`] with origin `(0.0, 0.0)` and
     /// the provided corner radius.
-    ///
-    /// [`RoundedRect`]: struct.RoundedRect.html
     #[inline]
     pub fn to_rounded_rect(self, radius: f64) -> RoundedRect {
         self.to_rect().to_rounded_rect(radius)

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -15,7 +15,7 @@ use crate::{Affine, Circle, CubicBez, Line, Point, QuadBez, Rect, RoundedRect, V
 /// | 0 0 1 |
 /// ```
 ///
-/// See [`Affine`](struct.Affine.html) for more details about the
+/// See [`Affine`] for more details about the
 /// equivalence with augmented matrices.
 ///
 /// Various multiplication ops are defined, and these are all defined
@@ -32,7 +32,7 @@ use crate::{Affine, Circle, CubicBez, Line, Point, QuadBez, Rect, RoundedRect, V
 /// has an implicit conversion).
 ///
 /// This transformation is less powerful than `Affine`, but can be applied
-/// to more primitives, especially including [`Rect`](struct.Rect.html).
+/// to more primitives, especially including [`Rect`].
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TranslateScale {

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -91,7 +91,9 @@ impl Vec2 {
     /// Thus, in a Y-down coordinate system (as is common for graphics),
     /// it is a clockwise rotation, and in Y-up (traditional for math), it
     /// is anti-clockwise. This convention is consistent with
-    /// [`Affine::rotate`](struct.Affine.html#method.rotate).
+    /// [`Affine::rotate`].
+    ///
+    /// [`Affine::rotate`]: crate::Affine::rotate
     #[inline]
     pub fn from_angle(th: f64) -> Vec2 {
         Vec2 {


### PR DESCRIPTION
Older versions of rustc will still work but might get warnings. This was the case before this patch, as the crate already uses intra-doc references.