### PR TITLE
Add tolerance parmeters to Shape methods

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -165,7 +165,7 @@ impl Shape for Arc {
 
     /// Note: shape isn't closed so area is not well defined.
     #[inline]
-    fn area(&self) -> f64 {
+    fn area(&self, _tolerance: f64) -> f64 {
         let Vec2 { x, y } = self.radii;
         PI * x * y
     }
@@ -183,12 +183,12 @@ impl Shape for Arc {
 
     /// Note: shape isn't closed, so a point's winding number is not well defined.
     #[inline]
-    fn winding(&self, pt: Point) -> i32 {
+    fn winding(&self, pt: Point, _tolerance: f64) -> i32 {
         self.path_segments(0.1).winding(pt)
     }
 
     #[inline]
-    fn bounding_box(&self) -> Rect {
+    fn bounding_box(&self, _tolerance: f64) -> Rect {
         self.path_segments(0.1).bounding_box()
     }
 }

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -125,7 +125,7 @@ impl Shape for Circle {
     }
 
     #[inline]
-    fn area(&self) -> f64 {
+    fn area(&self, _tolerance: f64) -> f64 {
         PI * self.radius.powi(2)
     }
 
@@ -134,7 +134,7 @@ impl Shape for Circle {
         (2.0 * PI * self.radius).abs()
     }
 
-    fn winding(&self, pt: Point) -> i32 {
+    fn winding(&self, pt: Point, _tolerance: f64) -> i32 {
         if (pt - self.center).hypot2() < self.radius.powi(2) {
             1
         } else {
@@ -143,7 +143,7 @@ impl Shape for Circle {
     }
 
     #[inline]
-    fn bounding_box(&self) -> Rect {
+    fn bounding_box(&self, _tolerance: f64) -> Rect {
         let r = self.radius.abs();
         let (x, y) = self.center.into();
         Rect::new(x - r, y - r, x + r, y + r)
@@ -320,7 +320,7 @@ impl Shape for CircleSegment {
     }
 
     #[inline]
-    fn area(&self) -> f64 {
+    fn area(&self, _tolerance: f64) -> f64 {
         0.5 * (self.outer_radius.powi(2) - self.inner_radius.powi(2)).abs() * self.sweep_angle
     }
 
@@ -330,7 +330,7 @@ impl Shape for CircleSegment {
             + self.sweep_angle * (self.inner_radius + self.outer_radius)
     }
 
-    fn winding(&self, pt: Point) -> i32 {
+    fn winding(&self, pt: Point, _tolerance: f64) -> i32 {
         let angle = (pt - self.center).atan2();
         if angle < self.start_angle || angle > self.start_angle + self.sweep_angle {
             return 0;
@@ -347,7 +347,7 @@ impl Shape for CircleSegment {
     }
 
     #[inline]
-    fn bounding_box(&self) -> Rect {
+    fn bounding_box(&self, _tolerance: f64) -> Rect {
         // todo this is currently not tight
         let r = self.inner_radius.max(self.outer_radius);
         let (x, y) = self.center.into();
@@ -370,22 +370,22 @@ mod tests {
     fn area_sign() {
         let center = Point::new(5.0, 5.0);
         let c = Circle::new(center, 5.0);
-        assert_approx_eq(c.area(), 25.0 * PI);
+        assert_approx_eq(c.area(1.0), 25.0 * PI);
 
-        assert_eq!(c.winding(center), 1);
+        assert_eq!(c.winding(center, 1.0), 1);
 
         let p = c.to_path(1e-9);
-        assert_approx_eq(c.area(), p.area());
-        assert_eq!(c.winding(center), p.winding(center));
+        assert_approx_eq(c.area(1.0), p.area(1.0));
+        assert_eq!(c.winding(center, 1.0), p.winding(center, 1.0));
 
         let c_neg_radius = Circle::new(center, -5.0);
-        assert_approx_eq(c_neg_radius.area(), 25.0 * PI);
+        assert_approx_eq(c_neg_radius.area(1.0), 25.0 * PI);
 
-        assert_eq!(c_neg_radius.winding(center), 1);
+        assert_eq!(c_neg_radius.winding(center, 1.0), 1);
 
         let p_neg_radius = c_neg_radius.to_path(1e-9);
-        assert_approx_eq(c_neg_radius.area(), p_neg_radius.area());
-        assert_eq!(c_neg_radius.winding(center), p_neg_radius.winding(center));
+        assert_approx_eq(c_neg_radius.area(1.0), p_neg_radius.area(1.0));
+        assert_eq!(c_neg_radius.winding(center, 1.0), p_neg_radius.winding(center, 1.0));
     }
 }
 

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -470,7 +470,7 @@ impl Shape for CubicBez {
         }
     }
 
-    fn area(&self) -> f64 {
+    fn area(&self, _tolerance: f64) -> f64 {
         0.0
     }
 
@@ -479,12 +479,12 @@ impl Shape for CubicBez {
         self.arclen(accuracy)
     }
 
-    fn winding(&self, _pt: Point) -> i32 {
+    fn winding(&self, _pt: Point, _tolerance: f64) -> i32 {
         0
     }
 
     #[inline]
-    fn bounding_box(&self) -> Rect {
+    fn bounding_box(&self, _tolerance: f64) -> Rect {
         ParamCurveExtrema::bounding_box(self)
     }
 }

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -220,7 +220,7 @@ impl Shape for Ellipse {
     }
 
     #[inline]
-    fn area(&self) -> f64 {
+    fn area(&self, _tolerance: f64) -> f64 {
         let Vec2 { x, y } = self.radii();
         PI * x * y
     }
@@ -236,7 +236,7 @@ impl Shape for Ellipse {
         self.path_segments(0.1).perimeter(accuracy)
     }
 
-    fn winding(&self, pt: Point) -> i32 {
+    fn winding(&self, pt: Point, _tolerance: f64) -> i32 {
         // Strategy here is to apply the inverse map to the point and see if it is in the unit
         // circle.
         let inv = self.inner.inverse();
@@ -259,7 +259,7 @@ impl Shape for Ellipse {
     //
     //  We can then use the method in the link with the translation to get the bounding box.
     #[inline]
-    fn bounding_box(&self) -> Rect {
+    fn bounding_box(&self, _tolerance: f64) -> Rect {
         let aff = self.inner.as_coeffs();
         let a2 = aff[0] * aff[0];
         let b2 = aff[1] * aff[1];
@@ -293,23 +293,23 @@ mod tests {
     fn area_sign() {
         let center = Point::new(5.0, 5.0);
         let e = Ellipse::new(center, (5.0, 5.0), 1.0);
-        assert_approx_eq(e.area(), 25.0 * PI);
+        assert_approx_eq(e.area(1.0), 25.0 * PI);
         let e = Ellipse::new(center, (5.0, 10.0), 1.0);
-        assert_approx_eq(e.area(), 50.0 * PI);
+        assert_approx_eq(e.area(1.0), 50.0 * PI);
 
-        assert_eq!(e.winding(center), 1);
+        assert_eq!(e.winding(center, 1.0), 1);
 
         let p = e.to_path(1e-9);
-        assert_approx_eq(e.area(), p.area());
-        assert_eq!(e.winding(center), p.winding(center));
+        assert_approx_eq(e.area(1.0), p.area(1.0));
+        assert_eq!(e.winding(center, 1.0), p.winding(center, 1.0));
 
         let e_neg_radius = Ellipse::new(center, (-5.0, 10.0), 1.0);
-        assert_approx_eq(e_neg_radius.area(), 50.0 * PI);
+        assert_approx_eq(e_neg_radius.area(1.0), 50.0 * PI);
 
-        assert_eq!(e_neg_radius.winding(center), 1);
+        assert_eq!(e_neg_radius.winding(center, 1.0), 1);
 
         let p_neg_radius = e_neg_radius.to_path(1e-9);
-        assert_approx_eq(e_neg_radius.area(), p_neg_radius.area());
-        assert_eq!(e_neg_radius.winding(center), p_neg_radius.winding(center));
+        assert_approx_eq(e_neg_radius.area(1.0), p_neg_radius.area(1.0));
+        assert_eq!(e_neg_radius.winding(center, 1.0), p_neg_radius.winding(center, 1.0));
     }
 }

--- a/src/line.rs
+++ b/src/line.rs
@@ -252,7 +252,7 @@ impl Shape for Line {
     /// only meaningful for closed shapes), but an argument can be made
     /// that the contract should be tightened to include the Green's
     /// theorem contribution.
-    fn area(&self) -> f64 {
+    fn area(&self, _tolerance: f64) -> f64 {
         0.0
     }
 
@@ -262,12 +262,12 @@ impl Shape for Line {
     }
 
     /// Same consideration as `area`.
-    fn winding(&self, _pt: Point) -> i32 {
+    fn winding(&self, _pt: Point, _tolerance: f64) -> i32 {
         0
     }
 
     #[inline]
-    fn bounding_box(&self) -> Rect {
+    fn bounding_box(&self, _tolerance: f64) -> Rect {
         Rect::from_points(self.p0, self.p1)
     }
 

--- a/src/quadbez.rs
+++ b/src/quadbez.rs
@@ -126,7 +126,7 @@ impl Shape for QuadBez {
         QuadBezIter { quad: *self, ix: 0 }
     }
 
-    fn area(&self) -> f64 {
+    fn area(&self, _tolerance: f64) -> f64 {
         0.0
     }
 
@@ -135,12 +135,12 @@ impl Shape for QuadBez {
         self.arclen(accuracy)
     }
 
-    fn winding(&self, _pt: Point) -> i32 {
+    fn winding(&self, _pt: Point, _tolerance: f64) -> i32 {
         0
     }
 
     #[inline]
-    fn bounding_box(&self) -> Rect {
+    fn bounding_box(&self, _tolerance: f64) -> Rect {
         ParamCurveExtrema::bounding_box(self)
     }
 }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -590,12 +590,12 @@ impl Shape for Rect {
     // It's a bit of duplication having both this and the impl method, but
     // removing that would require using the trait. We'll leave it for now.
     #[inline]
-    fn area(&self) -> f64 {
+    fn area(&self, _tolerance: f64) -> f64 {
         Rect::area(self)
     }
 
     #[inline]
-    fn perimeter(&self, _accuracy: f64) -> f64 {
+    fn perimeter(&self, _tolerance: f64) -> f64 {
         2.0 * (self.width().abs() + self.height().abs())
     }
 
@@ -603,7 +603,7 @@ impl Shape for Rect {
     /// tiled with rectangles, the winding number will be nonzero for exactly
     /// one of them.
     #[inline]
-    fn winding(&self, pt: Point) -> i32 {
+    fn winding(&self, pt: Point, _tolerance: f64) -> i32 {
         let xmin = self.x0.min(self.x1);
         let xmax = self.x0.max(self.x1);
         let ymin = self.y0.min(self.y1);
@@ -620,7 +620,7 @@ impl Shape for Rect {
     }
 
     #[inline]
-    fn bounding_box(&self) -> Rect {
+    fn bounding_box(&self, _tolerance: f64) -> Rect {
         self.abs()
     }
 
@@ -630,7 +630,7 @@ impl Shape for Rect {
     }
 
     #[inline]
-    fn contains(&self, pt: Point) -> bool {
+    fn contains(&self, pt: Point, _tolerance: f64) -> bool {
         self.contains(pt)
     }
 }
@@ -695,19 +695,19 @@ mod tests {
         let center = r.center();
         assert_approx_eq(r.area(), 100.0);
 
-        assert_eq!(r.winding(center), 1);
+        assert_eq!(r.winding(center, 1.0), 1);
 
         let p = r.to_path(1e-9);
-        assert_approx_eq(r.area(), p.area());
-        assert_eq!(r.winding(center), p.winding(center));
+        assert_approx_eq(r.area(), p.area(1.0));
+        assert_eq!(r.winding(center, 1.0), p.winding(center, 1.0));
 
         let r_flip = Rect::new(0.0, 10.0, 10.0, 0.0);
         assert_approx_eq(r_flip.area(), -100.0);
 
-        assert_eq!(r_flip.winding(Point::new(5.0, 5.0)), -1);
+        assert_eq!(r_flip.winding(Point::new(5.0, 5.0), 1.0), -1);
         let p_flip = r_flip.to_path(1e-9);
-        assert_approx_eq(r_flip.area(), p_flip.area());
-        assert_eq!(r_flip.winding(center), p_flip.winding(center));
+        assert_approx_eq(r_flip.area(), p_flip.area(1.0));
+        assert_eq!(r_flip.winding(center, 1.0), p_flip.winding(center, 1.0));
     }
 
     #[test]

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -225,7 +225,7 @@ impl Shape for RoundedRect {
     }
 
     #[inline]
-    fn area(&self) -> f64 {
+    fn area(&self, _tolerance: f64) -> f64 {
         // A corner is a quarter-circle, i.e.
         // .............#
         // .       ######
@@ -289,7 +289,7 @@ impl Shape for RoundedRect {
     }
 
     #[inline]
-    fn winding(&self, mut pt: Point) -> i32 {
+    fn winding(&self, mut pt: Point, _tolerance: f64) -> i32 {
         let center = self.center();
 
         // 1. Translate the point relative to the center of the rectangle.
@@ -339,8 +339,8 @@ impl Shape for RoundedRect {
     }
 
     #[inline]
-    fn bounding_box(&self) -> Rect {
-        self.rect.bounding_box()
+    fn bounding_box(&self, accuracy: f64) -> Rect {
+        self.rect.bounding_box(accuracy)
     }
 
     #[inline]
@@ -443,26 +443,26 @@ mod tests {
         // Extremum: 0.0 radius corner -> rectangle
         let rect = Rect::new(0.0, 0.0, 100.0, 100.0);
         let rounded_rect = RoundedRect::new(0.0, 0.0, 100.0, 100.0, 0.0);
-        assert!((rect.area() - rounded_rect.area()).abs() < epsilon);
+        assert!((rect.area() - rounded_rect.area(1.0)).abs() < epsilon);
 
         // Extremum: half-size radius corner -> circle
         let circle = Circle::new((0.0, 0.0), 50.0);
         let rounded_rect = RoundedRect::new(0.0, 0.0, 100.0, 100.0, 50.0);
-        assert!((circle.area() - rounded_rect.area()).abs() < epsilon);
+        assert!((circle.area(1.0) - rounded_rect.area(1.0)).abs() < epsilon);
     }
 
     #[test]
     fn winding() {
         let rect = RoundedRect::new(-5.0, -5.0, 10.0, 20.0, (5.0, 5.0, 5.0, 0.0));
-        assert_eq!(rect.winding(Point::new(0.0, 0.0)), 1);
-        assert_eq!(rect.winding(Point::new(-5.0, 0.0)), 1); // left edge
-        assert_eq!(rect.winding(Point::new(0.0, 20.0)), 1); // bottom edge
-        assert_eq!(rect.winding(Point::new(10.0, 20.0)), 0); // bottom-right corner
-        assert_eq!(rect.winding(Point::new(-5.0, 20.0)), 1); // bottom-left corner (has a radius of 0)
-        assert_eq!(rect.winding(Point::new(-10.0, 0.0)), 0);
+        assert_eq!(rect.winding(Point::new(0.0, 0.0), 1.0), 1);
+        assert_eq!(rect.winding(Point::new(-5.0, 0.0), 1.0), 1); // left edge
+        assert_eq!(rect.winding(Point::new(0.0, 20.0), 1.0), 1); // bottom edge
+        assert_eq!(rect.winding(Point::new(10.0, 20.0), 1.0), 0); // bottom-right corner
+        assert_eq!(rect.winding(Point::new(-5.0, 20.0), 1.0), 1); // bottom-left corner (has a radius of 0)
+        assert_eq!(rect.winding(Point::new(-10.0, 0.0), 1.0), 0);
 
         let rect = RoundedRect::new(-10.0, -20.0, 10.0, 20.0, 0.0); // rectangle
-        assert_eq!(rect.winding(Point::new(10.0, 20.0)), 1); // bottom-right corner
+        assert_eq!(rect.winding(Point::new(10.0, 20.0), 1.0), 1); // bottom-right corner
     }
 
     #[test]
@@ -471,7 +471,7 @@ mod tests {
         let p = rect.to_path(1e-9);
         // Note: could be more systematic about tolerance tightness.
         let epsilon = 1e-7;
-        assert!((rect.area() - p.area()).abs() < epsilon);
-        assert_eq!(p.winding(Point::new(0.0, 0.0)), 1);
+        assert!((rect.area(1.0) - p.area(1.0)).abs() < epsilon);
+        assert_eq!(p.winding(Point::new(0.0, 0.0), 1.0), 1);
     }
 }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -111,11 +111,29 @@ pub trait Shape: Sized {
     /// positive. Thus, it is clockwise when down is increasing y (the
     /// usual convention for graphics), and anticlockwise when
     /// up is increasing y (the usual convention for math).
-    fn area(&self) -> f64;
+    /// 
+    /// The tolerance parameter behaves the same as in [`path_elements()`],
+    /// allowing the default implmentation that first converts to a bezier path.
+    /// Note this allows the returned area to be off by a most the tolerance times the perimiter.
+    /// 
+    /// Tolerance should be ignored (by implementing this method directly)
+    /// if there is an easy way to return a precice result.
+    fn area(&self, tolerance: f64) -> f64 {
+        segments(self.path_elements(tolerance)).area()
+    }
 
     /// Total length of perimeter.
-    //FIXME: document the accuracy param
-    fn perimeter(&self, accuracy: f64) -> f64;
+    /// 
+    /// The tolerance parameter behaves the same as in [`path_elements()`],
+    /// allowing the default implmentation that first converts to a bezier path.
+    /// In addition, it may also be used to control the accuracy of integration of the arc length
+    /// (note that varying a sufficiently smooth curve will vary the perimiter by a simillar amount as the deflection).
+    /// 
+    /// Tolerance should be ignored (by implementing this method directly)
+    /// if there is an easy way to return a precice result.
+    fn perimeter(&self, tolerance: f64) -> f64 {
+        segments(self.path_elements(tolerance)).perimeter(tolerance)
+    }
 
     /// The [winding number] of a point.
     ///
@@ -125,20 +143,35 @@ pub trait Shape: Sized {
     /// meaning it is +1 when the point is inside a positive area shape
     /// and -1 when it is inside a negative area shape. Of course, greater
     /// magnitude values are also possible when the shape is more complex.
+    /// 
+    /// The tolerance parameter behaves the same as in [`path_elements()`],
+    /// allowing the default implmentation that first converts to a bezier path.
+    /// As a result, the returned value is allowed to be the tinging number of
+    /// a point at most tolerance away from p.
+    /// 
+    /// Tolerance should be ignored (by implementing this method directly)
+    /// if there is an easy way to return a precice result.
     ///
     /// [`area`]: Shape::area
     /// [winding number]: https://mathworld.wolfram.com/ContourWindingNumber.html
-    fn winding(&self, pt: Point) -> i32;
+    fn winding(&self, pt: Point, tolerance: f64) -> i32{
+        segments(self.path_elements(tolerance)).winding(pt)
+    }
 
-    /// Returns `true` if the [`Point`] is inside this shape.
+    /// Returns `true` if the [`Point`] (up to tolerance, see [`winding`]) is inside this shape.
     ///
     /// This is only meaningful for closed shapes.
-    fn contains(&self, pt: Point) -> bool {
-        self.winding(pt) != 0
+    fn contains(&self, pt: Point, tolerance: f64) -> bool {
+        self.winding(pt, tolerance) != 0
     }
 
     /// The smallest rectangle that encloses the shape.
-    fn bounding_box(&self) -> Rect;
+    /// 
+    /// The tolerance parameter behaves the same as in [`path_elements()`],
+    /// allowing the default implmentation that first converts to a bezier path.
+    /// It should be ignored (by implementing this method directly)
+    /// if there is an easy way to return a precice result.
+    fn bounding_box(&self, tolerance: f64) -> Rect;
 
     /// If the shape is a line, make it available.
     fn as_line(&self) -> Option<Line> {
@@ -189,20 +222,20 @@ impl<'a, T: Shape> Shape for &'a T {
         (*self).path_segments(tolerance)
     }
 
-    fn area(&self) -> f64 {
-        (*self).area()
+    fn area(&self, tolerance: f64) -> f64 {
+        (*self).area(tolerance)
     }
 
-    fn perimeter(&self, accuracy: f64) -> f64 {
-        (*self).perimeter(accuracy)
+    fn perimeter(&self, tolerance: f64) -> f64 {
+        (*self).perimeter(tolerance)
     }
 
-    fn winding(&self, pt: Point) -> i32 {
-        (*self).winding(pt)
+    fn winding(&self, pt: Point, tolerance: f64) -> i32 {
+        (*self).winding(pt, tolerance)
     }
 
-    fn bounding_box(&self) -> Rect {
-        (*self).bounding_box()
+    fn bounding_box(&self, tolerance: f64) -> Rect {
+        (*self).bounding_box(tolerance)
     }
 
     fn as_line(&self) -> Option<Line> {

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -513,7 +513,7 @@ mod tests {
     fn test_parse_svg_arc_pie() {
         let path = BezPath::from_svg("M 100 100 h 25 a 25 25 0 1 0 -25 25 z").unwrap();
         // Approximate figures, but useful for regression testing
-        assert_eq!(path.area().round(), -1473.0);
+        assert_eq!(path.area(1.0).round(), -1473.0);
         assert_eq!(path.perimeter(1e-6).round(), 168.0);
     }
 


### PR DESCRIPTION
Allows the lesser-used `Shape` methods to be implemented in terms of `path_elements` and provides default implementations.

Resolves #263 