### PR TITLE
Add alloc feature to serde dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kurbo"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2021"
@@ -37,7 +37,7 @@ optional = true
 version = "1.0.105"
 optional = true
 default-features = false
-features = ["derive"]
+features = ["alloc", "derive"]
 
 # This is used for research but not really needed; maybe refactor.
 [dev-dependencies]


### PR DESCRIPTION
Restores serde support for BezPath.

Also bumps version so we can release.