### PR TITLE
Allow cloning of iterators over BezPath elements

### DIFF
--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -650,6 +650,7 @@ where
 /// An iterator that transforms path elements to path segments.
 ///
 /// This struct is created by the [`segments`] function.
+#[derive(Clone)]
 pub struct Segments<I: Iterator<Item = PathEl>> {
     elements: I,
     start_last: Option<(Point, Point)>,
@@ -731,15 +732,6 @@ impl<I: Iterator<Item = PathEl>> Segments<I> {
             }
         }
         bbox.unwrap_or_default()
-    }
-}
-
-impl<I: Clone + Iterator<Item = PathEl>> Clone for Segments<I> {
-    fn clone(&self) -> Self {
-        Self {
-            start_last: self.start_last,
-            elements: self.elements.clone(),
-        }
     }
 }
 

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -269,12 +269,12 @@ impl BezPath {
     }
 
     /// Returns an iterator over the path's elements.
-    pub fn iter(&self) -> impl Iterator<Item = PathEl> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = PathEl> + Clone + '_ {
         self.0.iter().copied()
     }
 
     /// Iterate over the path segments.
-    pub fn segments(&self) -> impl Iterator<Item = PathSeg> + '_ {
+    pub fn segments(&self) -> impl Iterator<Item = PathSeg> + Clone + '_ {
         segments(self.iter())
     }
 
@@ -731,6 +731,15 @@ impl<I: Iterator<Item = PathEl>> Segments<I> {
             }
         }
         bbox.unwrap_or_default()
+    }
+}
+
+impl<I: Clone + Iterator<Item = PathEl>> Clone for Segments<I> {
+    fn clone(&self) -> Self {
+        Self {
+            start_last: self.start_last,
+            elements: self.elements.clone(),
+        }
     }
 }
 


### PR DESCRIPTION
This makes it so you can clone iterators over `PathEl`s or `PathSeg`s.