### PR TITLE
Replace panic with error return in `BezPath::from_svg`

### DIFF
--- a/src/svg.rs
+++ b/src/svg.rs
@@ -102,6 +102,10 @@ impl BezPath {
         let mut implicit_moveto = None;
         while let Some(c) = lexer.get_cmd(last_cmd) {
             if c != b'm' && c != b'M' {
+                if path.elements().is_empty() {
+                    return Err(SvgParseError::UninitializedPath)
+                }
+                
                 if let Some(pt) = implicit_moveto.take() {
                     path.move_to(pt);
                 }
@@ -242,6 +246,8 @@ pub enum SvgParseError {
     UnexpectedEof,
     /// Encountered an unknown command letter.
     UnknownCommand(char),
+    /// Encountered a command that precedes expected 'moveto' command.
+    UninitializedPath,
 }
 
 impl Display for SvgParseError {
@@ -250,6 +256,7 @@ impl Display for SvgParseError {
             SvgParseError::Wrong => write!(f, "Unable to parse a number"),
             SvgParseError::UnexpectedEof => write!(f, "Unexpected EOF"),
             SvgParseError::UnknownCommand(letter) => write!(f, "Unknown command, \"{letter}\""),
+            SvgParseError::UninitializedPath => write!(f, "Unititialized path (missing moveto command)"),
         }
     }
 }
@@ -515,6 +522,12 @@ mod tests {
         // Approximate figures, but useful for regression testing
         assert_eq!(path.area().round(), -1473.0);
         assert_eq!(path.perimeter(1e-6).round(), 168.0);
+    }
+
+    #[test]
+    fn test_parse_svg_uninitialized() {
+        let path = BezPath::from_svg("L10 10 100 0 0 100");
+        assert!(path.is_err());
     }
 
     #[test]

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -103,9 +103,9 @@ impl BezPath {
         while let Some(c) = lexer.get_cmd(last_cmd) {
             if c != b'm' && c != b'M' {
                 if path.elements().is_empty() {
-                    return Err(SvgParseError::UninitializedPath)
+                    return Err(SvgParseError::UninitializedPath);
                 }
-                
+
                 if let Some(pt) = implicit_moveto.take() {
                     path.move_to(pt);
                 }
@@ -256,7 +256,9 @@ impl Display for SvgParseError {
             SvgParseError::Wrong => write!(f, "Unable to parse a number"),
             SvgParseError::UnexpectedEof => write!(f, "Unexpected EOF"),
             SvgParseError::UnknownCommand(letter) => write!(f, "Unknown command, \"{letter}\""),
-            SvgParseError::UninitializedPath => write!(f, "Unititialized path (missing moveto command)"),
+            SvgParseError::UninitializedPath => {
+                write!(f, "Unititialized path (missing moveto command)")
+            }
         }
     }
 }


### PR DESCRIPTION
As pointed out in https://github.com/linebender/kurbo/issues/303#issuecomment-1856382911 `BezPath::from_svg` does not handle case when SVG path does not start with initial point. This PR makes the `BezPath::from_svg` return an error for this case.