### PR TITLE
feat: Add a feature that allows usage on no_std targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
           profile: minimal
           override: true
 
+      - run: rustup target add thumbv7m-none-eabi
+
       - name: cargo clippy
         uses: actions-rs/cargo@v1
         with:
@@ -58,6 +60,10 @@ jobs:
         with:
           command: test
           args: --all-features
+
+      - name: Build with no default features
+        # Use no-std target to ensure we don't link to std.
+        run: cargo build --no-default-features --features libm --target thumbv7m-none-eabi
 
   test-stable-wasm:
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,17 @@ categories = ["graphics"]
 [package.metadata.docs.rs]
 features = ["mint", "schemars", "serde"]
 
-[dependencies]
-arrayvec = "0.7.1"
+[features]
+default = ["std"]
+std = []
+
+[dependencies.arrayvec]
+version = "0.7.1"
+default-features = false
+
+[dependencies.libm]
+version = "0.2.6"
+optional = true
 
 [dependencies.mint]
 version = "0.5.1"
@@ -27,6 +36,7 @@ optional = true
 [dependencies.serde]
 version = "1.0.105"
 optional = true
+default-features = false
 features = ["derive"]
 
 # This is used for research but not really needed; maybe refactor.

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -1,21 +1,24 @@
 //! Example of circle
 
+#[cfg(feature = "std")]
 fn main() {
-    #[cfg(feature = "std")]
-    {
-        use kurbo::{Circle, Shape};
+    use kurbo::{Circle, Shape};
 
-        let circle = Circle::new((400.0, 400.0), 380.0);
-        println!("<!DOCTYPE html>");
-        println!("<html>");
-        println!("<body>");
-        println!("<svg height=\"800\" width=\"800\">");
-        let path = circle.to_path(1e-3).to_svg();
-        println!("  <path d=\"{}\" stroke=\"black\" fill=\"none\" />", path);
-        let path = circle.to_path(1.0).to_svg();
-        println!("  <path d=\"{}\" stroke=\"red\" fill=\"none\" />", path);
-        println!("</svg>");
-        println!("</body>");
-        println!("</html>");
-    }
+    let circle = Circle::new((400.0, 400.0), 380.0);
+    println!("<!DOCTYPE html>");
+    println!("<html>");
+    println!("<body>");
+    println!("<svg height=\"800\" width=\"800\">");
+    let path = circle.to_path(1e-3).to_svg();
+    println!("  <path d=\"{}\" stroke=\"black\" fill=\"none\" />", path);
+    let path = circle.to_path(1.0).to_svg();
+    println!("  <path d=\"{}\" stroke=\"red\" fill=\"none\" />", path);
+    println!("</svg>");
+    println!("</body>");
+    println!("</html>");
+}
+
+#[cfg(not(feature = "std"))]
+fn main() {
+    println!("This example requires the standard library");
 }

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -1,18 +1,21 @@
 //! Example of circle
 
-use kurbo::{Circle, Shape};
-
 fn main() {
-    let circle = Circle::new((400.0, 400.0), 380.0);
-    println!("<!DOCTYPE html>");
-    println!("<html>");
-    println!("<body>");
-    println!("<svg height=\"800\" width=\"800\">");
-    let path = circle.to_path(1e-3).to_svg();
-    println!("  <path d=\"{path}\" stroke=\"black\" fill=\"none\" />");
-    let path = circle.to_path(1.0).to_svg();
-    println!("  <path d=\"{path}\" stroke=\"red\" fill=\"none\" />");
-    println!("</svg>");
-    println!("</body>");
-    println!("</html>");
+    #[cfg(feature = "std")]
+    {
+        use kurbo::{Circle, Shape};
+
+        let circle = Circle::new((400.0, 400.0), 380.0);
+        println!("<!DOCTYPE html>");
+        println!("<html>");
+        println!("<body>");
+        println!("<svg height=\"800\" width=\"800\">");
+        let path = circle.to_path(1e-3).to_svg();
+        println!("  <path d=\"{}\" stroke=\"black\" fill=\"none\" />", path);
+        let path = circle.to_path(1.0).to_svg();
+        println!("  <path d=\"{}\" stroke=\"red\" fill=\"none\" />", path);
+        println!("</svg>");
+        println!("</body>");
+        println!("</html>");
+    }
 }

