### PR TITLE
multiply by recip in CubicBez::subdivide_3 to match cu2qu.py

### DIFF
--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -272,14 +272,19 @@ impl CubicBez {
             self.p2.to_vec2(),
             self.p3.to_vec2(),
         );
-        let mid1 = (8.0 * p0 + 12.0 * p1 + 6.0 * p2 + p3)
-            .div_exact(27.0)
-            .to_point();
-        let deriv1 = (p3 + 3.0 * p2 - 4.0 * p0).div_exact(27.0);
-        let mid2 = (p0 + 6.0 * p1 + 12.0 * p2 + 8.0 * p3)
-            .div_exact(27.0)
-            .to_point();
-        let deriv2 = (4.0 * p3 - 3.0 * p1 - p0).div_exact(27.0);
+        // The original Python cu2qu code here does not use division operator to divide by 27 but
+        // instead uses multiplication by the reciprocal 1 / 27. We want to match it exactly
+        // to avoid any floating point differences, hence in this particular case we do not use div_exact.
+        // I could directly use the Vec2 Div trait (also implemented as multiplication by reciprocal)
+        // but I prefer to be explicit here.
+        // Source: https://github.com/fonttools/fonttools/blob/85c80be/Lib/fontTools/cu2qu/cu2qu.py#L215-L218
+        // See also: https://github.com/linebender/kurbo/issues/272
+        let one_27th = 27.0_f64.recip();
+        let mid1 = ((8.0 * p0 + 12.0 * p1 + 6.0 * p2 + p3) * one_27th).to_point();
+        let deriv1 = (p3 + 3.0 * p2 - 4.0 * p0) * one_27th;
+        let mid2 = ((p0 + 6.0 * p1 + 12.0 * p2 + 8.0 * p3) * one_27th).to_point();
+        let deriv2 = (4.0 * p3 - 3.0 * p1 - p0) * one_27th;
+
         let left = CubicBez::new(
             self.p0,
             (2.0 * p0 + p1).div_exact(3.0).to_point(),

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -652,6 +652,7 @@ mod tests {
     use crate::{
         cubics_to_quadratic_splines, Affine, CubicBez, Nearest, ParamCurve, ParamCurveArclen,
         ParamCurveArea, ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest, Point, QuadBez,
+        QuadSpline,
     };
 
     #[test]
@@ -982,5 +983,46 @@ mod tests {
 
         // FontTools can solve this with accuracy 0.001, we can too
         assert!(cubics_to_quadratic_splines(&[cubic], 0.001).is_some());
+    }
+
+    #[test]
+    fn cubics_to_quadratic_splines_matches_python() {
+        // https://github.com/linebender/kurbo/pull/273
+        let light = CubicBez::new((378., 608.), (378., 524.), (355., 455.), (266., 455.));
+        let regular = CubicBez::new((367., 607.), (367., 511.), (338., 472.), (243., 472.));
+        let bold = CubicBez::new(
+            (372.425, 593.05),
+            (372.425, 524.95),
+            (355.05, 485.95),
+            (274., 485.95),
+        );
+        let qsplines = cubics_to_quadratic_splines(&[light, regular, bold], 1.0).unwrap();
+        assert_eq!(
+            qsplines,
+            [
+                QuadSpline::new(vec![
+                    (378.0, 608.0).into(),
+                    (378.0, 566.0).into(),
+                    (359.0833333333333, 496.5).into(),
+                    (310.5, 455.0).into(),
+                    (266.0, 455.0).into(),
+                ]),
+                QuadSpline::new(vec![
+                    (367.0, 607.0).into(),
+                    (367.0, 559.0).into(),
+                    // Previous behavior produced 496.5 for the y coordinate
+                    (344.5833333333333, 499.49999999999994).into(),
+                    (290.5, 472.0).into(),
+                    (243.0, 472.0).into(),
+                ]),
+                QuadSpline::new(vec![
+                    (372.425, 593.05).into(),
+                    (372.425, 559.0).into(),
+                    (356.98333333333335, 511.125).into(),
+                    (314.525, 485.95).into(),
+                    (274.0, 485.95).into(),
+                ]),
+            ]
+        )
     }
 }


### PR DESCRIPTION
Follow up from https://github.com/linebender/kurbo/pull/273

I noticed that we still get off-by-one differences (after rounding coordinates to integer) in some cases.
E.g. in a (failing) test case that I pushed here as the first commit, I am getting the differences below.
Left is current kurbo code as of https://github.com/linebender/kurbo/commit/552c6add2a2be7f0df4d09bd4e57b610c4b25500 immediately after #273 was merged; right is the expected result as coming from python cu2qu:

```
 left: `[... (344.58333333333337, 499.5), ...]`,
 right: `[... (344.5833333333333, 499.49999999999994), ...]`',
```

So @dfrg duly changed all occurrences of Vec2 division by a scalar with the new `div_exact` method (that uses f64 division instead of multiplication by reciprocal), but actually it turns out that in some specific lines the original Python cu2qu prefers to explicitly use multiplication instead of division (don't ask me why).
I will shortly push another commit (that undoes some of the changes Chad made) to verify that the test passes afterwards.

Fixes https://github.com/linebender/kurbo/pull/272
