### PR TITLE
Revert semver breaking change and bump version for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kurbo"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2021"

--- a/src/size.rs
+++ b/src/size.rs
@@ -75,11 +75,6 @@ impl Size {
 
     /// Returns a new size bounded by `min` and `max.`
     ///
-    /// # Panics
-    ///
-    /// Panics if `min.width` > `max.width` or `min.height` > `max.height`,
-    /// or if any of those four are `NaN`.
-    ///
     /// # Examples
     ///
     /// ```
@@ -91,8 +86,8 @@ impl Size {
     /// assert_eq!(this.clamp(min, max), Size::new(10., 50.))
     /// ```
     pub fn clamp(self, min: Size, max: Size) -> Self {
-        let width = self.width.clamp(min.width, max.width);
-        let height = self.height.clamp(min.height, max.height);
+        let width = self.width.max(min.width).min(max.width);
+        let height = self.height.max(min.height).min(max.height);
         Size { width, height }
     }
 


### PR DESCRIPTION
This reverts the clamp change in #233 (this clippy lint is now set to allow by default due to changes in behavior) to allow a patch release without breaking semver.

Updates the version to 0.9.2.