### PR TITLE
Handle special case of fitting a line

### DIFF
--- a/src/fit.rs
+++ b/src/fit.rs
@@ -509,8 +509,16 @@ fn cubic_fit(th0: f64, th1: f64, area: f64, mx: f64) -> ArrayVec<(CubicBez, f64,
         }
     } else if a3.abs() > EPS {
         roots.extend(solve_cubic(a0, a1, a2, a3));
-    } else {
+    } else if a2.abs() > EPS || a1.abs() > EPS || a0.abs() > EPS {
         roots.extend(solve_quadratic(a0, a1, a2));
+    } else {
+        return [(
+            CubicBez::new((0.0, 0.0), (1. / 3., 0.0), (2. / 3., 0.0), (1., 0.0)),
+            1f64 / 3.,
+            1f64 / 3.,
+        )]
+        .into_iter()
+        .collect();
     }
 
     let s01 = s0 * c1 + s1 * c0;

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -209,4 +209,11 @@ mod tests {
         let co = CubicOffset::new_regularized(c, -0.5, DIM_TUNE * TOLERANCE);
         fit_to_bezpath(&co, TOLERANCE);
     }
+
+    #[test]
+    fn test_cubic_offset_simple_line() {
+        let cubic = CubicBez::new((0., 0.), (10., 0.), (20., 0.), (30., 0.));
+        let offset = CubicOffset::new(cubic, 5.);
+        let _optimized = fit_to_bezpath(&offset, 1e-6);
+    }
 }


### PR DESCRIPTION
When the algorithm is asked to curve-fit a line, area and moment are both zero, which provokes numerical instablily. Just return a straight line in that case.