### PR TITLE
Add a custom return type for BezPath::min_dist

### DIFF
--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -9,7 +9,6 @@ use std::ops::{Mul, Range};
 use arrayvec::ArrayVec;
 
 use crate::common::{solve_cubic, solve_quadratic};
-use crate::mindist::min_dist_param;
 use crate::MAX_EXTREMA;
 use crate::{
     Affine, CubicBez, Line, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea,
@@ -139,6 +138,24 @@ pub struct LineIntersection {
     /// This value is nominally in the range 0..1, although it may slightly exceed
     /// that range at the boundaries of segments.
     pub segment_t: f64,
+}
+
+/// The minimum distance between two Bézier curves.
+pub struct MinDistance {
+    /// The shortest distance between any two points on the two curves.
+    pub distance: f64,
+    /// The position of the nearest point on the first curve, as a parameter.
+    ///
+    /// To resolve this to a [`Point`], use [`ParamCurve::eval`].
+    ///
+    /// [`ParamCurve::eval`]: crate::ParamCurve::eval
+    pub t1: f64,
+    /// The position of the nearest point on the second curve, as a parameter.
+    ///
+    /// To resolve this to a [`Point`], use [`ParamCurve::eval`].
+    ///
+    /// [`ParamCurve::eval`]: crate::ParamCurve::eval
+    pub t2: f64,
 }
 
 impl BezPath {
@@ -972,8 +989,8 @@ impl PathSeg {
     /// Returns a tuple of the distance, the path time `t1` of the closest point
     /// on the first PathSeg, and the path time `t2` of the closest point on the
     /// second PathSeg.
-    pub fn min_dist(&self, other: PathSeg, accuracy: f64) -> (f64, f64, f64) {
-        let (dist, t1, t2) = min_dist_param(
+    pub fn min_dist(&self, other: PathSeg, accuracy: f64) -> MinDistance {
+        let (distance, t1, t2) = crate::mindist::min_dist_param(
             &self.as_vec2_vec(),
             &other.as_vec2_vec(),
             (0.0, 1.0),
@@ -981,7 +998,11 @@ impl PathSeg {
             accuracy,
             None,
         );
-        (dist.sqrt(), t1, t2)
+        MinDistance {
+            distance: distance.sqrt(),
+            t1,
+            t2,
+        }
     }
 }
 

--- a/src/mindist.rs
+++ b/src/mindist.rs
@@ -1,11 +1,27 @@
+// Copyright 2021 The kurbo Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Minimum distance between two Bézier curves
+//!
+//! This implements the algorithm in "Computing the minimum distance between
+//! two Bézier curves", Chen et al., *Journal of Computational and Applied
+//! Mathematics* 229(2009), 294-301
+
 use crate::Vec2;
 use core::cmp::Ordering;
 
-// This implements the algorithm in "Computing the
-// minimum distance between two Bézier curves", Chen et al.,
-// *Journal of Computational and Applied Mathematics* 229(2009), 294-301
-
-pub fn min_dist_param(
+pub(crate) fn min_dist_param(
     bez1: &[Vec2],
     bez2: &[Vec2],
     u: (f64, f64),
@@ -269,8 +285,8 @@ mod tests {
             (215.0, 408.0),
             (309.0, 408.0),
         ));
-        let (dist, _t1, _t2) = bez1.min_dist(bez2, 0.001);
-        assert!((dist - 50.9966).abs() < 0.5);
+        let mindist = bez1.min_dist(bez2, 0.001);
+        assert!((mindist.distance - 50.9966).abs() < 0.5);
     }
 
     #[test]
@@ -282,8 +298,8 @@ mod tests {
             (141.0, 301.0),
         ));
         let bez2 = PathSeg::Line(Line::new((359.0, 416.0), (367.0, 755.0)));
-        let (dist, _t1, _t2) = bez1.min_dist(bez2, 0.001);
-        assert!((dist - 246.4731222669117).abs() < 0.5);
+        let mindist = bez1.min_dist(bez2, 0.001);
+        assert!((mindist.distance - 246.4731222669117).abs() < 0.5);
     }
 
     #[test]
@@ -295,8 +311,8 @@ mod tests {
             (359.0, 416.0),
         ));
         let bez2 = PathSeg::Line(Line::new((141.0, 301.0), (152.0, 709.0)));
-        let (dist1, _t1, _t2) = bez1.min_dist(bez2, 0.5);
-        let (dist2, _t1, _t2) = bez2.min_dist(bez1, 0.5);
-        assert!((dist1 - dist2).abs() < 0.5);
+        let mindist1 = bez1.min_dist(bez2, 0.5);
+        let mindist2 = bez2.min_dist(bez1, 0.5);
+        assert!((mindist1.distance - mindist2.distance).abs() < 0.5);
     }
 }

--- a/src/quadspline.rs
+++ b/src/quadspline.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 The kurbo Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Quadratic Bézier splines.
 use crate::Point;
 


### PR DESCRIPTION
This is part of a bit of cleanup before doing a release, and includes a
few other doc and license fixes. It also makes min_dist_param pub(crate)
instead of pub; mindist was not exported to this isn't available as
public API in any case. If someone specifically needs to use this at
some point we can consider making it public then.


@simoncozens does this make sense for you? The one main question I have is around whether we should be returning distance or distance2 from `min_dist`. [`ParamCurve::nearest`](https://docs.rs/kurbo/0.8.1/kurbo/struct.Nearest.html) returns the distance2, is there a reason to prefer distance here? I think it makes sense to have the same behaviour in both places, though.