### PR TITLE
Make fit_to_bezpath_opt handle cusps

### DIFF
--- a/examples/offset.rs
+++ b/examples/offset.rs
@@ -12,7 +12,7 @@ fn main() {
         "  <path d='{}' stroke='#000' fill='none' />",
         c.to_path(1e-9).to_svg()
     );
-    for i in 1..=10 {
+    for i in 1..=80 {
         let co = CubicOffset::new(c, i as f64 * 4.0);
         let path = kurbo::fit_to_bezpath_opt(&co, 1e-3);
         println!(

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -273,6 +273,11 @@ impl BezPath {
         segments(self.iter())
     }
 
+    /// Shorten the path, keeping the first `len` elements.
+    pub fn truncate(&mut self, len: usize) {
+        self.0.truncate(len);
+    }
+
     /// Flatten the path, invoking the callback repeatedly.
     ///
     /// Flattening is the action of approximating a curve with a succession of line segments.

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -6,6 +6,8 @@
 
 use core::ops::Range;
 
+use alloc::vec::Vec;
+
 use arrayvec::ArrayVec;
 
 use crate::{


### PR DESCRIPTION
Add cusp handling to the optimizing variant. It should be reasonably numerically robust, but this has not been extensively tested yet.