### PR TITLE
Make TranslateScale::from_scale_about to take `Into<Point>`.

### DIFF
--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -91,11 +91,11 @@ impl TranslateScale {
     /// assert_near(ts * Point::new(2., 2.), Point::new(3., 3.));
     /// ```
     #[inline]
-    pub fn from_scale_about(scale: f64, focus: Point) -> Self {
+    pub fn from_scale_about(scale: f64, focus: impl Into<Point>) -> Self {
         // We need to create a transform that is equivalent to translating `focus`
         // to the origin, followed by a normal scale, followed by reversing the translation.
         // We need to find the (translation ∘ scale) that matches this.
-        let focus = focus.to_vec2();
+        let focus = focus.into().to_vec2();
         let translation = focus - focus * scale;
         Self::new(translation, scale)
     }


### PR DESCRIPTION
bring it into alignment with `Rect` methods that take `Into<Point>`.

Randomly noticed this, this patch doesn't do a full audit of the methods taking `Point`, should (we, or I) do such?
I went ahead and had a look through, here are the functions that take Points as parameters that we could consider
changing.

1. The `nearest` functions of `ParamCurve`, `CubicBez`, `QuadBez`, `PathSeg`, and `Line`.
2. `Shape::winding`, and `Shape::contains` trait methods.
3. The `other` variable, of various Point functions `lerp` `midpoint`, `distance`, `distance_squared`
4. `Rect::union_pt`
5. `Ellipse::with_center`
6. `Affine::rotate_about`, `pre_rotate_about`, `then_rotate_about`.

Here are some things I don't think should change, and reasons
4. While the `new` fn of `QuadSpline` takes a `Vec<Point>`, it takes ownership, turning it into an `IntoIterator` or something
Would force an allocation in collect.
