### PR TITLE
Translate scale improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kurbo"
+# This should be bumped to 0.10 at the next release, because master has breaking changes
 version = "0.9.5"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "kurbo"
-# This should be bumped to 0.10 at the next release, because master has breaking changes
 version = "0.9.5"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 license = "MIT/Apache-2.0"

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -63,8 +63,15 @@ impl TranslateScale {
 
     /// Create a new transformation with translation only.
     #[inline]
-    pub const fn translate(translation: Vec2) -> TranslateScale {
-        TranslateScale::new(translation, 1.0)
+    pub fn translate(translation: impl Into<Vec2>) -> TranslateScale {
+        TranslateScale::new(translation.into(), 1.0)
+    }
+
+    /// Decompose transformation into translation and scale.
+    #[deprecated(note = "use the struct fields directly")]
+    #[inline]
+    pub const fn as_tuple(self) -> (Vec2, f64) {
+        (self.translation, self.scale)
     }
 
     /// Create a transform that scales about a point other than the origin.

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -68,6 +68,21 @@ impl TranslateScale {
     }
 
     /// Create a transform that scales about a point other than the origin.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use kurbo::{Point, TranslateScale};
+    /// # fn assert_near(p0: Point, p1: Point) {
+    /// #   assert!((p1 - p0).hypot() < 1e-9, "{p0:?} != {p1:?}");
+    /// # }
+    /// let center = Point::new(1., 1.);
+    /// let ts = TranslateScale::from_scale_about(2., center);
+    /// // Should keep the point (1., 1.) stationary
+    /// assert_near(ts * center, center);
+    /// // (2., 2.) -> (3., 3.)
+    /// assert_near(ts * Point::new(2., 2.), Point::new(3., 3.));
+    /// ```
     pub fn from_scale_about(scale: f64, focus: Point) -> Self {
         // We need to create a transform that is equivalent to translating `focus`
         // to the origin, followed by a normal scale, followed by reversing the translation.
@@ -295,16 +310,6 @@ mod tests {
         let ts = TranslateScale::new(Vec2::new(5.0, 6.0), 2.0);
 
         assert_near(ts * p, Point::new(11.0, 14.0));
-    }
-
-    #[test]
-    fn scale_about() {
-        let center = Point::new(1., 1.);
-        let ts = TranslateScale::from_scale_about(2., center);
-        // Should keep the point (1., 1.) stationary
-        assert_near(ts * center, center);
-        // (2., 2.) -> (3., 3.)
-        assert_near(ts * Point::new(2., 2.), Point::new(3., 3.));
     }
 
     #[test]

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -71,7 +71,7 @@ impl TranslateScale {
     pub fn from_scale_about(scale: f64, focus: Point) -> Self {
         // We need to create a transform that is equivalent to translating `focus`
         // to the origin, followed by a normal scale, followed by reversing the translation.
-        // We need to find the (scale ∘ translation) that matches this.
+        // We need to find the (translation ∘ scale) that matches this.
         let focus = focus.to_vec2();
         let translation = focus - focus * scale;
         Self::new(translation, scale)

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -57,13 +57,13 @@ impl TranslateScale {
 
     /// Create a new transformation with scale only.
     #[inline]
-    pub const fn from_scale(s: f64) -> TranslateScale {
+    pub const fn scale(s: f64) -> TranslateScale {
         TranslateScale::new(Vec2::ZERO, s)
     }
 
     /// Create a new transformation with translation only.
     #[inline]
-    pub const fn from_translate(translation: Vec2) -> TranslateScale {
+    pub const fn translate(translation: Vec2) -> TranslateScale {
         TranslateScale::new(translation, 1.0)
     }
 
@@ -83,6 +83,7 @@ impl TranslateScale {
     /// // (2., 2.) -> (3., 3.)
     /// assert_near(ts * Point::new(2., 2.), Point::new(3., 3.));
     /// ```
+    #[inline]
     pub fn from_scale_about(scale: f64, focus: Point) -> Self {
         // We need to create a transform that is equivalent to translating `focus`
         // to the origin, followed by a normal scale, followed by reversing the translation.
@@ -99,6 +100,7 @@ impl TranslateScale {
     /// (modulo floating point rounding errors).
     ///
     /// Produces NaN values when scale is zero.
+    #[inline]
     pub fn inverse(self) -> TranslateScale {
         let scale_recip = self.scale.recip();
         TranslateScale {
@@ -323,11 +325,8 @@ mod tests {
         let a: Affine = ts.into();
         assert_near(ts * p, a * p);
 
-        assert_near(
-            (s * p.to_vec2()).to_point(),
-            TranslateScale::from_scale(s) * p,
-        );
-        assert_near(p + t, TranslateScale::from_translate(t) * p);
+        assert_near((s * p.to_vec2()).to_point(), TranslateScale::scale(s) * p);
+        assert_near(p + t, TranslateScale::translate(t) * p);
     }
 
     #[test]

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -302,7 +302,9 @@ mod tests {
         let center = Point::new(1., 1.);
         let ts = TranslateScale::from_scale_about(2., center);
         // Should keep the point (1., 1.) stationary
-        assert_near(center, ts * center);
+        assert_near(ts * center, center);
+        // (2., 2.) -> (3., 3.)
+        assert_near(ts * Point::new(2., 2.), Point::new(3., 3.));
     }
 
     #[test]

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -9,7 +9,7 @@ use crate::{
     Affine, Circle, CubicBez, Line, Point, QuadBez, Rect, RoundedRect, RoundedRectRadii, Vec2,
 };
 
-/// A transformation including scaling and translation.
+/// A transformation including uniform scaling and translation.
 ///
 /// If the translation is `(x, y)` and the scale is `s`, then this
 /// transformation represents this augmented matrix:
@@ -42,8 +42,10 @@ use crate::{
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TranslateScale {
-    translation: Vec2,
-    scale: f64,
+    /// The translation component of this transformation
+    pub translation: Vec2,
+    /// The scale component of this transformation
+    pub scale: f64,
 }
 
 impl TranslateScale {
@@ -55,19 +57,14 @@ impl TranslateScale {
 
     /// Create a new transformation with scale only.
     #[inline]
-    pub const fn scale(s: f64) -> TranslateScale {
+    pub const fn from_scale(s: f64) -> TranslateScale {
         TranslateScale::new(Vec2::ZERO, s)
     }
 
     /// Create a new transformation with translation only.
     #[inline]
-    pub const fn translate(t: Vec2) -> TranslateScale {
+    pub const fn from_translate(t: Vec2) -> TranslateScale {
         TranslateScale::new(t, 1.0)
-    }
-
-    /// Decompose transformation into translation and scale.
-    pub fn as_tuple(self) -> (Vec2, f64) {
-        (self.translation, self.scale)
     }
 
     /// Compute the inverse transform.
@@ -101,7 +98,7 @@ impl TranslateScale {
 impl Default for TranslateScale {
     #[inline]
     fn default() -> TranslateScale {
-        TranslateScale::scale(1.0)
+        TranslateScale::new(Vec2::ZERO, 1.0)
     }
 }
 
@@ -301,8 +298,11 @@ mod tests {
         let a: Affine = ts.into();
         assert_near(ts * p, a * p);
 
-        assert_near((s * p.to_vec2()).to_point(), TranslateScale::scale(s) * p);
-        assert_near(p + t, TranslateScale::translate(t) * p);
+        assert_near(
+            (s * p.to_vec2()).to_point(),
+            TranslateScale::from_scale(s) * p,
+        );
+        assert_near(p + t, TranslateScale::from_translate(t) * p);
     }
 
     #[test]


### PR DESCRIPTION
A few ~~(breaking)~~ changes to make `TranslateScale` more consistent with other types in `kurbo` (including making parameters public since there are no invalid states, using `from_` convention for constructors, and making documentation more specific).

Also added method to create a `TranslateScale` from a scaling and a center of the scale. This is a useful operation when you want to e.g. scale at the location of the mouse cursor.

**Edit** I removed the breaking changes because I don't think they were pulling their weight.