### PR TITLE
This patch adds some common aliases for vec2 methods.

### DIFF
--- a/src/point.rs
+++ b/src/point.rs
@@ -13,6 +13,15 @@ use crate::Vec2;
 use crate::common::FloatFuncs;
 
 /// A 2D point.
+///
+/// This type represents a point in 2D space. It has the same layout as [`Vec2`][crate::Vec2], but
+/// its meaning is different: `Vec2` represents a change in location (for example velocity).
+///
+/// In general, `kurbo` overloads math operators where it makes sense, for example implementing
+/// `Affine * Point` as the point under the affine transformation. However `Point + Point` and
+/// `f64 * Point` are not implemented, because the operations do not make geometric sense. If you
+/// need to apply these operations, then 1) check what you're doing makes geometric sense, then 2)
+/// use [`Point::to_vec2`] to convert the point to a `Vec2`.
 #[derive(Clone, Copy, Default, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -96,7 +96,7 @@ impl Vec2 {
     /// This is an alias for [`Vec2::hypot2`].
     #[inline]
     pub fn length_squared(self) -> f64 {
-        self.dot(self)
+        self.hypot2()
     }
 
     /// Find the angle in radians between this vector and the vector `Vec2 { x: 1.0, y: 0.0 }`

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -69,9 +69,20 @@ impl Vec2 {
     }
 
     /// Magnitude of vector.
+    ///
+    /// This is similar to `self.hypot2().sqrt()` but defers to the platform `hypot` method, which
+    /// in general will handle the case where `self.hypot2() > f64::MAX`.
     #[inline]
     pub fn hypot(self) -> f64 {
         self.x.hypot(self.y)
+    }
+
+    /// Magnitude of vector.
+    ///
+    /// This is an alias for [`Vec2::hypot`].
+    #[inline]
+    pub fn length(self) -> f64 {
+        self.hypot()
     }
 
     /// Magnitude squared of vector.
@@ -80,13 +91,31 @@ impl Vec2 {
         self.dot(self)
     }
 
-    /// Angle of vector.
+    /// Magnitude squared of vector.
+    ///
+    /// This is an alias for [`Vec2::hypot2`].
+    #[inline]
+    pub fn length_squared(self) -> f64 {
+        self.dot(self)
+    }
+
+    /// Find the angle in radians between this vector and the vector `Vec2 { x: 1.0, y: 0.0 }`
+    /// in the positive `y` direction.
     ///
     /// If the vector is interpreted as a complex number, this is the argument.
     /// The angle is expressed in radians.
     #[inline]
     pub fn atan2(self) -> f64 {
         self.y.atan2(self.x)
+    }
+
+    /// Find the angle in radians between this vector and the vector `Vec2 { x: 1.0, y: 0.0 }`
+    /// in the positive `y` direction.
+    ///
+    /// This is an alias for [`Vec2::atan2`].
+    #[inline]
+    pub fn angle(self) -> f64 {
+        self.atan2()
     }
 
     /// A unit vector of the given angle.


### PR DESCRIPTION
This should hopefully reduce confusion for new users. The suggestion was made in #182, and this PR will close #182.