### PR TITLE
Improve cusp detection for strokes

### DIFF
--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -437,7 +437,7 @@ impl CubicBez {
             let d = q.eval(nearest.t);
             let d2 = q.deriv().eval(nearest.t);
             let cross = d.to_vec2().cross(d2.to_vec2());
-            if nearest.distance_sq.powi(3) < (cross * dimension).powi(2) {
+            if nearest.distance_sq.powi(3) <= (cross * dimension).powi(2) {
                 let a = 3. * det_012 + det_023 - 2. * det_013;
                 let b = -3. * det_012 + det_013;
                 let c = det_012;

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -189,31 +189,31 @@ fn fit_to_bezpath_rec(
             return;
         }
     }
-    if let Some(t) = source.break_cusp(start..end) {
-        fit_to_bezpath_rec(source, start..t, accuracy, path);
-        fit_to_bezpath_rec(source, t..end, accuracy, path);
+    let t = if let Some(t) = source.break_cusp(start..end) {
+        t
     } else if let Some((c, _)) = fit_to_cubic(source, start..end, accuracy) {
         if path.is_empty() {
             path.move_to(c.p0);
         }
         path.curve_to(c.p1, c.p2, c.p3);
+        return;
     } else {
         // A smarter approach is possible than midpoint subdivision, but would be
         // a significant increase in complexity.
-        let t = 0.5 * (start + end);
-        if t == start || t == end {
-            // infinite recursion, just draw a line
-            let p1 = start_p.lerp(end_p, 1.0 / 3.0);
-            let p2 = end_p.lerp(start_p, 1.0 / 3.0);
-            if path.is_empty() {
-                path.move_to(start_p);
-            }
-            path.curve_to(p1, p2, end_p);
-            return;
+        0.5 * (start + end)
+    };
+    if t == start || t == end {
+        // infinite recursion, just draw a line
+        let p1 = start_p.lerp(end_p, 1.0 / 3.0);
+        let p2 = end_p.lerp(start_p, 1.0 / 3.0);
+        if path.is_empty() {
+            path.move_to(start_p);
         }
-        fit_to_bezpath_rec(source, start..t, accuracy, path);
-        fit_to_bezpath_rec(source, t..end, accuracy, path);
+        path.curve_to(p1, p2, end_p);
+        return;
     }
+    fit_to_bezpath_rec(source, start..t, accuracy, path);
+    fit_to_bezpath_rec(source, t..end, accuracy, path);
 }
 
 const N_SAMPLE: usize = 20;


### PR DESCRIPTION
The cusp detection was failing because a comparison wasn't inclusive enough. In particular, it was trying to compute whether curvature at the point exceeded 1/dimension, without doing division, but both values in the comparison become zero when the derivative vanishes.

Also avoids infinite recursion when break_cusp reports a cusp within ulp of an endpoint. This is supposed to be a violation of the contract, but it's not hard to see how it can happen.

Includes test cases adapted from vello#388