--- a/examples/ellipse.rs
+++ b/examples/ellipse.rs
@@ -1,22 +1,25 @@
 //! Example of ellipse
 
-use kurbo::{Ellipse, Shape};
-use std::f64::consts::PI;
-
+#[cfg(feature = "std")]
 fn main() {
-    #[cfg(feature = "std")]
-    {
-        let ellipse = Ellipse::new((400.0, 400.0), (200.0, 100.0), 0.25 * PI);
-        println!("<!DOCTYPE html>");
-        println!("<html>");
-        println!("<body>");
-        println!("<svg height=\"800\" width=\"800\" style=\"background-color: #999\">");
-        let path = ellipse.to_path(1e-3).to_svg();
-        println!("  <path d=\"{}\" stroke=\"black\" fill=\"none\" />", path);
-        let path = ellipse.to_path(1.0).to_svg();
-        println!("  <path d=\"{}\" stroke=\"red\" fill=\"none\" />", path);
-        println!("</svg>");
-        println!("</body>");
-        println!("</html>");
-    }
+    use kurbo::{Ellipse, Shape};
+    use std::f64::consts::PI;
+
+    let ellipse = Ellipse::new((400.0, 400.0), (200.0, 100.0), 0.25 * PI);
+    println!("<!DOCTYPE html>");
+    println!("<html>");
+    println!("<body>");
+    println!("<svg height=\"800\" width=\"800\" style=\"background-color: #999\">");
+    let path = ellipse.to_path(1e-3).to_svg();
+    println!("  <path d=\"{}\" stroke=\"black\" fill=\"none\" />", path);
+    let path = ellipse.to_path(1.0).to_svg();
+    println!("  <path d=\"{}\" stroke=\"red\" fill=\"none\" />", path);
+    println!("</svg>");
+    println!("</body>");
+    println!("</html>");
+}
+
+#[cfg(not(feature = "std"))]
+fn main() {
+    println!("This example requires the standard library");
 }

--- a/examples/ellipse.rs
+++ b/examples/ellipse.rs
@@ -4,16 +4,19 @@ use kurbo::{Ellipse, Shape};
 use std::f64::consts::PI;
 
 fn main() {
-    let ellipse = Ellipse::new((400.0, 400.0), (200.0, 100.0), 0.25 * PI);
-    println!("<!DOCTYPE html>");
-    println!("<html>");
-    println!("<body>");
-    println!("<svg height=\"800\" width=\"800\" style=\"background-color: #999\">");
-    let path = ellipse.to_path(1e-3).to_svg();
-    println!("  <path d=\"{path}\" stroke=\"black\" fill=\"none\" />");
-    let path = ellipse.to_path(1.0).to_svg();
-    println!("  <path d=\"{path}\" stroke=\"red\" fill=\"none\" />");
-    println!("</svg>");
-    println!("</body>");
-    println!("</html>");
+    #[cfg(feature = "std")]
+    {
+        let ellipse = Ellipse::new((400.0, 400.0), (200.0, 100.0), 0.25 * PI);
+        println!("<!DOCTYPE html>");
+        println!("<html>");
+        println!("<body>");
+        println!("<svg height=\"800\" width=\"800\" style=\"background-color: #999\">");
+        let path = ellipse.to_path(1e-3).to_svg();
+        println!("  <path d=\"{}\" stroke=\"black\" fill=\"none\" />", path);
+        let path = ellipse.to_path(1.0).to_svg();
+        println!("  <path d=\"{}\" stroke=\"red\" fill=\"none\" />", path);
+        println!("</svg>");
+        println!("</body>");
+        println!("</html>");
+    }
 }

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -1,8 +1,11 @@
 //! Affine transforms.
 
-use std::ops::{Mul, MulAssign};
+use core::ops::{Mul, MulAssign};
 
 use crate::{Point, Rect, Vec2};
+
+#[allow(unused_imports)]
+use crate::common::FloatFuncs;
 
 /// A 2D affine transform.
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -4,7 +4,7 @@ use core::ops::{Mul, MulAssign};
 
 use crate::{Point, Rect, Vec2};
 
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;
 
 /// A 2D affine transform.

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 #[cfg(not(feature = "std"))]
-use crate::common::{FloatFuncs, FloatFuncsExtra};
+use crate::common::FloatFuncs;
 
 /// A single arc segment.
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -1,10 +1,13 @@
 //! An ellipse arc.
 
 use crate::{PathEl, Point, Rect, Shape, Vec2};
