### PR TITLE
Specialize `inv_arclen` for `PathSeg` and `ConstPoint`

### DIFF
--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -677,6 +677,14 @@ impl ParamCurveArclen for PathSeg {
             PathSeg::Cubic(cubic) => cubic.arclen(accuracy),
         }
     }
+
+    fn inv_arclen(&self, arclen: f64, accuracy: f64) -> f64 {
+        match *self {
+            PathSeg::Line(line) => line.inv_arclen(arclen, accuracy),
+            PathSeg::Quad(quad) => quad.inv_arclen(arclen, accuracy),
+            PathSeg::Cubic(cubic) => cubic.inv_arclen(arclen, accuracy),
+        }
+    }
 }
 
 impl ParamCurveArea for PathSeg {

--- a/src/line.rs
+++ b/src/line.rs
@@ -179,6 +179,11 @@ impl ParamCurveArclen for ConstPoint {
     fn arclen(&self, _accuracy: f64) -> f64 {
         0.0
     }
+
+    #[inline]
+    fn inv_arclen(&self, _arclen: f64, _accuracy: f64) -> f64 {
+        0.0
+    }
 }
 
 impl Mul<Line> for Affine {


### PR DESCRIPTION
The default implementation of `ParamCurveArclen::inv_arclen` uses an
iterative solver. For some types we can skip that:
- `PathSeg`: forward it to the inner implementation (useful for `Line`)
- `ConstPoint`: always return 0

As an additional thought, maybe it would be better to not have a default implementation of some of these methods, as it can accidentally create inefficiencies when left unimplemented for specific cases. Instead, there could be easy-to-use functions to call from the methods when this behavior is desired in concrete instances.