### PR TITLE
Fancier solver for inverse arclength

### DIFF
--- a/src/line.rs
+++ b/src/line.rs
@@ -88,6 +88,11 @@ impl ParamCurveArclen for Line {
     fn arclen(&self, _accuracy: f64) -> f64 {
         (self.p1 - self.p0).hypot()
     }
+
+    #[inline]
+    fn inv_arclen(&self, arclen: f64, _accuracy: f64) -> f64 {
+        arclen / (self.p1 - self.p0).hypot()
+    }
 }
 
 impl ParamCurveArea for Line {


### PR DESCRIPTION
Use the ITP method for solving inverse arclength, which converges more
quickly than bisection but is just as robust.

This patch makes the ITP solver available in `common` as well, as it is
likely to be of general use. It's also nice that the solver is factored
out from the arclength-specific logic.

Also use the simple analytical solution for inverse arc length of a
line.