### PR TITLE
Remove Into<Size> for Vec2

### DIFF
--- a/src/size.rs
+++ b/src/size.rs
@@ -340,14 +340,6 @@ impl From<Size> for (f64, f64) {
     }
 }
 
-//FIXME: remove for 0.6.0 https://github.com/linebender/kurbo/issues/95
-impl Into<Size> for Vec2 {
-    #[inline]
-    fn into(self) -> Size {
-        self.to_size()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
We want to force these sorts of conversions to be explicit.

This is itself a breaking change, so should do it with the next version bump.