### PR TITLE
Better numerical robustness for stroking

### DIFF
--- a/src/fit.rs
+++ b/src/fit.rs
@@ -195,6 +195,16 @@ fn fit_to_bezpath_rec(
         // A smarter approach is possible than midpoint subdivision, but would be
         // a significant increase in complexity.
         let t = 0.5 * (start + end);
+        if t == start || t == end {
+            // infinite recursion, just draw a line
+            let p1 = start_p.lerp(end_p, 1.0 / 3.0);
+            let p2 = end_p.lerp(start_p, 1.0 / 3.0);
+            if path.is_empty() {
+                path.move_to(start_p);
+            }
+            path.curve_to(p1, p2, end_p);
+            return;
+        }
         fit_to_bezpath_rec(source, start..t, accuracy, path);
         fit_to_bezpath_rec(source, t..end, accuracy, path);
     }

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -194,4 +194,19 @@ mod tests {
         let path_opt = fit_to_bezpath(&offset_path, accuracy);
         assert!(matches!(path_opt.iter().next(), Some(PathEl::MoveTo(_))));
     }
+
+    /// Cubic offset that used to trigger infinite recursion.
+    #[test]
+    fn infinite_recursion() {
+        const DIM_TUNE: f64 = 0.25;
+        const TOLERANCE: f64 = 0.1;
+        let c = CubicBez::new(
+            (1096.2962962962963, 593.90243902439033),
+            (1043.6213991769548, 593.90243902439033),
+            (1030.4526748971193, 593.90243902439033),
+            (1056.7901234567901, 593.90243902439033),
+        );
+        let co = CubicOffset::new_regularized(c, -0.5, DIM_TUNE * TOLERANCE);
+        fit_to_bezpath(&co, TOLERANCE);
+    }
 }

--- a/src/stroke.rs
+++ b/src/stroke.rs
@@ -421,17 +421,18 @@ impl StrokeCtx {
 
         // Ordinarily, this is the direction of the chord, but if the chord is very
         // short, we take the longer control arm.
-        let mut chord_ref = c.p3 - c.p0;
+        let chord = c.p3 - c.p0;
+        let mut chord_ref = chord;
         let mut chord_ref_hypot2 = chord_ref.hypot2();
         let d01 = c.p1 - c.p0;
         if d01.hypot2() > chord_ref_hypot2 {
             chord_ref = d01;
-            chord_ref_hypot2 = d01.hypot2();
+            chord_ref_hypot2 = chord_ref.hypot2();
         }
         let d23 = c.p3 - c.p2;
         if d23.hypot2() > chord_ref_hypot2 {
             chord_ref = d23;
-            chord_ref_hypot2 = d23.hypot2();
+            chord_ref_hypot2 = chord_ref.hypot2();
         }
         // Project Bézier onto chord
         let p0 = c.p0.to_vec2().dot(chord_ref);
@@ -447,8 +448,9 @@ impl StrokeCtx {
             // potentially a cusp inside
             let x01 = d01.cross(chord_ref);
             let x23 = d23.cross(chord_ref);
+            let x03 = chord.cross(chord_ref);
             let thresh = tolerance.powi(2) * chord_ref_hypot2;
-            if x01 * x01 < thresh && x23 * x23 < thresh {
+            if x01 * x01 < thresh && x23 * x23 < thresh && x03 * x03 < thresh {
                 // control points are nearly co-linear
                 let midpoint = c.p0.midpoint(c.p3);
                 // Mapping back from projection of reference chord


### PR DESCRIPTION
A number of fixes to improve stroke robustness.

Infinite recursion on curve fit is avoided by checking whether subdivision has hit the floating point limit. That said, the quality of curve fit is poor when the input is discontinuous (which does happen for degenerate cubics with cusps, where all points are co-linear).

Thus, in stroking, the degenerate cases are detected and drawn with special-case logic (do_linear). This uses existing drawing capabilities to draw the degenerate cubic with lines and round joins.

Finally, do_join mistakenly detected a half-turn as zero turn, as it was only considering the cross product (which vanishes).

Fixes #300