### PR TITLE
Implement GATs

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -132,9 +132,9 @@ fn rotate_pt(pt: Vec2, angle: f64) -> Vec2 {
 }
 
 impl Shape for Arc {
-    type PathElementsIter = iter::Chain<iter::Once<PathEl>, ArcAppendIter>;
+    type PathElementsIter<'iter> = iter::Chain<iter::Once<PathEl>, ArcAppendIter>;
 
-    fn path_elements(&self, tolerance: f64) -> Self::PathElementsIter {
+    fn path_elements(&self, tolerance: f64) -> Self::PathElementsIter<'_> {
         let p0 = sample_ellipse(self.radii, self.x_rotation, self.start_angle);
         iter::once(PathEl::MoveTo(self.center + p0)).chain(self.append_iter(tolerance))
     }

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -1108,10 +1108,10 @@ impl From<QuadBez> for PathSeg {
 }
 
 impl Shape for BezPath {
-    type PathElementsIter = std::vec::IntoIter<PathEl>;
+    type PathElementsIter<'iter> = std::iter::Copied<std::slice::Iter<'iter, PathEl>>;
 
-    fn path_elements(&self, _tolerance: f64) -> Self::PathElementsIter {
-        self.0.clone().into_iter()
+    fn path_elements(&self, _tolerance: f64) -> Self::PathElementsIter<'_> {
+        self.0.iter().copied()
     }
 
     fn to_path(&self, _tolerance: f64) -> BezPath {
@@ -1176,11 +1176,13 @@ impl PathEl {
 ///
 /// If the slice starts with `LineTo`, `QuadTo`, or `CurveTo`, it will be treated as a `MoveTo`.
 impl<'a> Shape for &'a [PathEl] {
-    type PathElementsIter = std::iter::Cloned<std::slice::Iter<'a, PathEl>>;
+    type PathElementsIter<'iter>
+
+    = std::iter::Copied<std::slice::Iter<'a, PathEl>> where 'a: 'iter;
 
     #[inline]
-    fn path_elements(&self, _tolerance: f64) -> Self::PathElementsIter {
-        self.iter().cloned()
+    fn path_elements(&self, _tolerance: f64) -> Self::PathElementsIter<'_> {
+        self.iter().copied()
     }
 
     fn to_path(&self, _tolerance: f64) -> BezPath {
@@ -1218,7 +1220,7 @@ pub struct PathSegIter {
 }
 
 impl Shape for PathSeg {
-    type PathElementsIter = PathSegIter;
+    type PathElementsIter<'iter> = PathSegIter;
 
     #[inline]
     fn path_elements(&self, _tolerance: f64) -> PathSegIter {

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -94,7 +94,7 @@ pub struct CirclePathIter {
 }
 
 impl Shape for Circle {
-    type PathElementsIter = CirclePathIter;
+    type PathElementsIter<'iter> = CirclePathIter;
 
     fn path_elements(&self, tolerance: f64) -> CirclePathIter {
         let scaled_err = self.radius.abs() / tolerance;
@@ -269,7 +269,7 @@ type CircleSegmentPathIter = std::iter::Chain<
 >;
 
 impl Shape for CircleSegment {
-    type PathElementsIter = CircleSegmentPathIter;
+    type PathElementsIter<'iter> = CircleSegmentPathIter;
 
     fn path_elements(&self, tolerance: f64) -> CircleSegmentPathIter {
         iter::once(PathEl::MoveTo(point_on_circle(

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -338,7 +338,7 @@ pub struct CubicBezIter {
 }
 
 impl Shape for CubicBez {
-    type PathElementsIter = CubicBezIter;
+    type PathElementsIter<'iter> = CubicBezIter;
 
     #[inline]
     fn path_elements(&self, _tolerance: f64) -> CubicBezIter {

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -192,9 +192,9 @@ impl From<Circle> for Ellipse {
 }
 
 impl Shape for Ellipse {
-    type PathElementsIter = iter::Chain<iter::Once<PathEl>, ArcAppendIter>;
+    type PathElementsIter<'iter> = iter::Chain<iter::Once<PathEl>, ArcAppendIter>;
 
-    fn path_elements(&self, tolerance: f64) -> Self::PathElementsIter {
+    fn path_elements(&self, tolerance: f64) -> Self::PathElementsIter<'_> {
         let (radii, x_rotation) = self.inner.svd();
         Arc {
             center: self.center(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,8 @@
 #![allow(
     clippy::unreadable_literal,
     clippy::many_single_char_names,
-    clippy::excessive_precision
+    clippy::excessive_precision,
+    clippy::bool_to_int_with_if
 )]
 
 mod affine;

--- a/src/line.rs
+++ b/src/line.rs
@@ -238,7 +238,7 @@ pub struct LinePathIter {
 }
 
 impl Shape for Line {
-    type PathElementsIter = LinePathIter;
+    type PathElementsIter<'iter> = LinePathIter;
 
     #[inline]
     fn path_elements(&self, _tolerance: f64) -> LinePathIter {

--- a/src/quadbez.rs
+++ b/src/quadbez.rs
@@ -113,7 +113,7 @@ pub struct QuadBezIter {
 }
 
 impl Shape for QuadBez {
-    type PathElementsIter = QuadBezIter;
+    type PathElementsIter<'iter> = QuadBezIter;
 
     #[inline]
     fn path_elements(&self, _tolerance: f64) -> QuadBezIter {

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -575,7 +575,7 @@ pub struct RectPathIter {
 }
 
 impl Shape for Rect {
-    type PathElementsIter = RectPathIter;
+    type PathElementsIter<'iter> = RectPathIter;
 
     fn path_elements(&self, _tolerance: f64) -> RectPathIter {
         RectPathIter { rect: *self, ix: 0 }

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -145,7 +145,7 @@ pub struct RoundedRectPathIter {
 }
 
 impl Shape for RoundedRect {
-    type PathElementsIter = RoundedRectPathIter;
+    type PathElementsIter<'iter> = RoundedRectPathIter;
 
     fn path_elements(&self, tolerance: f64) -> RoundedRectPathIter {
         let radii = self.radii();


### PR DESCRIPTION
The main gain from this is being able to iterate over `BezPath`s without cloning. Makes MSRV 1.65