### PR TITLE
Add pop method to BezPath

### DIFF
--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -187,6 +187,11 @@ impl BezPath {
         BezPath(v)
     }
 
+    /// Pop a generic path element off of the path.
+    pub fn pop(&mut self) -> Option<PathEl> {
+        self.0.pop()
+    }
+
     /// Push a generic path element onto the path.
     pub fn push(&mut self, el: PathEl) {
         self.0.push(el)

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -187,7 +187,7 @@ impl BezPath {
         BezPath(v)
     }
 
-    /// Pop a generic path element off of the path.
+    /// Removes the last [`PathEl`] from the path and returns it, or `None` if the path is empty.
     pub fn pop(&mut self) -> Option<PathEl> {
         self.0.pop()
     }


### PR DESCRIPTION
This adds a `pop` method to `BezPath` so that the end of a path can be adjusted as needed.

I needed this change for a project and thought it may benefit others. My use case is as follows. My program creates a Bézier path following the user's cursor. When a new coordinate is produced, the last segment of the path is removed and replaced by two new fitted segments. As it currently stands, I need to maintain a `Vector<PathEl>` to be able to perform the popping. I then need to clone the `Vector` to create a `BezPath` for rendering. I am able to skip the cloning and use the `BezPath` directly with this new method.