-use std::{
+use core::{
     f64::consts::{FRAC_PI_2, PI},
     iter,
 };
+
+#[allow(unused_imports)]
+use crate::common::{FloatFuncs, FloatFuncsExtra};
 
 /// A single arc segment.
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -6,7 +6,7 @@ use core::{
     iter,
 };
 
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use crate::common::{FloatFuncs, FloatFuncsExtra};
 
 /// A single arc segment.

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -2,9 +2,11 @@
 
 #![allow(clippy::many_single_char_names)]
 
-use std::iter::{Extend, FromIterator};
-use std::mem;
-use std::ops::{Mul, Range};
+use core::iter::{Extend, FromIterator};
+use core::mem;
+use core::ops::{Mul, Range};
+
+use alloc::vec::Vec;
 
 use arrayvec::ArrayVec;
 
@@ -14,6 +16,9 @@ use crate::{
     Affine, CubicBez, Line, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea,
     ParamCurveExtrema, ParamCurveNearest, Point, QuadBez, Rect, Shape, TranslateScale, Vec2,
 };
+
+#[allow(unused_imports)]
+use crate::common::FloatFuncs;
 
 /// A Bézier path.
 ///
@@ -404,7 +409,7 @@ impl FromIterator<PathEl> for BezPath {
 /// slice, as it returns `PathEl` items, rather than references.
 impl<'a> IntoIterator for &'a BezPath {
     type Item = PathEl;
-    type IntoIter = std::iter::Cloned<std::slice::Iter<'a, PathEl>>;
+    type IntoIter = core::iter::Cloned<core::slice::Iter<'a, PathEl>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.elements().iter().cloned()
@@ -413,7 +418,7 @@ impl<'a> IntoIterator for &'a BezPath {
 
 impl IntoIterator for BezPath {
     type Item = PathEl;
-    type IntoIter = std::vec::IntoIter<PathEl>;
+    type IntoIter = alloc::vec::IntoIter<PathEl>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -1108,7 +1113,7 @@ impl From<QuadBez> for PathSeg {
 }
 
 impl Shape for BezPath {
-    type PathElementsIter<'iter> = std::iter::Copied<std::slice::Iter<'iter, PathEl>>;
+    type PathElementsIter<'iter> = core::iter::Copied<core::slice::Iter<'iter, PathEl>>;
 
     fn path_elements(&self, _tolerance: f64) -> Self::PathElementsIter<'_> {
         self.0.iter().copied()
@@ -1178,7 +1183,7 @@ impl PathEl {
 impl<'a> Shape for &'a [PathEl] {
     type PathElementsIter<'iter>
 
-    = std::iter::Copied<std::slice::Iter<'a, PathEl>> where 'a: 'iter;
+    = core::iter::Copied<core::slice::Iter<'a, PathEl>> where 'a: 'iter;
 
     #[inline]
     fn path_elements(&self, _tolerance: f64) -> Self::PathElementsIter<'_> {
@@ -1218,7 +1223,7 @@ impl<'a> Shape for &'a [PathEl] {
 ///
 /// If the array starts with `LineTo`, `QuadTo`, or `CurveTo`, it will be treated as a `MoveTo`.
 impl<const N: usize> Shape for [PathEl; N] {
-    type PathElementsIter<'iter> = std::iter::Copied<std::slice::Iter<'iter, PathEl>>;
+    type PathElementsIter<'iter> = core::iter::Copied<core::slice::Iter<'iter, PathEl>>;
 
     #[inline]
     fn path_elements(&self, _tolerance: f64) -> Self::PathElementsIter<'_> {

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -17,7 +17,7 @@ use crate::{
     ParamCurveExtrema, ParamCurveNearest, Point, QuadBez, Rect, Shape, TranslateScale, Vec2,
 };
 
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;
 
 /// A Bézier path.

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -1,12 +1,15 @@
 //! Implementation of circle shape.
 
-use std::{
+use core::{
     f64::consts::{FRAC_PI_2, PI},
     iter,
     ops::{Add, Mul, Sub},
 };
 
 use crate::{Affine, Arc, ArcAppendIter, Ellipse, PathEl, Point, Rect, Shape, Vec2};
+
+#[allow(unused_imports)]
+use crate::common::FloatFuncs;
 
 /// A circle.
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
@@ -260,7 +263,7 @@ impl Sub<Vec2> for CircleSegment {
     }
 }
 
-type CircleSegmentPathIter = std::iter::Chain<
+type CircleSegmentPathIter = iter::Chain<
     iter::Chain<
         iter::Chain<iter::Chain<iter::Once<PathEl>, iter::Once<PathEl>>, ArcAppendIter>,
         iter::Once<PathEl>,

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -8,7 +8,7 @@ use core::{
 
 use crate::{Affine, Arc, ArcAppendIter, Ellipse, PathEl, Point, Rect, Shape, Vec2};
 
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;
 
 /// A circle.

--- a/src/common.rs
+++ b/src/common.rs
@@ -7,7 +7,7 @@ use arrayvec::ArrayVec;
 /// Defines a trait that chooses between libstd or libm implementations of float methods.
 macro_rules! define_float_funcs {
     ($(
-        fn $name:ident(self $(,$arg:ident: $arg_ty:ty)*) -> $ret:ty 
+        fn $name:ident(self $(,$arg:ident: $arg_ty:ty)*) -> $ret:ty
         => $lname:ident/$lfname:ident;
     )+) => {
         pub(crate) trait FloatFuncs : Sized {
@@ -20,7 +20,7 @@ macro_rules! define_float_funcs {
                 return self.$name($($arg),*);
 
                 #[cfg(not(feature = "std"))]
-                return libm::$lfname(self $(,$arg as _)*); 
+                return libm::$lfname(self $(,$arg as _)*);
 
                 #[cfg(all(not(feature = "std"), not(feature = "libm")))]
                 compile_error!("kurbo requires either the `std` or `libm` feature");

--- a/src/common.rs
+++ b/src/common.rs
@@ -10,32 +10,29 @@ macro_rules! define_float_funcs {
         fn $name:ident(self $(,$arg:ident: $arg_ty:ty)*) -> $ret:ty
         => $lname:ident/$lfname:ident;
     )+) => {
+        #[cfg(not(feature = "std"))]
         pub(crate) trait FloatFuncs : Sized {
             $(fn $name(self $(,$arg: $arg_ty)*) -> $ret;)+
         }
 
+        #[cfg(not(feature = "std"))]
         impl FloatFuncs for f32 {
             $(fn $name(self $(,$arg: $arg_ty)*) -> $ret {
-                #[cfg(feature = "std")]
-                return self.$name($($arg),*);
-
-                #[cfg(not(feature = "std"))]
+                #[cfg(feature = "libm")]
                 return libm::$lfname(self $(,$arg as _)*);
 
-                #[cfg(all(not(feature = "std"), not(feature = "libm")))]
-                compile_error!("kurbo requires either the `std` or `libm` feature");
+                #[cfg(not(feature = "libm"))]
+                compile_error!("kurbo requires either the `std` or `libm` feature")
             })+
         }
 
+        #[cfg(not(feature = "std"))]
         impl FloatFuncs for f64 {
             $(fn $name(self $(,$arg: $arg_ty)*) -> $ret {
-                #[cfg(feature = "std")]
-                return self.$name($($arg),*);
-
-                #[cfg(all(not(feature = "std"), feature = "libm"))]
+                #[cfg(feature = "libm")]
                 return libm::$lname(self $(,$arg as _)*);
 
-                #[cfg(all(not(feature = "std"), not(feature = "libm")))]
+                #[cfg(not(feature = "libm"))]
                 compile_error!("kurbo requires either the `std` or `libm` feature")
             })+
         }
@@ -63,10 +60,12 @@ define_float_funcs! {
 }
 
 /// Special implementation for signum, because libm doesn't have it.
+#[cfg(not(feature = "std"))]
 pub(crate) trait FloatFuncsExtra {
     fn signum(self) -> Self;
 }
 
+#[cfg(not(feature = "std"))]
 impl FloatFuncsExtra for f32 {
     #[inline]
     fn signum(self) -> f32 {
@@ -78,6 +77,7 @@ impl FloatFuncsExtra for f32 {
     }
 }
 
+#[cfg(not(feature = "std"))]
 impl FloatFuncsExtra for f64 {
     #[inline]
     fn signum(self) -> f64 {

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,6 +4,91 @@
 
 use arrayvec::ArrayVec;
 
+/// Defines a trait that chooses between libstd or libm implementations of float methods.
+macro_rules! define_float_funcs {
+    ($(
+        fn $name:ident(self $(,$arg:ident: $arg_ty:ty)*) -> $ret:ty 
+        => $lname:ident/$lfname:ident;
+    )+) => {
+        pub(crate) trait FloatFuncs : Sized {
+            $(fn $name(self $(,$arg: $arg_ty)*) -> $ret;)+
+        }
+
+        impl FloatFuncs for f32 {
+            $(fn $name(self $(,$arg: $arg_ty)*) -> $ret {
+                #[cfg(feature = "std")]
+                return self.$name($($arg),*);
+
+                #[cfg(not(feature = "std"))]
+                return libm::$lfname(self $(,$arg as _)*); 
+
+                #[cfg(all(not(feature = "std"), not(feature = "libm")))]
+                compile_error!("kurbo requires either the `std` or `libm` feature");
+            })+
+        }
+
+        impl FloatFuncs for f64 {
+            $(fn $name(self $(,$arg: $arg_ty)*) -> $ret {
+                #[cfg(feature = "std")]
+                return self.$name($($arg),*);
+
+                #[cfg(all(not(feature = "std"), feature = "libm"))]
+                return libm::$lname(self $(,$arg as _)*);
+
+                #[cfg(all(not(feature = "std"), not(feature = "libm")))]
+                compile_error!("kurbo requires either the `std` or `libm` feature")
+            })+
+        }
+    }
+}
+
+define_float_funcs! {
+    fn abs(self) -> Self => fabs/fabsf;
+    fn atan2(self, other: Self) -> Self => atan2/atan2f;
+    fn cbrt(self) -> Self => cbrt/cbrtf;
+    fn ceil(self) -> Self => ceil/ceilf;
+    fn copysign(self, sign: Self) -> Self => copysign/copysignf;
+    fn floor(self) -> Self => floor/floorf;
+    fn hypot(self, other: Self) -> Self => hypot/hypotf;
+    fn ln(self) -> Self => log/logf;
+    fn log2(self) -> Self => log2/log2f;
+    fn mul_add(self, a: Self, b: Self) -> Self => fma/fmaf;
+    fn powi(self, n: i32) -> Self => pow/powf;
+    fn powf(self, n: Self) -> Self => pow/powf;
+    fn round(self) -> Self => round/roundf;
+    fn sin_cos(self) -> (Self, Self) => sincos/sincosf;
+    fn sqrt(self) -> Self => sqrt/sqrtf;
+    fn tan(self) -> Self => tan/tanf;
+    fn trunc(self) -> Self => trunc/truncf;
+}
+
+/// Special implementation for signum, because libm doesn't have it.
+pub(crate) trait FloatFuncsExtra {
+    fn signum(self) -> Self;
+}
+
+impl FloatFuncsExtra for f32 {
+    #[inline]
+    fn signum(self) -> f32 {
+        if self.is_nan() {
+            f32::NAN
+        } else {
+            1.0_f32.copysign(self)
+        }
+    }
+}
+
+impl FloatFuncsExtra for f64 {
+    #[inline]
+    fn signum(self) -> f64 {
+        if self.is_nan() {
+            f64::NAN
+        } else {
+            1.0_f64.copysign(self)
+        }
+    }
+}
+
 /// Adds convenience methods to `f32` and `f64`.
 pub trait FloatExt<T> {
     /// Rounds to the nearest integer away from zero,

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -1,6 +1,8 @@
 //! Cubic Bézier segments.
 
-use std::ops::{Mul, Range};
+use core::ops::{Mul, Range};
+use alloc::vec::Vec;
+use alloc::vec;
 
 use crate::MAX_EXTREMA;
 use crate::{Line, QuadSpline, Vec2};
@@ -14,6 +16,9 @@ use crate::{
     Affine, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea, ParamCurveCurvature,
     ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest, PathEl, Point, QuadBez, Rect, Shape,
 };
+
+#[allow(unused_imports)]
+use crate::common::FloatFuncs;
 
 const MAX_SPLINE_SPLIT: usize = 100;
 
@@ -217,7 +222,7 @@ impl CubicBez {
         let delta_2 = dt * dt;
         let delta_3 = dt * delta_2;
 
-        std::iter::from_fn(move || {
+        core::iter::from_fn(move || {
             // if storage exists, we use it exclusively
             if let Some(storage) = storage.as_mut() {
                 return storage.pop();

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -1,8 +1,8 @@
 //! Cubic Bézier segments.
 
-use core::ops::{Mul, Range};
-use alloc::vec::Vec;
 use alloc::vec;
+use alloc::vec::Vec;
+use core::ops::{Mul, Range};
 
 use crate::MAX_EXTREMA;
 use crate::{Line, QuadSpline, Vec2};

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -17,7 +17,7 @@ use crate::{
     ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest, PathEl, Point, QuadBez, Rect, Shape,
 };
 
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;
 
 const MAX_SPLINE_SPLIT: usize = 100;

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -8,7 +8,7 @@ use core::{
 
 use crate::{Affine, Arc, ArcAppendIter, Circle, PathEl, Point, Rect, Shape, Size, Vec2};
 
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;
 
 /// An ellipse.

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -1,12 +1,15 @@
 //! Implementation of ellipse shape.
 
-use std::f64::consts::PI;
-use std::{
+use core::f64::consts::PI;
+use core::{
     iter,
     ops::{Add, Mul, Sub},
 };
 
 use crate::{Affine, Arc, ArcAppendIter, Circle, PathEl, Point, Rect, Shape, Size, Vec2};
+
+#[allow(unused_imports)]
+use crate::common::FloatFuncs;
 
 /// An ellipse.
 #[derive(Clone, Copy, Default, Debug, PartialEq)]

--- a/src/insets.rs
+++ b/src/insets.rs
@@ -14,7 +14,7 @@
 
 //! A description of the distances between the edges of two rectangles.
 
-use std::ops::{Add, Neg, Sub};
+use core::ops::{Add, Neg, Sub};
 
 use crate::{Rect, Size};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,16 +66,16 @@
 //! let hit = closest_perimeter_point(circle, hit_point).unwrap();
 //! assert!(hit.distance(expectation) <= DESIRED_ACCURACY);
 //! ```
-//! 
+//!
 //! # Features
-//! 
+//!
 //! This crate either uses the standard library or the [`libm`] crate for
 //! math functionality. The `std` feature is enabled by default, but can be
 //! disabled, as long as the `libm` feature is enabled. This is useful for
 //! `no_std` environments. However, note that the `libm` crate is not as
 //! efficient as the standard library, and that this crate still uses the
 //! `alloc` crate regardless.
-//! 
+//!
 //! [`Piet`]: https://docs.rs/piet
 //! [`Druid`]: https://docs.rs/druid
 //! [`libm`]: https://docs.rs/libm
@@ -89,7 +89,6 @@
     clippy::excessive_precision,
     clippy::bool_to_int_with_if
 )]
-
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 
 #[cfg(not(any(feature = "std", feature = "libm")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,8 +66,19 @@
 //! let hit = closest_perimeter_point(circle, hit_point).unwrap();
 //! assert!(hit.distance(expectation) <= DESIRED_ACCURACY);
 //! ```
+//! 
+//! # Features
+//! 
+//! This crate either uses the standard library or the [`libm`] crate for
+//! math functionality. The `std` feature is enabled by default, but can be
+//! disabled, as long as the `libm` feature is enabled. This is useful for
+//! `no_std` environments. However, note that the `libm` crate is not as
+//! efficient as the standard library, and that this crate still uses the
+//! `alloc` crate regardless.
+//! 
 //! [`Piet`]: https://docs.rs/piet
 //! [`Druid`]: https://docs.rs/druid
+//! [`libm`]: https://docs.rs/libm
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs, clippy::trivially_copy_pass_by_ref)]
@@ -78,6 +89,13 @@
     clippy::excessive_precision,
     clippy::bool_to_int_with_if
 )]
+
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+
+#[cfg(not(any(feature = "std", feature = "libm")))]
+compile_error!("kurbo requires either the `std` or `libm` feature");
+
+extern crate alloc;
 
 mod affine;
 mod arc;
@@ -98,6 +116,7 @@ mod rounded_rect;
 mod rounded_rect_radii;
 mod shape;
 mod size;
+#[cfg(feature = "std")]
 mod svg;
 mod translate_scale;
 mod vec2;
@@ -119,6 +138,7 @@ pub use crate::rounded_rect::*;
 pub use crate::rounded_rect_radii::*;
 pub use crate::shape::*;
 pub use crate::size::*;
+#[cfg(feature = "std")]
 pub use crate::svg::*;
 pub use crate::translate_scale::*;
 pub use crate::vec2::*;

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,6 +1,6 @@
 //! Lines.
 
-use std::ops::{Add, Mul, Range, Sub};
+use core::ops::{Add, Mul, Range, Sub};
 
 use arrayvec::ArrayVec;
 

--- a/src/mindist.rs
+++ b/src/mindist.rs
@@ -21,6 +21,9 @@
 use crate::Vec2;
 use core::cmp::Ordering;
 
+#[allow(unused_imports)]
+use crate::common::FloatFuncs;
+
 pub(crate) fn min_dist_param(
     bez1: &[Vec2],
     bez2: &[Vec2],

--- a/src/mindist.rs
+++ b/src/mindist.rs
@@ -21,7 +21,7 @@
 use crate::Vec2;
 use core::cmp::Ordering;
 
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;
 
 pub(crate) fn min_dist_param(

--- a/src/param_curve.rs
+++ b/src/param_curve.rs
@@ -6,7 +6,7 @@ use arrayvec::ArrayVec;
 
 use crate::{common, Point, Rect};
 
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;
 
 /// A default value for methods that take an 'accuracy' argument.

--- a/src/param_curve.rs
+++ b/src/param_curve.rs
@@ -1,10 +1,13 @@
 //! A trait for curves parametrized by a scalar.
 
-use std::ops::Range;
+use core::ops::Range;
 
 use arrayvec::ArrayVec;
 
 use crate::{common, Point, Rect};
+
+#[allow(unused_imports)]
+use crate::common::FloatFuncs;
 
 /// A default value for methods that take an 'accuracy' argument.
 ///

--- a/src/point.rs
+++ b/src/point.rs
@@ -6,7 +6,7 @@ use core::ops::{Add, AddAssign, Sub, SubAssign};
 use crate::common::FloatExt;
 use crate::Vec2;
 
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;
 
 /// A 2D point.

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,10 +1,13 @@
 //! A 2D point.
 
-use std::fmt;
-use std::ops::{Add, AddAssign, Sub, SubAssign};
+use core::fmt;
+use core::ops::{Add, AddAssign, Sub, SubAssign};
 
 use crate::common::FloatExt;
 use crate::Vec2;
+
+#[allow(unused_imports)]
+use crate::common::FloatFuncs;
 
 /// A 2D point.
 #[derive(Clone, Copy, Default, PartialEq)]

--- a/src/quadbez.rs
+++ b/src/quadbez.rs
@@ -1,6 +1,6 @@
 //! Quadratic Bézier segments.
 
-use std::ops::{Mul, Range};
+use core::ops::{Mul, Range};
 
 use arrayvec::ArrayVec;
 
@@ -11,6 +11,9 @@ use crate::{
     ParamCurveCurvature, ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest, PathEl, Point,
     Rect, Shape,
 };
+
+#[allow(unused_imports)]
+use crate::common::{FloatFuncs, FloatFuncsExtra};
 
 /// A single quadratic Bézier segment.
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/quadbez.rs
+++ b/src/quadbez.rs
@@ -12,7 +12,7 @@ use crate::{
     Rect, Shape,
 };
 
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use crate::common::{FloatFuncs, FloatFuncsExtra};
 
 /// A single quadratic Bézier segment.

--- a/src/quadbez.rs
+++ b/src/quadbez.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 #[cfg(not(feature = "std"))]
-use crate::common::{FloatFuncs, FloatFuncsExtra};
+use crate::common::FloatFuncs;
 
 /// A single quadratic Bézier segment.
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/quadspline.rs
+++ b/src/quadspline.rs
@@ -14,6 +14,8 @@
 
 //! Quadratic Bézier splines.
 use crate::Point;
+
+use alloc::vec::Vec;
 use crate::QuadBez;
 
 /// A quadratic Bézier spline in [B-spline](https://en.wikipedia.org/wiki/B-spline) format.

--- a/src/quadspline.rs
+++ b/src/quadspline.rs
@@ -15,8 +15,8 @@
 //! Quadratic Bézier splines.
 use crate::Point;
 
-use alloc::vec::Vec;
 use crate::QuadBez;
+use alloc::vec::Vec;
 
 /// A quadratic Bézier spline in [B-spline](https://en.wikipedia.org/wiki/B-spline) format.
 #[derive(Clone, Debug, PartialEq)]

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -5,7 +5,7 @@ use core::ops::{Add, Sub};
 
 use crate::{Ellipse, Insets, PathEl, Point, RoundedRect, RoundedRectRadii, Shape, Size, Vec2};
 
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;
 
 /// A rectangle.

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -1,9 +1,12 @@
 //! A rectangle.
 
-use std::fmt;
-use std::ops::{Add, Sub};
+use core::fmt;
+use core::ops::{Add, Sub};
 
 use crate::{Ellipse, Insets, PathEl, Point, RoundedRect, RoundedRectRadii, Shape, Size, Vec2};
+
+#[allow(unused_imports)]
+use crate::common::FloatFuncs;
 
 /// A rectangle.
 #[derive(Clone, Copy, Default, PartialEq)]

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -5,7 +5,7 @@ use core::ops::{Add, Sub};
 
 use crate::{arc::ArcAppendIter, Arc, PathEl, Point, Rect, RoundedRectRadii, Shape, Size, Vec2};
 
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;
 
 /// A rectangle with equally rounded corners.

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -1,9 +1,12 @@
 //! A rectangle with rounded corners.
 
-use std::f64::consts::{FRAC_PI_2, FRAC_PI_4};
-use std::ops::{Add, Sub};
+use core::f64::consts::{FRAC_PI_2, FRAC_PI_4};
+use core::ops::{Add, Sub};
 
 use crate::{arc::ArcAppendIter, Arc, PathEl, Point, Rect, RoundedRectRadii, Shape, Size, Vec2};
+
+#[allow(unused_imports)]
+use crate::common::FloatFuncs;
 
 /// A rectangle with equally rounded corners.
 ///

--- a/src/rounded_rect_radii.rs
+++ b/src/rounded_rect_radii.rs
@@ -16,7 +16,7 @@
 
 use core::convert::From;
 
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;
 
 /// Radii for each corner of a rounded rectangle.

--- a/src/rounded_rect_radii.rs
+++ b/src/rounded_rect_radii.rs
@@ -14,7 +14,10 @@
 
 //! A description of the radii for each corner of a rounded rectangle.
 
-use std::convert::From;
+use core::convert::From;
+
+#[allow(unused_imports)]
+use crate::common::FloatFuncs;
 
 /// Radii for each corner of a rounded rectangle.
 ///

--- a/src/size.rs
+++ b/src/size.rs
@@ -1,10 +1,13 @@
 //! A 2D size.
 
-use std::fmt;
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+use core::fmt;
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
 use crate::common::FloatExt;
 use crate::{Rect, RoundedRect, RoundedRectRadii, Vec2};
+
+#[allow(unused_imports)]
+use crate::common::FloatFuncs;
 
 /// A 2D size.
 #[derive(Clone, Copy, Default, PartialEq)]

--- a/src/size.rs
+++ b/src/size.rs
@@ -6,7 +6,7 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 use crate::common::FloatExt;
 use crate::{Rect, RoundedRect, RoundedRectRadii, Vec2};
 
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;
 
 /// A 2D size.

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -1,6 +1,6 @@
 //! A transformation that includes both scale and translation.
 
-use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 
 use crate::{
     Affine, Circle, CubicBez, Line, Point, QuadBez, Rect, RoundedRect, RoundedRectRadii, Vec2,

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -1,10 +1,13 @@
 //! A simple 2D vector.
 
-use std::fmt;
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use core::fmt;
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::common::FloatExt;
 use crate::{Point, Size};
+
+#[allow(unused_imports)]
+use crate::common::FloatFuncs;
 
 /// A 2D vector.
 ///

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -6,7 +6,7 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use crate::common::FloatExt;
 use crate::{Point, Size};
 
-#[allow(unused_imports)]
+#[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;
 
 /// A 2D vector.


### PR DESCRIPTION
This PR adds features `std` (enabled by default) and `libm` that allow this crate to be used on `no_std` targets.