### PR TITLE
No std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,11 @@ features = ["derive"]
 # This is used for research but not really needed; maybe refactor.
 [dev-dependencies]
 rand = "0.7.2"
+
+[[example]]
+name = "ellipse"
+required-features = ["std"]
+
+[[example]]
+name = "circle"
+required-features = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,16 @@ description = "A 2D curves library"
 readme = "README.md"
 categories = ["graphics"]
 
+[features]
+std = ["arrayvec/std"]
+default = ["std"]
+
 [package.metadata.docs.rs]
-features = ["mint", "serde"]
+features = ["std", "mint", "serde"]
 
 [dependencies]
-arrayvec = "0.5.1"
+arrayvec = { version = "0.5.1", default-features = false }
+libm = "0.2.1"
 
 [dependencies.mint]
 version = "0.5.1"

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -1,5 +1,4 @@
 //! Example of circle
-
 use kurbo::{Circle, Shape};
 
 fn main() {

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -1,8 +1,11 @@
 //! Affine transforms.
 
-use std::ops::{Mul, MulAssign};
-
-use crate::{Point, Rect, Vec2};
+#[cfg(not(feature = "std"))]
+use crate::common::Float;
+use crate::{
+    std::ops::{Mul, MulAssign},
+    Point, Rect, Vec2,
+};
 
 /// A 2D affine transform.
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -305,8 +305,7 @@ impl From<mint::ColumnMatrix2x3<f64>> for Affine {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Affine, Point};
-    use std::f64::consts::PI;
+    use crate::{std::f64::consts::PI, Affine, Point};
 
     fn assert_near(p0: Point, p1: Point) {
         assert!((p1 - p0).hypot() < 1e-9, "{:?} != {:?}", p0, p1);

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -1,9 +1,13 @@
 //! An ellipse arc.
 
-use crate::{PathEl, Point, Rect, Shape, Vec2};
-use std::{
-    f64::consts::{FRAC_PI_2, PI},
-    iter,
+#[cfg(not(feature = "std"))]
+use crate::common::Float;
+use crate::{
+    std::{
+        f64::consts::{FRAC_PI_2, PI},
+        iter,
+    },
+    PathEl, Point, Rect, Shape, Vec2,
 };
 
 /// A single arc segment.

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -1183,7 +1183,7 @@ mod alloc {
 #[cfg(feature = "std")]
 pub use alloc::BezPath;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
 

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -1,12 +1,15 @@
 //! Implementation of circle shape.
 
-use std::{
-    f64::consts::{FRAC_PI_2, PI},
-    iter,
-    ops::{Add, Mul, Sub},
+#[cfg(not(feature = "std"))]
+use crate::common::Float;
+use crate::{
+    std::{
+        f64::consts::{FRAC_PI_2, PI},
+        iter,
+        ops::{Add, Mul, Sub},
+    },
+    Affine, Arc, ArcAppendIter, Ellipse, PathEl, Point, Rect, Shape, Vec2,
 };
-
-use crate::{Affine, Arc, ArcAppendIter, Ellipse, PathEl, Point, Rect, Shape, Vec2};
 
 /// A circle.
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
@@ -259,7 +262,7 @@ impl Sub<Vec2> for CircleSegment {
     }
 }
 
-type CircleSegmentPathIter = std::iter::Chain<
+type CircleSegmentPathIter = iter::Chain<
     iter::Chain<
         iter::Chain<iter::Chain<iter::Once<PathEl>, iter::Once<PathEl>>, ArcAppendIter>,
         iter::Once<PathEl>,

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -351,10 +351,9 @@ impl Shape for CircleSegment {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))] // requires to_path
 mod tests {
-    use crate::{Circle, Point, Shape};
-    use std::f64::consts::PI;
+    use crate::{std::f64::consts::PI, Circle, Point, Shape};
 
     fn assert_approx_eq(x: f64, y: f64) {
         // Note: we might want to be more rigorous in testing the accuracy

--- a/src/common.rs
+++ b/src/common.rs
@@ -68,7 +68,7 @@ mod float {
             }
         }
 
-        // This needs to be replaced with something better, if/when std gets more modular.
+        // This needs to be replaced with something better. I couldn't find it in libm.
         fn powi(mut self, mut i: i32) -> f64 {
             let mut acc = 1.;
             if i < 0 {
@@ -84,12 +84,7 @@ mod float {
     }
 }
 
-#[cfg(feature = "std")]
-mod float {
-    pub trait Float {}
-    impl Float for f64 {}
-}
-
+#[cfg(not(feature = "std"))]
 pub use float::Float;
 
 /// Adds convenience methods to `f32` and `f64`.
@@ -107,7 +102,7 @@ pub trait FloatExt<T> {
     /// let f = 3.7_f64;
     /// let g = 3.0_f64;
     /// let h = -3.7_f64;
-    /// let i = -5.1_f32;
+    /// let i = -5.1_f64;
     ///
     /// assert_eq!(f.expand(), 4.0);
     /// assert_eq!(g.expand(), 3.0);

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -1,15 +1,15 @@
 //! Cubic Bézier segments.
 
-use std::ops::{Mul, Range};
-
-use crate::MAX_EXTREMA;
 use arrayvec::ArrayVec;
 
-use crate::common::solve_quadratic;
-use crate::common::GAUSS_LEGENDRE_COEFFS_9;
+#[cfg(not(feature = "std"))]
+use crate::common::Float;
 use crate::{
+    common::{solve_quadratic, GAUSS_LEGENDRE_COEFFS_9},
+    std::ops::{Mul, Range},
     Affine, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea, ParamCurveCurvature,
     ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest, PathEl, Point, QuadBez, Rect, Shape,
+    MAX_EXTREMA,
 };
 
 /// A single cubic Bézier segment.
@@ -301,7 +301,7 @@ impl ParamCurveExtrema for CubicBez {
         let d2 = self.p3 - self.p2;
         one_coord(&mut result, d0.x, d1.x, d2.x);
         one_coord(&mut result, d0.y, d1.y, d2.y);
-        result.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        result.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
         result
     }
 }

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -488,6 +488,7 @@ mod tests {
 
     // ensure to_quads returns something given colinear points
     #[test]
+    #[cfg(feature = "std")]
     fn degenerate_to_quads() {
         let c = CubicBez::new((0., 9.), (6., 6.), (12., 3.0), (18., 0.0));
         let quads = c.to_quads(1e-6).collect::<Vec<_>>();

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -267,10 +267,9 @@ impl Shape for Ellipse {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))] // requires to_path
 mod tests {
-    use crate::{Ellipse, Point, Shape};
-    use std::f64::consts::PI;
+    use crate::{std::f64::consts::PI, Ellipse, Point, Shape};
 
     fn assert_approx_eq(x: f64, y: f64) {
         // Note: we might want to be more rigorous in testing the accuracy

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -1,12 +1,15 @@
 //! Implementation of ellipse shape.
 
-use std::f64::consts::PI;
-use std::{
-    iter,
-    ops::{Add, Mul, Sub},
+#[cfg(not(feature = "std"))]
+use crate::common::Float;
+use crate::{
+    std::{
+        f64::consts::PI,
+        iter,
+        ops::{Add, Mul, Sub},
+    },
+    Affine, Arc, ArcAppendIter, Circle, PathEl, Point, Rect, Shape, Size, Vec2,
 };
-
-use crate::{Affine, Arc, ArcAppendIter, Circle, PathEl, Point, Rect, Shape, Size, Vec2};
 
 /// An ellipse.
 #[derive(Clone, Copy, Default, Debug, PartialEq)]

--- a/src/insets.rs
+++ b/src/insets.rs
@@ -14,9 +14,10 @@
 
 //! A description of the distances between the edges of two rectangles.
 
-use std::ops::{Add, Neg, Sub};
-
-use crate::{Rect, Size};
+use crate::{
+    std::ops::{Add, Neg, Sub},
+    Rect, Size,
+};
 
 /// Insets from the edges of a rectangle.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@
     clippy::many_single_char_names,
     clippy::excessive_precision
 )]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 mod affine;
 mod arc;
@@ -95,6 +96,8 @@ mod rounded_rect;
 mod rounded_rect_radii;
 mod shape;
 mod size;
+// TODO it might be possible to include some of svg in no_std, would have to investigate.
+#[cfg(feature = "std")]
 mod svg;
 mod translate_scale;
 mod vec2;
@@ -115,6 +118,16 @@ pub use crate::rounded_rect::*;
 pub use crate::rounded_rect_radii::*;
 pub use crate::shape::*;
 pub use crate::size::*;
+#[cfg(feature = "std")]
 pub use crate::svg::*;
 pub use crate::translate_scale::*;
 pub use crate::vec2::*;
+
+/// This module wraps `std` if available, or `core` otherwise. It means we can just use
+/// `crate::std` in the rest of the crate without worrying about whether we are in `no_std` or not.
+mod std {
+    #[cfg(not(feature = "std"))]
+    pub use ::core::*;
+    #[cfg(feature = "std")]
+    pub use ::std::*;
+}

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,10 +1,9 @@
 //! Lines.
 
-use std::ops::{Add, Mul, Range, Sub};
-
 use arrayvec::ArrayVec;
 
 use crate::{
+    std::ops::{Add, Mul, Range, Sub},
     Affine, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea, ParamCurveCurvature,
     ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest, PathEl, Point, Rect, Shape, Vec2,
     DEFAULT_ACCURACY, MAX_EXTREMA,

--- a/src/param_curve.rs
+++ b/src/param_curve.rs
@@ -1,10 +1,10 @@
 //! A trait for curves parametrized by a scalar.
 
-use std::ops::Range;
-
 use arrayvec::ArrayVec;
 
-use crate::{Point, Rect};
+#[cfg(not(feature = "std"))]
+use crate::common::Float;
+use crate::{std::ops::Range, Point, Rect};
 
 /// A default value for methods that take an 'accuracy' argument.
 ///

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,10 +1,15 @@
 //! A 2D point.
 
-use std::fmt;
-use std::ops::{Add, AddAssign, Sub, SubAssign};
-
-use crate::common::FloatExt;
-use crate::Vec2;
+#[cfg(not(feature = "std"))]
+use crate::common::Float;
+use crate::{
+    common::FloatExt,
+    std::{
+        fmt,
+        ops::{Add, AddAssign, Sub, SubAssign},
+    },
+    Vec2,
+};
 
 /// A 2D point.
 #[derive(Clone, Copy, Default, PartialEq)]

--- a/src/point.rs
+++ b/src/point.rs
@@ -301,6 +301,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn display() {
         let p = Point::new(0.12345, 9.87654);
         assert_eq!(format!("{}", p), "(0.12345, 9.87654)");

--- a/src/quadbez.rs
+++ b/src/quadbez.rs
@@ -1,15 +1,15 @@
 //! Quadratic Bézier segments.
 
-use std::ops::{Mul, Range};
-
 use arrayvec::ArrayVec;
 
-use crate::common::solve_cubic;
-use crate::MAX_EXTREMA;
+#[cfg(not(feature = "std"))]
+use crate::common::Float;
 use crate::{
+    common::solve_cubic,
+    std::ops::{Mul, Range},
     Affine, CubicBez, Line, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea,
     ParamCurveCurvature, ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest, PathEl, Point,
-    Rect, Shape,
+    Rect, Shape, MAX_EXTREMA,
 };
 
 /// A single quadratic Bézier segment.
@@ -47,6 +47,7 @@ impl QuadBez {
     }
 
     /// Estimate the number of subdivisions for flattening.
+    #[cfg(feature = "std")]
     pub(crate) fn estimate_subdiv(&self, sqrt_tol: f64) -> FlattenParams {
         // Determine transformation to $y = x^2$ parabola.
         let d01 = self.p1 - self.p0;
@@ -86,6 +87,7 @@ impl QuadBez {
     }
 
     // Maps a value from 0..1 to 0..1.
+    #[cfg(feature = "std")]
     pub(crate) fn determine_subdiv_t(&self, params: &FlattenParams, x: f64) -> f64 {
         let a = params.a0 + (params.a2 - params.a0) * x;
         let u = approx_parabola_inv_integral(a);
@@ -151,6 +153,7 @@ impl Iterator for QuadBezIter {
     }
 }
 
+#[cfg(feature = "std")]
 pub(crate) struct FlattenParams {
     a0: f64,
     a2: f64,
@@ -163,12 +166,14 @@ pub(crate) struct FlattenParams {
 /// An approximation to $\int (1 + 4x^2) ^ -0.25 dx$
 ///
 /// This is used for flattening curves.
+#[cfg(feature = "std")]
 fn approx_parabola_integral(x: f64) -> f64 {
     const D: f64 = 0.67;
     x / (1.0 - D + (D.powi(4) + 0.25 * x * x).sqrt().sqrt())
 }
 
 /// An approximation to the inverse parabola integral.
+#[cfg(feature = "std")]
 fn approx_parabola_inv_integral(x: f64) -> f64 {
     const B: f64 = 0.39;
     x * (1.0 - B + (B * B + 0.25 * x * x).sqrt())

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -683,6 +683,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn area_sign() {
         let r = Rect::new(0.0, 0.0, 10.0, 10.0);
         let center = r.center();
@@ -704,6 +705,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn display() {
         let r = Rect::from_origin_size((10., 12.23214), (22.222222222, 23.1));
         assert_eq!(
@@ -725,7 +727,7 @@ mod tests {
 
     #[test]
     fn contained_rect_with_aspect_ratio() {
-        use std::f64;
+        use crate::std::f64;
 
         fn case(outer: [f64; 4], aspect_ratio: f64, expected: [f64; 4]) {
             let outer = Rect::new(outer[0], outer[1], outer[2], outer[3]);
@@ -761,6 +763,6 @@ mod tests {
     #[test]
     fn aspect_ratio() {
         let test = Rect::new(0.0, 0.0, 1.0, 1.0);
-        assert!((test.aspect_ratio() - 1.0).abs() < 1e-6);
+        assert_approx_eq(test.aspect_ratio(), 1.0);
     }
 }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -1,9 +1,14 @@
 //! A rectangle.
 
-use std::fmt;
-use std::ops::{Add, Sub};
-
-use crate::{Ellipse, Insets, PathEl, Point, RoundedRect, RoundedRectRadii, Shape, Size, Vec2};
+#[cfg(not(feature = "std"))]
+use crate::common::Float;
+use crate::{
+    std::{
+        fmt,
+        ops::{Add, Sub},
+    },
+    Ellipse, Insets, PathEl, Point, RoundedRect, RoundedRectRadii, Shape, Size, Vec2,
+};
 
 /// A rectangle.
 #[derive(Clone, Copy, Default, PartialEq)]

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -465,6 +465,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn bez_conversion() {
         let rect = RoundedRect::new(-5.0, -5.0, 10.0, 20.0, 5.0);
         let p = rect.to_path(1e-9);

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -1,9 +1,15 @@
 //! A rectangle with rounded corners.
 
-use std::f64::consts::{FRAC_PI_2, FRAC_PI_4};
-use std::ops::{Add, Sub};
-
-use crate::{arc::ArcAppendIter, Arc, PathEl, Point, Rect, RoundedRectRadii, Shape, Size, Vec2};
+#[cfg(not(feature = "std"))]
+use crate::common::Float;
+use crate::{
+    arc::ArcAppendIter,
+    std::{
+        f64::consts::{FRAC_PI_2, FRAC_PI_4},
+        ops::{Add, Sub},
+    },
+    Arc, PathEl, Point, Rect, RoundedRectRadii, Shape, Size, Vec2,
+};
 
 /// A rectangle with equally rounded corners.
 ///

--- a/src/rounded_rect_radii.rs
+++ b/src/rounded_rect_radii.rs
@@ -14,7 +14,9 @@
 
 //! A description of the radii for each corner of a rounded rectangle.
 
-use std::convert::From;
+#[cfg(not(feature = "std"))]
+use crate::common::Float;
+use crate::std::convert::From;
 
 /// Radii for each corner of a rounded rectangle.
 ///

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1,6 +1,8 @@
 //! A generic trait for shapes.
 
-use crate::{segments, BezPath, Circle, Line, PathEl, Point, Rect, RoundedRect, Segments};
+#[cfg(feature = "std")]
+use crate::BezPath;
+use crate::{segments, Circle, Line, PathEl, Point, Rect, RoundedRect, Segments};
 
 /// A generic trait for open and closed shapes.
 ///
@@ -64,6 +66,7 @@ pub trait Shape: Sized {
     /// The `tolerance` parameter is the same as for [`path_elements`].
     ///
     /// [`path_elements`]: Shape::path_elements
+    #[cfg(feature = "std")]
     fn to_path(&self, tolerance: f64) -> BezPath {
         self.path_elements(tolerance).collect()
     }
@@ -81,12 +84,14 @@ pub trait Shape: Sized {
     /// The `tolerance` parameter is the same as for [`path_elements()`].
     ///
     /// [`path_elements()`]: Shape::path_elements
+    #[cfg(feature = "std")]
     fn into_path(self, tolerance: f64) -> BezPath {
         self.to_path(tolerance)
     }
 
     #[deprecated(since = "0.7.0", note = "Use into_path instead")]
     #[doc(hidden)]
+    #[cfg(feature = "std")]
     fn into_bez_path(self, tolerance: f64) -> BezPath {
         self.into_path(tolerance)
     }
@@ -179,6 +184,7 @@ impl<'a, T: Shape> Shape for &'a T {
         (*self).path_elements(tolerance)
     }
 
+    #[cfg(feature = "std")]
     fn to_path(&self, tolerance: f64) -> BezPath {
         (*self).to_path(tolerance)
     }

--- a/src/size.rs
+++ b/src/size.rs
@@ -356,6 +356,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "std")]
     fn display() {
         let s = Size::new(-0.12345, 9.87654);
         assert_eq!(format!("{}", s), "(-0.12345×9.87654)");

--- a/src/size.rs
+++ b/src/size.rs
@@ -1,10 +1,15 @@
 //! A 2D size.
 
-use std::fmt;
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
-
-use crate::common::FloatExt;
-use crate::{Rect, RoundedRect, RoundedRectRadii, Vec2};
+#[cfg(not(feature = "std"))]
+use crate::common::Float;
+use crate::{
+    common::FloatExt,
+    std::{
+        fmt,
+        ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
+    },
+    Rect, RoundedRect, RoundedRectRadii, Vec2,
+};
 
 /// A 2D size.
 #[derive(Clone, Copy, Default, PartialEq)]

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -1,11 +1,14 @@
 //! SVG path representation.
 
-use std::error::Error;
-use std::f64::consts::PI;
-use std::fmt::{self, Display, Formatter};
-use std::io::{self, Write};
-
-use crate::{Arc, BezPath, ParamCurve, PathEl, PathSeg, Point, Vec2};
+use crate::{
+    std::{
+        error::Error,
+        f64::consts::PI,
+        fmt::{self, Display, Formatter},
+        io::{self, Write},
+    },
+    Arc, BezPath, ParamCurve, PathEl, PathSeg, Point, Vec2,
+};
 
 // Note: the SVG arc logic is heavily adapted from https://github.com/nical/lyon
 

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -1,8 +1,7 @@
 //! A transformation that includes both scale and translation.
 
-use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
-
 use crate::{
+    std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
     Affine, Circle, CubicBez, Line, Point, QuadBez, Rect, RoundedRect, RoundedRectRadii, Vec2,
 };
 

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -1,10 +1,15 @@
 //! A simple 2D vector.
 
-use std::fmt;
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-
-use crate::common::FloatExt;
-use crate::{Point, Size};
+#[cfg(not(feature = "std"))]
+use crate::common::Float;
+use crate::{
+    common::FloatExt,
+    std::{
+        fmt,
+        ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+    },
+    Point, Size,
+};
 
 /// A 2D vector.
 ///

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -382,7 +382,7 @@ impl From<mint::Vector2<f64>> for Vec2 {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
     #[test]


### PR DESCRIPTION
I needed a geometry library for a play that I've been having with my PineTime, and so have modified kurbo to work with no_std. I've done this by using a feature `std` that is on-by-default. When in `no_std`, I use `libm` for math routines, and cfg-out things that require an allocator (which is surprising little). I re-export core or std from a private module to enable the rest of the crate to just use `std`.

One change that was required is changing a sort to a sort_unstable, because the former allocates. In practice the change should make little or no difference.

Sharing here in case you are interested in upstreaming no_std support.