### PR TITLE
Standardize copyright headers.

### DIFF
--- a/benches/cubic_arclen.rs
+++ b/benches/cubic_arclen.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Benchmarks of cubic arclength approaches.
 
 #![cfg(nightly)]

--- a/benches/quad_arclen.rs
+++ b/benches/quad_arclen.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Benchmarks of quadratic arclength approaches.
 
 // TODO: organize so there's less cut'n'paste from arclen_accuracy example.

--- a/benches/rect_expand.rs
+++ b/benches/rect_expand.rs
@@ -1,3 +1,6 @@
+// Copyright 2020 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #![cfg(nightly)]
 #![feature(test)]
 extern crate test;

--- a/examples/arclen_accuracy.rs
+++ b/examples/arclen_accuracy.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! A test program to plot the error of arclength approximation.
 
 // Lots of stuff is commented out or was just something to try.

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -1,3 +1,6 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Example of circle
 
 use kurbo::{Circle, Shape};

--- a/examples/cubic_arclen.rs
+++ b/examples/cubic_arclen.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Research testbed for arclengths of cubic Bézier segments.
 
 // Lots of stuff is commented out or was just something to try.

--- a/examples/ellipse.rs
+++ b/examples/ellipse.rs
@@ -1,3 +1,6 @@
+// Copyright 2020 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Example of ellipse
 
 use kurbo::{Ellipse, Shape};

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Affine transforms.
 
 use std::ops::{Mul, MulAssign};

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -1,3 +1,6 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! An ellipse arc.
 
 use crate::{PathEl, Point, Rect, Shape, Vec2};

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Bézier paths (up to cubic).
 
 #![allow(clippy::many_single_char_names)]

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -1,3 +1,6 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Implementation of circle shape.
 
 use std::{

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Common mathematical operations
 
 #![allow(missing_docs)]

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Cubic Bézier segments.
 
 use std::ops::{Mul, Range};

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -1,3 +1,6 @@
+// Copyright 2020 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Implementation of ellipse shape.
 
 use std::f64::consts::PI;

--- a/src/insets.rs
+++ b/src/insets.rs
@@ -1,16 +1,5 @@
-// Copyright 2019 The kurbo Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! A description of the distances between the edges of two rectangles.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,5 @@
-// Copyright 2018 The kurbo Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! 2D geometry, with a focus on curves.
 //!

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Lines.
 
 use std::ops::{Add, Mul, Range, Sub};

--- a/src/mindist.rs
+++ b/src/mindist.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The kurbo Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2021 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Minimum distance between two Bézier curves
 //!

--- a/src/param_curve.rs
+++ b/src/param_curve.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! A trait for curves parametrized by a scalar.
 
 use std::ops::Range;

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,3 +1,6 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! A 2D point.
 
 use std::fmt;

--- a/src/quadbez.rs
+++ b/src/quadbez.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! Quadratic Bézier segments.
 
 use std::ops::{Mul, Range};

--- a/src/quadspline.rs
+++ b/src/quadspline.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The kurbo Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2021 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Quadratic Bézier splines.
 use crate::Point;

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -1,3 +1,6 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! A rectangle.
 
 use std::fmt;

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -1,3 +1,6 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! A rectangle with rounded corners.
 
 use std::f64::consts::{FRAC_PI_2, FRAC_PI_4};

--- a/src/rounded_rect_radii.rs
+++ b/src/rounded_rect_radii.rs
@@ -1,16 +1,5 @@
-// Copyright 2021 The kurbo Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2021 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! A description of the radii for each corner of a rounded rectangle.
 

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1,3 +1,6 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! A generic trait for shapes.
 
 use crate::{segments, BezPath, Circle, Line, PathEl, Point, Rect, RoundedRect, Segments};

--- a/src/size.rs
+++ b/src/size.rs
@@ -1,3 +1,6 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! A 2D size.
 
 use std::fmt;

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! SVG path representation.
 
 use std::error::Error;

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -1,3 +1,6 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! A transformation that includes both scale and translation.
 
 use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 //! A simple 2D vector.
 
 use std::fmt;


### PR DESCRIPTION
First step towards standardizing the copyright headers across linebender. More information can be found in #207.

Fixes #207