### PR TITLE
Implement Affine * Arc

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -199,8 +199,7 @@ impl Mul<Arc> for Affine {
     fn mul(self, arc: Arc) -> Self::Output {
         let ellipse = self * Ellipse::new(arc.center, arc.radii, arc.x_rotation);
         let center = ellipse.center();
-        let radii = ellipse.radii();
-        let rotation = ellipse.rotation();
+        let (radii, rotation) = ellipse.radii_and_rotation();
         Arc {
             center,
             radii,

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -3,10 +3,11 @@
 
 //! An ellipse arc.
 
-use crate::{PathEl, Point, Rect, Shape, Vec2};
+use crate::{Affine, Ellipse, PathEl, Point, Rect, Shape, Vec2};
 use core::{
     f64::consts::{FRAC_PI_2, PI},
     iter,
+    ops::Mul,
 };
 
 #[cfg(not(feature = "std"))]
@@ -31,6 +32,23 @@ pub struct Arc {
 }
 
 impl Arc {
+    /// Create a new `Arc`.
+    pub fn new(
+        center: impl Into<Point>,
+        radii: impl Into<Vec2>,
+        start_angle: f64,
+        sweep_angle: f64,
+        x_rotation: f64,
+    ) -> Self {
+        Self {
+            center: center.into(),
+            radii: radii.into(),
+            start_angle,
+            sweep_angle,
+            x_rotation,
+        }
+    }
+
     /// Create an iterator generating Bezier path elements.
     ///
     /// The generated elements can be appended to an existing bezier path.
@@ -172,5 +190,23 @@ impl Shape for Arc {
     #[inline]
     fn bounding_box(&self) -> Rect {
         self.path_segments(0.1).bounding_box()
+    }
+}
+
+impl Mul<Arc> for Affine {
+    type Output = Arc;
+
+    fn mul(self, arc: Arc) -> Self::Output {
+        let ellipse = self * Ellipse::new(arc.center, arc.radii, arc.x_rotation);
+        let center = ellipse.center();
+        let radii = ellipse.radii();
+        let rotation = ellipse.rotation();
+        Arc {
+            center,
+            radii,
+            x_rotation: rotation,
+            start_angle: arc.start_angle,
+            sweep_angle: arc.sweep_angle,
+        }
     }
 }

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -138,6 +138,13 @@ impl Ellipse {
         self.inner.svd().1
     }
 
+    /// Returns the radii and the rotation of this ellipse.
+    ///
+    /// Equivalent to `(self.radii(), self.rotation())` but more efficient.
+    pub fn radii_and_rotation(&self) -> (Vec2, f64) {
+        self.inner.svd()
+    }
+
     /// Is this ellipse finite?
     #[inline]
     pub fn is_finite(&self) -> bool {


### PR DESCRIPTION
Implements `Affine` * `Arc`, for parity with other `Shape` types.

Closes #251 