### PR TITLE
Satisfy clippy up to 1.67 beta.

### DIFF
--- a/examples/arclen_accuracy.rs
+++ b/examples/arclen_accuracy.rs
@@ -184,7 +184,7 @@ fn run_simple() {
         let elapsed = duration_to_time(start_time.elapsed());
         let err = true_len - est;
         if i > 0 {
-            println!("{} {}", elapsed, err);
+            println!("{elapsed} {err}");
         }
     }
 }

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -9,9 +9,9 @@ fn main() {
     println!("<body>");
     println!("<svg height=\"800\" width=\"800\">");
     let path = circle.to_path(1e-3).to_svg();
-    println!("  <path d=\"{}\" stroke=\"black\" fill=\"none\" />", path);
+    println!("  <path d=\"{path}\" stroke=\"black\" fill=\"none\" />");
     let path = circle.to_path(1.0).to_svg();
-    println!("  <path d=\"{}\" stroke=\"red\" fill=\"none\" />", path);
+    println!("  <path d=\"{path}\" stroke=\"red\" fill=\"none\" />");
     println!("</svg>");
     println!("</body>");
     println!("</html>");

--- a/examples/cubic_arclen.rs
+++ b/examples/cubic_arclen.rs
@@ -249,13 +249,13 @@ fn main() {
         let est = gauss_arclen_9(c);
         let est_err = est_gauss9_error_3(c);
         let err = (accurate_arclen - est).abs();
-        println!("{} {}", est_err, err);
+        println!("{est_err} {err}");
 
         /*
         let mut count = 0;
         let est = my_arclen9(c, accuracy, 0, &mut count);
         let err = (accurate_arclen - est).abs();
-        println!("{} {}", err, count);
+        println!("{err} {count}");
         */
     }
 }

