### PR TITLE
Use SPDX 2.1 license expression.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kurbo"
 version = "0.9.5"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.65" # When updating this, also update the README.md and CI.
 keywords = ["graphics", "curve", "curves", "bezier", "geometry"]


### PR DESCRIPTION
This improves the usage of automated tooling which consumes the license information.