### PR TITLE
Improve robustness of curve fitting

### DIFF
--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -443,9 +443,9 @@ impl CubicBez {
                 let c = det_012;
                 let d = b * b - 4. * a * c;
                 if d > 0.0 {
-                    return Some(CuspType::DoubleInflection)
+                    return Some(CuspType::DoubleInflection);
                 } else {
-                    return Some(CuspType::Loop)
+                    return Some(CuspType::Loop);
                 }
             }
         }

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -158,3 +158,27 @@ impl ParamCurveFit for CubicOffset {
         Some(x)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CubicOffset;
+    use crate::{fit_to_bezpath, fit_to_bezpath_opt, CubicBez, PathEl};
+
+    // This test tries combinations of parameters that have caused problems in the past.
+    #[test]
+    fn pathological_curves() {
+        let curve = CubicBez {
+            p0: (-1236.3746269978635, 152.17981429574826).into(),
+            p1: (-1175.18662093517, 108.04721798590596).into(),
+            p2: (-1152.142883879584, 105.76260301083356).into(),
+            p3: (-1151.842639804639, 105.73040758939104).into(),
+        };
+        let offset = 3603.7267536453924;
+        let accuracy = 0.1;
+        let offset_path = CubicOffset::new(curve, offset);
+        let path = fit_to_bezpath_opt(&offset_path, accuracy);
+        assert!(matches!(path.iter().next(), Some(PathEl::MoveTo(_))));
+        let path_opt = fit_to_bezpath(&offset_path, accuracy);
+        assert!(matches!(path_opt.iter().next(), Some(PathEl::MoveTo(_))));
+    }
+}

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -65,6 +65,11 @@ pub struct CubicOffset {
 
 impl CubicOffset {
     /// Create a new curve from Bézier segment and offset.
+    ///
+    /// This method should only be used if the Bézier is smooth. Use
+    /// [`new_regularized`]instead to deal with a wider range of inputs.
+    ///
+    /// [`new_regularized`]: Self::new_regularized
     pub fn new(c: CubicBez, d: f64) -> Self {
         let q = c.deriv();
         let d0 = q.p0.to_vec2();
@@ -78,6 +83,14 @@ impl CubicOffset {
             c1: d * 2.0 * d2.cross(d0),
             c2: d * d2.cross(d1),
         }
+    }
+
+    /// Create a new curve from Bézier segment and offset, with numerical robustness tweaks.
+    ///
+    /// The dimension represents a minimum feature size; the regularization is allowed to
+    /// perturb the curve by this amount in order to improve the robustness.
+    pub fn new_regularized(c: CubicBez, d: f64, dimension: f64) -> Self {
+        Self::new(c.regularize(dimension), d)
     }
 
     fn eval_offset(&self, t: f64) -> Vec2 {


### PR DESCRIPTION
The main improvement is to try to fit a line when the chord is very short. Very short segments can occur when the cusp finding reports imprecise results, and also the main cubic fit logic is not robust when the chord is short.

I believe the simple subdivision case is now fairly robust in that it won't keep recursing. This is in spite of not having an explicit bound on recursion depth; the theory is that each subdivision reduces the parameter space in half, and at some point you'll reach the point where the chord is shorter than the given tolerance. This is true even for an adversarial break_cusp, as it's bypassed in the short chord case.

The logic for the optimized case is not as careful, in particular break_cusp is not bypassed. I'm curious whether there are still failure cases.

This is likely not the end of the numerical robustness work. In particular, break_cusp can be better tuned to not over-report cusps, and the tangent detection can be improved for cusp and near-cusp source curves. But hopefully this commit gets us to where we at least return a valid fit.

Also adds a test lightly adapted from #269.

Progress toward #269 and #279