### PR TITLE
Prepare for 0.8.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kurbo"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -721,8 +721,8 @@ impl PathSeg {
     }
 
     /// Convert this segment to a cubic bezier.
-    pub fn to_cubic(self) -> CubicBez {
-        match self {
+    pub fn to_cubic(&self) -> CubicBez {
+        match *self {
             PathSeg::Line(Line { p0, p1 }) => CubicBez::new(p0, p0, p1, p1),
             PathSeg::Cubic(c) => c,
             PathSeg::Quad(q) => q.raise(),

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -55,7 +55,7 @@ impl CubicBez {
     ///
     /// This iterator will always produce at least one `QuadBez`.
     #[inline]
-    pub fn to_quads(self, accuracy: f64) -> impl Iterator<Item = (f64, f64, QuadBez)> {
+    pub fn to_quads(&self, accuracy: f64) -> impl Iterator<Item = (f64, f64, QuadBez)> {
         // The maximum error, as a vector from the cubic to the best approximating
         // quadratic, is proportional to the third derivative, which is constant
         // across the segment. Thus, the error scales down as the third power of
@@ -73,7 +73,7 @@ impl CubicBez {
         let err = (p2x2 - p1x2).hypot2();
         let n = ((err / max_hypot2).powf(1. / 6.0).ceil() as usize).max(1);
 
-        ToQuads { c: self, n, i: 0 }
+        ToQuads { c: *self, n, i: 0 }
     }
 
     /// Return a quadratic spline approximating this cubic bezier


### PR DESCRIPTION
This bumps the crate version, and also reverts two small changes since
0.8.1 that would've required us to go to 0.9. These changes were
  suggested by clippy at some point, but do not appear to be warnings
  any longer?