### PR TITLE
Update arrayvec to use const generics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["graphics"]
 features = ["mint", "serde"]
 
 [dependencies]
-arrayvec = "0.5.1"
+arrayvec = "0.7.1"
 
 [dependencies.mint]
 version = "0.5.1"

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -700,7 +700,7 @@ impl ParamCurveNearest for PathSeg {
 }
 
 impl ParamCurveExtrema for PathSeg {
-    fn extrema(&self) -> ArrayVec<[f64; MAX_EXTREMA]> {
+    fn extrema(&self) -> ArrayVec<f64, MAX_EXTREMA> {
         match *self {
             PathSeg::Line(line) => line.extrema(),
             PathSeg::Quad(quad) => quad.extrema(),
@@ -851,7 +851,7 @@ impl PathSeg {
     /// let point = seg.eval(intersection.segment_t);
     /// assert_eq!(point, Point::new(1.0, 0.0));
     /// ```
-    pub fn intersect_line(&self, line: Line) -> ArrayVec<[LineIntersection; 3]> {
+    pub fn intersect_line(&self, line: Line) -> ArrayVec<LineIntersection, 3> {
         const EPSILON: f64 = 1e-9;
         let p0 = line.p0;
         let p1 = line.p1;
@@ -945,7 +945,7 @@ impl PathSeg {
     }
 
     #[inline]
-    fn as_vec2_vec(&self) -> ArrayVec<[Vec2; 4]> {
+    fn as_vec2_vec(&self) -> ArrayVec<Vec2, 4> {
         let mut a = ArrayVec::new();
         match self {
             PathSeg::Line(l) => {

--- a/src/common.rs
+++ b/src/common.rs
@@ -51,7 +51,7 @@ impl FloatExt<f32> for f32 {
 /// See: <http://mathworld.wolfram.com/CubicFormula.html>
 ///
 /// Return values of x for which c0 + c1 x + c2 x² + c3 x³ = 0.
-pub fn solve_cubic(c0: f64, c1: f64, c2: f64, c3: f64) -> ArrayVec<[f64; 3]> {
+pub fn solve_cubic(c0: f64, c1: f64, c2: f64, c3: f64) -> ArrayVec<f64, 3> {
     let mut result = ArrayVec::new();
     let c3_recip = c3.recip();
     let scaled_c2 = c2 * c3_recip;
@@ -102,7 +102,7 @@ pub fn solve_cubic(c0: f64, c1: f64, c2: f64, c3: f64) -> ArrayVec<[f64; 3]> {
 /// the other root might be out of representable range. In the degenerate
 /// case where all coefficients are zero, so that all values of x satisfy
 /// the equation, a single `0.0` is returned.
-pub fn solve_quadratic(c0: f64, c1: f64, c2: f64) -> ArrayVec<[f64; 2]> {
+pub fn solve_quadratic(c0: f64, c1: f64, c2: f64) -> ArrayVec<f64, 2> {
     let mut result = ArrayVec::new();
     let sc0 = c0 * c2.recip();
     let sc1 = c1 * c2.recip();
@@ -319,9 +319,9 @@ pub const GAUSS_LEGENDRE_COEFFS_24: &[(f64, f64)] = &[
 #[cfg(test)]
 mod tests {
     use crate::common::*;
-    use arrayvec::{Array, ArrayVec};
+    use arrayvec::ArrayVec;
 
-    fn verify<T: Array<Item = f64>>(mut roots: ArrayVec<T>, expected: &[f64]) {
+    fn verify<const N: usize>(mut roots: ArrayVec<f64, N>, expected: &[f64]) {
         assert_eq!(expected.len(), roots.len());
         let epsilon = 1e-6;
         roots.sort_by(|a, b| a.partial_cmp(b).unwrap());

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -163,7 +163,9 @@ impl CubicBez {
 
     fn split_into_n(&self, n: usize) -> impl Iterator<Item = CubicBez> {
         // for certain small values of `n` we precompute all our values.
-        let mut storage = ArrayVec::<[_; 6]>::new();
+        // if we have six or fewer items we precompute them.
+        let mut storage = ArrayVec::<_, 6>::new();
+
         match n {
             1 => storage.push(*self),
             2 => {
@@ -505,8 +507,8 @@ impl ParamCurveNearest for CubicBez {
 impl ParamCurveCurvature for CubicBez {}
 
 impl ParamCurveExtrema for CubicBez {
-    fn extrema(&self) -> ArrayVec<[f64; MAX_EXTREMA]> {
-        fn one_coord(result: &mut ArrayVec<[f64; MAX_EXTREMA]>, d0: f64, d1: f64, d2: f64) {
+    fn extrema(&self) -> ArrayVec<f64, MAX_EXTREMA> {
+        fn one_coord(result: &mut ArrayVec<f64, MAX_EXTREMA>, d0: f64, d1: f64, d2: f64) {
             let a = d0 - 2.0 * d1 + d2;
             let b = 2.0 * (d1 - d0);
             let c = d0;

--- a/src/line.rs
+++ b/src/line.rs
@@ -141,7 +141,7 @@ impl ParamCurveCurvature for Line {
 
 impl ParamCurveExtrema for Line {
     #[inline]
-    fn extrema(&self) -> ArrayVec<[f64; MAX_EXTREMA]> {
+    fn extrema(&self) -> ArrayVec<f64, MAX_EXTREMA> {
         ArrayVec::new()
     }
 }

--- a/src/param_curve.rs
+++ b/src/param_curve.rs
@@ -190,10 +190,10 @@ pub trait ParamCurveExtrema: ParamCurve {
     /// cubic Béziers.
     ///
     /// The extrema should be reported in increasing parameter order.
-    fn extrema(&self) -> ArrayVec<[f64; MAX_EXTREMA]>;
+    fn extrema(&self) -> ArrayVec<f64, MAX_EXTREMA>;
 
     /// Return parameter ranges, each of which is monotonic within the range.
-    fn extrema_ranges(&self) -> ArrayVec<[Range<f64>; MAX_EXTREMA + 1]> {
+    fn extrema_ranges(&self) -> ArrayVec<Range<f64>, { MAX_EXTREMA + 1 }> {
         let mut result = ArrayVec::new();
         let mut t0 = 0.0;
         for t in self.extrema() {

--- a/src/quadbez.rs
+++ b/src/quadbez.rs
@@ -339,7 +339,7 @@ impl ParamCurveNearest for QuadBez {
 impl ParamCurveCurvature for QuadBez {}
 
 impl ParamCurveExtrema for QuadBez {
-    fn extrema(&self) -> ArrayVec<[f64; MAX_EXTREMA]> {
+    fn extrema(&self) -> ArrayVec<f64, MAX_EXTREMA> {
         let mut result = ArrayVec::new();
         let d0 = self.p1 - self.p0;
         let d1 = self.p2 - self.p1;


### PR DESCRIPTION
It's unclear to me whether or not this is a breaking change? I think it isn't, since the return types should behave identically, but I'm not a very good language lawyer..