### PR TITLE
Optional support for schemars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,17 @@ readme = "README.md"
 categories = ["graphics"]
 
 [package.metadata.docs.rs]
-features = ["mint", "serde"]
+features = ["mint", "schemars", "serde"]
 
 [dependencies]
 arrayvec = "0.7.1"
 
 [dependencies.mint]
 version = "0.5.1"
+optional = true
+
+[dependencies.schemars]
+version = "0.8.6"
 optional = true
 
 [dependencies.serde]

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -6,6 +6,7 @@ use crate::{Point, Rect, Vec2};
 
 /// A 2D affine transform.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Affine([f64; 6]);
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -8,6 +8,7 @@ use std::{
 
 /// A single arc segment.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Arc {
     /// The arc's centre point.

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -89,6 +89,7 @@ use crate::{
 /// [`FromIterator<PathEl>`]: std::iter::FromIterator
 /// [`Extend<PathEl>`]: std::iter::Extend
 #[derive(Clone, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BezPath(Vec<PathEl>);
 
@@ -96,6 +97,7 @@ pub struct BezPath(Vec<PathEl>);
 ///
 /// A valid path has `MoveTo` at the beginning of each subpath.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PathEl {
     /// Move directly to the point without drawing anything, starting a new
@@ -113,6 +115,7 @@ pub enum PathEl {
 
 /// A segment of a Bézier path.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PathSeg {
     /// A line segment.

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -10,6 +10,7 @@ use crate::{Affine, Arc, ArcAppendIter, Ellipse, PathEl, Point, Rect, Shape, Vec
 
 /// A circle.
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Circle {
     /// The center.

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -17,6 +17,7 @@ const MAX_SPLINE_SPLIT: usize = 100;
 
 /// A single cubic Bézier segment.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 pub struct CubicBez {

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -10,6 +10,7 @@ use crate::{Affine, Arc, ArcAppendIter, Circle, PathEl, Point, Rect, Shape, Size
 
 /// An ellipse.
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ellipse {
     /// All ellipses can be represented as an affine map of the unit circle,

--- a/src/insets.rs
+++ b/src/insets.rs
@@ -99,6 +99,7 @@ use crate::{Rect, Size};
 /// assert_eq!(insets2.y_value(), insets.y_value());
 /// ```
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Insets {
     /// The minimum x coordinate (left edge).

--- a/src/line.rs
+++ b/src/line.rs
@@ -12,6 +12,7 @@ use crate::{
 
 /// A single line.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Line {
     /// The line's start point.
@@ -148,6 +149,7 @@ impl ParamCurveExtrema for Line {
 
 /// A trivial "curve" that is just a constant.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConstPoint(Point);
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -8,6 +8,7 @@ use crate::Vec2;
 
 /// A 2D point.
 #[derive(Clone, Copy, Default, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Point {
     /// The x coordinate.

--- a/src/quadbez.rs
+++ b/src/quadbez.rs
@@ -14,6 +14,7 @@ use crate::{
 
 /// A single quadratic Bézier segment.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 pub struct QuadBez {

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -7,6 +7,7 @@ use crate::{Ellipse, Insets, PathEl, Point, RoundedRect, RoundedRectRadii, Shape
 
 /// A rectangle.
 #[derive(Clone, Copy, Default, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rect {
     /// The minimum x coordinate (left edge).

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -25,6 +25,7 @@ use crate::{arc::ArcAppendIter, Arc, PathEl, Point, Rect, RoundedRectRadii, Shap
 ///
 /// [`to_rounded_rect`]: Rect::to_rounded_rect
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RoundedRect {
     /// Coordinates of the rectangle.

--- a/src/rounded_rect_radii.rs
+++ b/src/rounded_rect_radii.rs
@@ -25,6 +25,7 @@ use std::convert::From;
 /// actually be the top, but `top` corners will always have a smaller y-value
 /// than `bottom` corners.
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RoundedRectRadii {
     /// The radius of the top-left corner.

--- a/src/size.rs
+++ b/src/size.rs
@@ -8,6 +8,7 @@ use crate::{Rect, RoundedRect, RoundedRectRadii, Vec2};
 
 /// A 2D size.
 #[derive(Clone, Copy, Default, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Size {
     /// The width.

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -11,6 +11,7 @@ use crate::{Arc, BezPath, ParamCurve, PathEl, PathSeg, Point, Vec2};
 
 /// A single SVG arc segment.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SvgArc {
     /// The arc's start point.

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -36,6 +36,7 @@ use crate::{
 /// This transformation is less powerful than `Affine`, but can be applied
 /// to more primitives, especially including [`Rect`].
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TranslateScale {
     translation: Vec2,

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -12,6 +12,7 @@ use crate::{Point, Size};
 /// but it can be interpreted as a translation, and converted to and
 /// from a point (vector relative to the origin) and size.
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Vec2 {
     /// The x-coordinate.


### PR DESCRIPTION
This is a prerequisite for using kurbo's `Rect` struct in [AccessKit](https://github.com/AccessKit/accesskit).