--- a/examples/ellipse.rs
+++ b/examples/ellipse.rs
@@ -10,9 +10,9 @@ fn main() {
     println!("<body>");
     println!("<svg height=\"800\" width=\"800\" style=\"background-color: #999\">");
     let path = ellipse.to_path(1e-3).to_svg();
-    println!("  <path d=\"{}\" stroke=\"black\" fill=\"none\" />", path);
+    println!("  <path d=\"{path}\" stroke=\"black\" fill=\"none\" />");
     let path = ellipse.to_path(1.0).to_svg();
-    println!("  <path d=\"{}\" stroke=\"red\" fill=\"none\" />", path);
+    println!("  <path d=\"{path}\" stroke=\"red\" fill=\"none\" />");
     println!("</svg>");
     println!("</body>");
     println!("</html>");

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -306,7 +306,7 @@ mod tests {
     use std::f64::consts::PI;
 
     fn assert_near(p0: Point, p1: Point) {
-        assert!((p1 - p0).hypot() < 1e-9, "{:?} != {:?}", p0, p1);
+        assert!((p1 - p0).hypot() < 1e-9, "{p0:?} != {p1:?}");
     }
 
     #[test]

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -1322,7 +1322,7 @@ mod tests {
     use super::*;
 
     fn assert_approx_eq(x: f64, y: f64) {
-        assert!((x - y).abs() < 1e-8, "{} != {}", x, y);
+        assert!((x - y).abs() < 1e-8, "{x} != {y}");
     }
 
     #[test]

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -357,7 +357,7 @@ mod tests {
     fn assert_approx_eq(x: f64, y: f64) {
         // Note: we might want to be more rigorous in testing the accuracy
         // of the conversion into Béziers. But this seems good enough.
-        assert!((x - y).abs() < 1e-7, "{} != {}", x, y);
+        assert!((x - y).abs() < 1e-7, "{x} != {y}");
     }
 
     #[test]

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -697,10 +697,7 @@ mod tests {
                 let actual_arc = c.subsegment(0.0..t).arclen(accuracy * 0.5);
                 assert!(
                     (arc - actual_arc).abs() < accuracy,
-                    "at accuracy {:e}, wanted {} got {}",
-                    accuracy,
-                    actual_arc,
-                    arc
+                    "at accuracy {accuracy:e}, wanted {actual_arc} got {arc}"
                 );
             }
         }
@@ -711,10 +708,7 @@ mod tests {
         let actual_arc = c.subsegment(0.0..t).arclen(accuracy);
         assert!(
             (arc - actual_arc).abs() < 2.0 * accuracy,
-            "at accuracy {:e}, want {} got {}",
-            accuracy,
-            actual_arc,
-            arc
+            "at accuracy {accuracy:e}, want {actual_arc} got {arc}"
         );
     }
 
@@ -762,9 +756,7 @@ mod tests {
         fn verify(result: Nearest, expected: f64) {
             assert!(
                 (result.t - expected).abs() < 1e-6,
-                "got {:?} expected {}",
-                result,
-                expected
+                "got {result:?} expected {expected}"
             );
         }
         // y = x^3
@@ -823,7 +815,7 @@ mod tests {
                     let p = q.eval(t);
                     let err = (p.y - p.x.powi(3)).abs();
                     worst = worst.max(err);
-                    assert!(err < accuracy, "got {} wanted {}", err, accuracy);
+                    assert!(err < accuracy, "got {err} wanted {accuracy}");
                 }
             }
         }

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -273,7 +273,7 @@ mod tests {
     fn assert_approx_eq(x: f64, y: f64) {
         // Note: we might want to be more rigorous in testing the accuracy
         // of the conversion into Béziers. But this seems good enough.
-        assert!((x - y).abs() < 1e-7, "{} != {}", x, y);
+        assert!((x - y).abs() < 1e-7, "{x} != {y}");
     }
 
     #[test]

--- a/src/mindist.rs
+++ b/src/mindist.rs
@@ -220,7 +220,7 @@ fn D_rk(r: usize, k: usize, bez1: &[Vec2], bez2: &[Vec2]) -> f64 {
 
 // Bezier basis function
 fn basis_function(n: usize, i: usize, u: f64) -> f64 {
-    choose(n, i) as f64 * (1.0 - u as f64).powi((n - i) as i32) * u.powi(i as i32)
+    choose(n, i) as f64 * (1.0 - u).powi((n - i) as i32) * u.powi(i as i32)
 }
 
 // Binomial co-efficient, but returning zeros for values outside of domain
@@ -266,9 +266,9 @@ mod tests {
             Vec2::new(309.0, 408.0),
         ];
         let b = A_r(1, &bez2);
-        assert!((b - 80283.0).abs() < 0.005, "B_1(Q)={:?}", b);
+        assert!((b - 80283.0).abs() < 0.005, "B_1(Q)={b:?}");
         let d = D_rk(0, 1, &bez1, &bez2);
-        assert!((d - 9220.0).abs() < 0.005, "D={:?}", d);
+        assert!((d - 9220.0).abs() < 0.005, "D={d:?}");
     }
 
     #[test]

--- a/src/point.rs
+++ b/src/point.rs
@@ -305,10 +305,10 @@ mod tests {
     #[test]
     fn display() {
         let p = Point::new(0.12345, 9.87654);
-        assert_eq!(format!("{}", p), "(0.12345, 9.87654)");
+        assert_eq!(format!("{p}"), "(0.12345, 9.87654)");
 
         let p = Point::new(0.12345, 9.87654);
-        assert_eq!(format!("{:.2}", p), "(0.12, 9.88)");
+        assert_eq!(format!("{p:.2}"), "(0.12, 9.88)");
     }
 }
 

--- a/src/quadbez.rs
+++ b/src/quadbez.rs
@@ -385,7 +385,7 @@ mod tests {
     };
 
     fn assert_near(p0: Point, p1: Point, epsilon: f64) {
-        assert!((p1 - p0).hypot() < epsilon, "{:?} != {:?}", p0, p1);
+        assert!((p1 - p0).hypot() < epsilon, "{p0:?} != {p1:?}");
     }
 
     #[test]
@@ -413,7 +413,7 @@ mod tests {
             let accuracy = 0.1f64.powi(i);
             let est = q.arclen(accuracy);
             let error = est - true_arclen;
-            assert!(error.abs() < accuracy, "{} != {}", est, true_arclen);
+            assert!(error.abs() < accuracy, "{est} != {true_arclen}");
         }
     }
 
@@ -425,9 +425,7 @@ mod tests {
         let est = q.arclen(accuracy);
         assert!(
             (est - true_arclen).abs() < accuracy,
-            "{} != {}",
-            est,
-            true_arclen
+            "{est} != {true_arclen}"
         );
     }
 
@@ -475,9 +473,7 @@ mod tests {
     fn verify(result: Nearest, expected: f64) {
         assert!(
             (result.t - expected).abs() < 1e-6,
-            "got {:?} expected {}",
-            result,
-            expected
+            "got {result:?} expected {expected}"
         );
     }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -708,10 +708,10 @@ mod tests {
     fn display() {
         let r = Rect::from_origin_size((10., 12.23214), (22.222222222, 23.1));
         assert_eq!(
-            format!("{}", r),
+            format!("{r}"),
             "Rect { (10, 12.23214) (22.222222222×23.1) }"
         );
-        assert_eq!(format!("{:.2}", r), "Rect { (10.00, 12.23) (22.22×23.10) }");
+        assert_eq!(format!("{r:.2}"), "Rect { (10.00, 12.23) (22.22×23.10) }");
     }
 
     /* TODO uncomment when a (possibly approximate) equality test has been decided on

--- a/src/size.rs
+++ b/src/size.rs
@@ -69,6 +69,11 @@ impl Size {
 
     /// Returns a new size bounded by `min` and `max.`
     ///
+    /// # Panics
+    ///
+    /// Panics if `min.width` > `max.width` or `min.height` > `max.height`,
+    /// or if any of those four are `NaN`.
+    ///
     /// # Examples
     ///
     /// ```
@@ -80,8 +85,8 @@ impl Size {
     /// assert_eq!(this.clamp(min, max), Size::new(10., 50.))
     /// ```
     pub fn clamp(self, min: Size, max: Size) -> Self {
-        let width = self.width.max(min.width).min(max.width);
-        let height = self.height.max(min.height).min(max.height);
+        let width = self.width.clamp(min.width, max.width);
+        let height = self.height.clamp(min.height, max.height);
         Size { width, height }
     }
 
@@ -354,10 +359,10 @@ mod tests {
     #[test]
     fn display() {
         let s = Size::new(-0.12345, 9.87654);
-        assert_eq!(format!("{}", s), "(-0.12345×9.87654)");
+        assert_eq!(format!("{s}"), "(-0.12345×9.87654)");
 
         let s = Size::new(-0.12345, 9.87654);
-        assert_eq!(format!("{:+6.2}", s), "( -0.12× +9.88)");
+        assert_eq!(format!("{s:+6.2}"), "( -0.12× +9.88)");
     }
 
     #[test]

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -243,7 +243,7 @@ impl Display for SvgParseError {
         match self {
             SvgParseError::Wrong => write!(f, "Unable to parse a number"),
             SvgParseError::UnexpectedEof => write!(f, "Unexpected EOF"),
-            SvgParseError::UnknownCommand(letter) => write!(f, "Unknown command, \"{}\"", letter),
+            SvgParseError::UnknownCommand(letter) => write!(f, "Unknown command, \"{letter}\""),
         }
     }
 }

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -276,7 +276,7 @@ mod tests {
     use crate::{Affine, Point, TranslateScale, Vec2};
 
     fn assert_near(p0: Point, p1: Point) {
-        assert!((p1 - p0).hypot() < 1e-9, "{:?} != {:?}", p0, p1);
+        assert!((p1 - p0).hypot() < 1e-9, "{p0:?} != {p1:?}");
     }
 
     #[test]

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -385,7 +385,7 @@ mod tests {
     #[test]
     fn display() {
         let v = Vec2::new(1.2332421, 532.10721213123);
-        let s = format!("{:.2}", v);
+        let s = format!("{v:.2}");
         assert_eq!(s.as_str(), "𝐯=(1.23, 532.11)");
     }
 }


### PR DESCRIPTION
Clippy lints addressed:
* [`unnecessary_cast`](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast)
* [`uninlined_format_args`](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args)
* [`manual_clamp`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_clamp)

The `clamp` one is a bit tricky. It introduces a panic condition to the `Size::clamp` method, which is never fun. Then again the panic case with the old implementation wouldn't satisfy the clamp conditions anyway, so perhaps the panic is justified. I ended up using the `std` `clamp` here, but I'm open to adding a clippy ignore attribute instead if the panic is too much.

