### PR TITLE
Improve robustness of curve fitting

### DIFF
--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -1073,6 +1073,51 @@ impl PathSeg {
             t2,
         }
     }
+
+    /// Compute endpoint tangents of a path segment.
+    ///
+    /// This version is robust to the path segment not being a regular curve.
+    pub(crate) fn tangents(&self) -> (Vec2, Vec2) {
+        const EPS: f64 = 1e-12;
+        match self {
+            PathSeg::Line(l) => {
+                let d = l.p1 - l.p0;
+                (d, d)
+            }
+            PathSeg::Quad(q) => {
+                let d01 = q.p1 - q.p0;
+                let d0 = if d01.hypot2() > EPS { d01 } else { q.p2 - q.p0 };
+                let d12 = q.p2 - q.p1;
+                let d1 = if d12.hypot2() > EPS { d12 } else { q.p2 - q.p0 };
+                (d0, d1)
+            }
+            PathSeg::Cubic(c) => {
+                let d01 = c.p1 - c.p0;
+                let d0 = if d01.hypot2() > EPS {
+                    d01
+                } else {
+                    let d02 = c.p2 - c.p0;
+                    if d02.hypot2() > EPS {
+                        d02
+                    } else {
+                        c.p3 - c.p0
+                    }
+                };
+                let d23 = c.p3 - c.p2;
+                let d1 = if d23.hypot2() > EPS {
+                    d23
+                } else {
+                    let d13 = c.p3 - c.p1;
+                    if d13.hypot2() > EPS {
+                        d13
+                    } else {
+                        c.p3 - c.p0
+                    }
+                };
+                (d0, d1)
+            }
+        }
+    }
 }
 
 impl LineIntersection {

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -353,7 +353,7 @@ pub fn fit_to_cubic(
 
     let chord = chord2.sqrt();
     let aff = Affine::translate(start.p.to_vec2()) * Affine::rotate(th) * Affine::scale(chord);
-    let mut curve_dist = CurveDist::from_curve(source, range.clone());
+    let mut curve_dist = CurveDist::from_curve(source, range);
     let acc2 = accuracy * accuracy;
     let mut best_c = None;
     let mut best_err2 = None;

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -247,7 +247,7 @@ pub fn fit_to_cubic(
     // the order of samples, for example bit-reversing.
     const N_SAMPLE: usize = 10;
     let step: f64 = (range.end - range.start) * (1.0 / (N_SAMPLE + 1) as f64);
-    let samples: ArrayVec<_, 10> = (0..N_SAMPLE)
+    let samples: ArrayVec<_, N_SAMPLE> = (0..N_SAMPLE)
         .map(|i| source.sample_pt_tangent(range.start + (i + 1) as f64 * step, 1.0))
         .collect();
     let acc2 = accuracy * accuracy;
@@ -445,7 +445,7 @@ fn fit_to_bezpath_opt_inner(
     let k1 = 0.2 / accuracy;
     let ya = -err;
     let yb = accuracy - last_err;
-    let x = match solve_itp_fallible(f, 0.0, accuracy, EPS, 1, k1, ya, yb) {
+    let (_, x) = match solve_itp_fallible(f, 0.0, accuracy, EPS, 1, k1, ya, yb) {
         Ok(x) => x,
         Err(t) => return Some(t),
     };
@@ -511,7 +511,7 @@ fn fit_opt_segment(source: &impl ParamCurveFit, accuracy: f64, range: Range<f64>
     const EPS: f64 = 1e-9;
     let k1 = 2.0 / (t1 - t0);
     match solve_itp_fallible(f, t0, t1, EPS, 1, k1, -accuracy, err - accuracy) {
-        Ok(t1) => FitResult::ParamVal(t1),
+        Ok((t1, _)) => FitResult::ParamVal(t1),
         Err(t) => FitResult::CuspFound(t),
     }
 }

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -311,7 +311,7 @@ impl CurveDist {
 /// the measured error (approximate Fréchet distance). This is ReLU-like,
 /// with a value of 1.0 below the elbow, and a given slope above it. The
 /// values here have been determined empirically to give good results.
-/// 
+///
 /// [Simplifying Bézier paths]:
 /// https://raphlinus.github.io/curves/2023/04/18/bezpath-simplify.html
 const D_PENALTY_ELBOW: f64 = 0.65;

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -548,7 +548,7 @@ fn fit_to_bezpath_opt_inner(
         Ok(x) => x,
         Err(t) => return Some(t),
     };
-    eprintln!("got fit with n={}, err={}", n, x);
+    //println!("got fit with n={}, err={}", n, x);
     let path_len = path.elements().len();
     for i in 0..n {
         let t1 = if i < n - 1 {


### PR DESCRIPTION
This PR contains a number of improvements to the robustness and accuracy of curve fitting. A milestone is that seems to handle the test case of #268 fairly well. It also implements one aspect of #267 (handling the case where the quartic has no real roots), but does not implement the higher level driver proposed in that issue. Thus, it does its best to fit corners with smooth curves.

A list of the changes in somewhat more detail:

* The quartic solver simply reports when there are no real solutions, rather than panicking. A potential future expansion might be to compute complex coefficients, but that would require a dependency on complex math and does not seem to be needed here.
* The ITP solving for determining subdivision points chooses the conservative side of the bracket rather than the midpoint. This gives much better results when the function being solved has discontinuities. This also avoids problems with causing n to increase due to non-monotonicity of the curve fitting.
* The error metric for estimating the Fréchet distance between the source curve and the approximation has been revised substantially. Previously it was the ray projection method from Tiller and Hanson, but this can significantly underestimate error when the source curve has extreme variations of curvature. A particularly bad case (illustrated below) is when the source curve has a corner (or nearly so), in which case the cubic approximation might have a loop, and the error metric reports a low error because the loop is not sampled. Even so, the code is probably slower. There may be an error metric out there which is both faster than the current code and robust enough.
* The `fit_to_bezpath_opt` logic has been changed to make accuracy bounds tighter for the curve fitting steps; those are allowed to fail, and logic can deal with that. Previously it set a HUGE accuracy bound with the expectation that some solution would always be found. This should improve both robustness and performance (relative

The new method is based on arc length parametrized sampling of the approximation curve (the sample points are sampled evenly in parameter space in the source curve, which might possibly be improved, but otherwise would require solving inverse arc length problems there). While this error metric is more robust, avoiding the loops, it is also dramatically slower. Thus, this PR applies a hybrid approach, first estimating whether the source curve is "spicy" by determining whether the tangent of the delta between tangent vectors between samples exceeds 0.1 (the `SPICY_THRESH` constant in the code). If so, the arc length method is used (after first running the ray cast method).

Experimentation is encouraged, as the goal is truly robust curve fitting. The techniques deserve a proper writeup. One thing of note is that arc length is computed (as an integral) as *another* application of the `ParamCurveFit` trait; no changes were needed to the trait itself. It's also worth noting that errors in computing arc length make the error metric more conservative, so extreme care is not needed there.

<img width="164" alt="Screenshot 2023-04-14 at 7 03 17 AM" src="https://user-images.githubusercontent.com/242367/232162325-b2774293-3261-4ae1-9a85-4cbf1ea8dab1.png">
