### PR TITLE
Cubic offset that triggers infinite recursion

### DIFF
--- a/src/fit.rs
+++ b/src/fit.rs
@@ -697,3 +697,25 @@ fn fit_opt_err_delta(
     let err = measure_one_seg(source, t0..t1, limit).unwrap_or(accuracy * 2.0);
     Ok(accuracy - err)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::offset::CubicOffset;
+
+    use super::*;
+
+    /// Cubic offset that triggers infinite recursion.
+    #[test]
+    fn infinite_recursion() {
+        const DIM_TUNE: f64 = 0.25;
+        const TOLERANCE: f64 = 0.1;
+        let c = CubicBez::new(
+            (1096.2962962962963, 593.90243902439033),
+            (1043.6213991769548, 593.90243902439033),
+            (1030.4526748971193, 593.90243902439033),
+            (1056.7901234567901, 593.90243902439033),
+        );
+        let co = CubicOffset::new_regularized(c, -0.5, DIM_TUNE * TOLERANCE);
+        fit_to_bezpath(&co, TOLERANCE);
+    }
+}


### PR DESCRIPTION
Adds a simple test for a curve that triggers infinite recursion during fitting for an offset. This was pulled from a run of the mmark example. Notably, the failing cubics all seem to have exactly the same y coordinates.

At the point of failure, the `start..end` parameters are nearly identical (within 1e-12!) but the sampled points never converge within reasonable tolerance so line fitting is not attempted.

@raphlinus let me know if I can do any additional investigation on this!