### PR TITLE
Make the FloatFuncs trait a sealed public trait, add sin/sinf.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -5,6 +5,16 @@
 
 #![allow(missing_docs)]
 
+#[cfg(not(feature = "std"))]
+mod sealed {
+    /// A [sealed trait](https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/)
+    /// which stops [`super::FloatFuncs`] from being implemented outside kurbo. This could
+    /// be relaxed in the future if there is are good reasons to allow external impls.
+    /// The benefit from being sealed is that we can add methods without breaking downstream
+    /// implementations.
+    pub trait FloatFuncsSealed {}
+}
+
 use arrayvec::ArrayVec;
 
 /// Defines a trait that chooses between libstd or libm implementations of float methods.
@@ -13,13 +23,22 @@ macro_rules! define_float_funcs {
         fn $name:ident(self $(,$arg:ident: $arg_ty:ty)*) -> $ret:ty
         => $lname:ident/$lfname:ident;
     )+) => {
+
+        /// Since core doesn't depend upon libm, this provides libm implementations
+        /// of float functions which are typically provided by the std library, when
+        /// the `std` feature is not enabled.
+        ///
+        /// For documentation see the respective functions in the std library.
         #[cfg(not(feature = "std"))]
-        pub(crate) trait FloatFuncs : Sized {
+        pub trait FloatFuncs : Sized + sealed::FloatFuncsSealed {
             /// Special implementation for signum, because libm doesn't have it.
             fn signum(self) -> Self;
 
             $(fn $name(self $(,$arg: $arg_ty)*) -> $ret;)+
         }
+
+        #[cfg(not(feature = "std"))]
+        impl sealed::FloatFuncsSealed for f32{}
 
         #[cfg(not(feature = "std"))]
         impl FloatFuncs for f32 {
@@ -41,6 +60,8 @@ macro_rules! define_float_funcs {
             })+
         }
 
+        #[cfg(not(feature = "std"))]
+        impl sealed::FloatFuncsSealed for f64{}
         #[cfg(not(feature = "std"))]
         impl FloatFuncs for f64 {
             #[inline]
@@ -79,6 +100,7 @@ define_float_funcs! {
     fn powi(self, n: i32) -> Self => pow/powf;
     fn powf(self, n: Self) -> Self => pow/powf;
     fn round(self) -> Self => round/roundf;
+    fn sin(self) -> Self => sin/sinf;
     fn sin_cos(self) -> (Self, Self) => sincos/sincosf;
     fn sqrt(self) -> Self => sqrt/sqrtf;
     fn tan(self) -> Self => tan/tanf;

--- a/src/common.rs
+++ b/src/common.rs
@@ -38,7 +38,7 @@ macro_rules! define_float_funcs {
         }
 
         #[cfg(not(feature = "std"))]
-        impl sealed::FloatFuncsSealed for f32{}
+        impl sealed::FloatFuncsSealed for f32 {}
 
         #[cfg(not(feature = "std"))]
         impl FloatFuncs for f32 {

--- a/src/common.rs
+++ b/src/common.rs
@@ -61,7 +61,7 @@ macro_rules! define_float_funcs {
         }
 
         #[cfg(not(feature = "std"))]
-        impl sealed::FloatFuncsSealed for f64{}
+        impl sealed::FloatFuncsSealed for f64 {}
         #[cfg(not(feature = "std"))]
         impl FloatFuncs for f64 {
             #[inline]


### PR DESCRIPTION
This trait, with the addition of sin/sinf is needed to build peniko with the `--no-default-features --features libm` combination (added in the pr below).

The approach taken here is that rather than duplicating this common module in peniko, to make it pub, and add the sin/sinf. for peniko.  This trait is only conditionally defined so use of it in peniko would look something like:

```
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
+use kurbo::common::FloatFuncs as _
```

This patch is in regards to fixing the testsuite failures for default features added in
https://github.com/linebender/peniko/pull/23