### PR TITLE
Give ParamCurveNearest::nearest a struct return type

### DIFF
--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -11,8 +11,8 @@ use arrayvec::ArrayVec;
 use crate::common::{solve_cubic, solve_quadratic};
 use crate::MAX_EXTREMA;
 use crate::{
-    Affine, CubicBez, Line, ParamCurve, ParamCurveArclen, ParamCurveArea, ParamCurveExtrema,
-    ParamCurveNearest, Point, QuadBez, Rect, Shape, TranslateScale,
+    Affine, CubicBez, Line, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea,
+    ParamCurveExtrema, ParamCurveNearest, Point, QuadBez, Rect, Shape, TranslateScale,
 };
 
 /// A Bézier path.
@@ -689,7 +689,7 @@ impl ParamCurveArea for PathSeg {
 }
 
 impl ParamCurveNearest for PathSeg {
-    fn nearest(&self, p: Point, accuracy: f64) -> (f64, f64) {
+    fn nearest(&self, p: Point, accuracy: f64) -> Nearest {
         match *self {
             PathSeg::Line(line) => line.nearest(p, accuracy),
             PathSeg::Quad(quad) => quad.nearest(p, accuracy),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,9 +52,9 @@
 //! fn closest_perimeter_point(shape: impl Shape, pt: Point) -> Option<Point> {
 //!     let mut best: Option<(Point, f64)> = None;
 //!     for segment in shape.path_segments(DESIRED_ACCURACY) {
-//!         let (t, distance) = segment.nearest(pt, DESIRED_ACCURACY);
-//!         if best.map(|(_, best_d)| distance < best_d).unwrap_or(true) {
-//!             best = Some((segment.eval(t), distance))
+//!         let nearest = segment.nearest(pt, DESIRED_ACCURACY);
+//!         if best.map(|(_, best_d)| nearest.distance_sq < best_d).unwrap_or(true) {
+//!             best = Some((segment.eval(nearest.t), nearest.distance_sq))
 //!         }
 //!     }
 //!     best.map(|(point, _)| point)

--- a/src/line.rs
+++ b/src/line.rs
@@ -5,9 +5,9 @@ use std::ops::{Add, Mul, Range, Sub};
 use arrayvec::ArrayVec;
 
 use crate::{
-    Affine, ParamCurve, ParamCurveArclen, ParamCurveArea, ParamCurveCurvature, ParamCurveDeriv,
-    ParamCurveExtrema, ParamCurveNearest, PathEl, Point, Rect, Shape, Vec2, DEFAULT_ACCURACY,
-    MAX_EXTREMA,
+    Affine, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea, ParamCurveCurvature,
+    ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest, PathEl, Point, Rect, Shape, Vec2,
+    DEFAULT_ACCURACY, MAX_EXTREMA,
 };
 
 /// A single line.
@@ -98,11 +98,11 @@ impl ParamCurveArea for Line {
 }
 
 impl ParamCurveNearest for Line {
-    fn nearest(&self, p: Point, _accuracy: f64) -> (f64, f64) {
+    fn nearest(&self, p: Point, _accuracy: f64) -> Nearest {
         let d = self.p1 - self.p0;
         let dotp = d.dot(p - self.p0);
         let d_squared = d.dot(d);
-        if dotp <= 0.0 {
+        let (t, distance_sq) = if dotp <= 0.0 {
             (0.0, (p - self.p0).hypot2())
         } else if dotp >= d_squared {
             (1.0, (p - self.p1).hypot2())
@@ -110,7 +110,8 @@ impl ParamCurveNearest for Line {
             let t = dotp / d_squared;
             let dist = (p - self.eval(t)).hypot2();
             (t, dist)
-        }
+        };
+        Nearest { t, distance_sq }
     }
 }
 

--- a/src/param_curve.rs
+++ b/src/param_curve.rs
@@ -137,12 +137,27 @@ pub trait ParamCurveArea {
     fn signed_area(&self) -> f64;
 }
 
+/// The nearest position on a curve to some point.
+///
+/// This is returned by [`ParamCurveNearest::nearest`]
+#[derive(Debug, Clone, Copy)]
+pub struct Nearest {
+    /// The square of the distance from the nearest position on the curve
+    /// to the given point.
+    pub distance_sq: f64,
+    /// The position on the curve of the nearest point, as a parameter.
+    ///
+    /// To resolve this to a [`Point`], use [`ParamCurve::eval`].
+    pub t: f64,
+}
+
 /// A parametrized curve that reports the nearest point.
 pub trait ParamCurveNearest {
-    /// Find the point on the curve nearest the given point.
+    /// Find the position on the curve that is nearest to the given point.
     ///
-    /// Returns the parameter and the square of the distance.
-    fn nearest(&self, p: Point, accuracy: f64) -> (f64, f64);
+    /// This returns a [`Nearest`] struct that contains information about
+    /// the position.
+    fn nearest(&self, p: Point, accuracy: f64) -> Nearest;
 }
 
 /// A parametrized curve that reports its curvature.


### PR DESCRIPTION
This has been a minor papercut since forever; I always forget which
argument is which.


Not sure about naming the one field 't'; it might make more sense to call it 'param' or something.

This is a breaking change, and we should do any other breaking we can think of before doing a release.