### PR TITLE
Add reverse_subpaths() method to BezPath

### DIFF
--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -456,24 +456,16 @@ impl BezPath {
             match el {
                 PathEl::MoveTo(pt) => {
                     if start_ix < ix {
-                        reverse_subpath(
-                            start_pt,
-                            false,
-                            elements.get(start_ix..ix)?,
-                            &mut reversed,
-                        );
+                        reverse_subpath(start_pt, elements.get(start_ix..ix)?, &mut reversed);
                     }
                     start_pt = *pt;
                     start_ix = ix + 1;
                 }
                 PathEl::ClosePath => {
                     if start_ix < ix {
-                        start_pt = reverse_subpath(
-                            start_pt,
-                            true,
-                            elements.get(start_ix..ix)?,
-                            &mut reversed,
-                        );
+                        start_pt =
+                            reverse_subpath(start_pt, elements.get(start_ix..ix)?, &mut reversed);
+                        reversed.push(PathEl::ClosePath);
                     }
                     start_ix = ix + 1;
                 }
@@ -481,7 +473,7 @@ impl BezPath {
             }
         }
         if start_ix < elements.len() {
-            reverse_subpath(start_pt, false, elements.get(start_ix..)?, &mut reversed);
+            reverse_subpath(start_pt, elements.get(start_ix..)?, &mut reversed);
         }
         Some(reversed)
     }
@@ -491,12 +483,7 @@ impl BezPath {
 ///
 /// The `els` parameter must not contain any `MoveTo` or `ClosePath` elements.
 /// Returns the final point of the subpath.
-fn reverse_subpath(
-    start_pt: Point,
-    is_closed: bool,
-    els: &[PathEl],
-    reversed: &mut BezPath,
-) -> Point {
+fn reverse_subpath(start_pt: Point, els: &[PathEl], reversed: &mut BezPath) -> Point {
     let mut end_pt = els.last().and_then(|el| el.end_point()).unwrap_or(start_pt);
     reversed.push(PathEl::MoveTo(end_pt));
     for (ix, el) in els.iter().enumerate().rev() {
@@ -511,9 +498,6 @@ fn reverse_subpath(
             PathEl::CurveTo(c0, c1, _) => reversed.push(PathEl::CurveTo(*c1, *c0, end_pt)),
             _ => panic!("reverse_subpath expects MoveTo and ClosePath to be removed"),
         }
-    }
-    if is_closed {
-        reversed.push(PathEl::ClosePath);
     }
     end_pt
 }

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -463,8 +463,7 @@ impl BezPath {
                 }
                 PathEl::ClosePath => {
                     if start_ix < ix {
-                        start_pt =
-                            reverse_subpath(start_pt, elements.get(start_ix..ix)?, &mut reversed);
+                        reverse_subpath(start_pt, elements.get(start_ix..ix)?, &mut reversed);
                         reversed.push(PathEl::ClosePath);
                     }
                     start_ix = ix + 1;
@@ -482,12 +481,11 @@ impl BezPath {
 /// Helper for reversing a subpath.
 ///
 /// The `els` parameter must not contain any `MoveTo` or `ClosePath` elements.
-/// Returns the final point of the subpath.
-fn reverse_subpath(start_pt: Point, els: &[PathEl], reversed: &mut BezPath) -> Point {
-    let mut end_pt = els.last().and_then(|el| el.end_point()).unwrap_or(start_pt);
+fn reverse_subpath(start_pt: Point, els: &[PathEl], reversed: &mut BezPath) {
+    let end_pt = els.last().and_then(|el| el.end_point()).unwrap_or(start_pt);
     reversed.push(PathEl::MoveTo(end_pt));
     for (ix, el) in els.iter().enumerate().rev() {
-        end_pt = if ix > 0 {
+        let end_pt = if ix > 0 {
             els[ix - 1].end_point().unwrap()
         } else {
             start_pt
@@ -499,7 +497,6 @@ fn reverse_subpath(start_pt: Point, els: &[PathEl], reversed: &mut BezPath) -> P
             _ => panic!("reverse_subpath expects MoveTo and ClosePath to be removed"),
         }
     }
-    end_pt
 }
 
 impl FromIterator<PathEl> for BezPath {


### PR DESCRIPTION
Returns a new path with winding direction of all subpaths reversed.

This is mostly based on the code here: https://github.com/googlefonts/fontations/blob/d4e07eb3b45836f3241e5a5343fdb697c40d978b/write-fonts/src/pens.rs#L164 which it is intended to replace. Tests are taken from that code as well.