### PR TITLE
Prepare 0.11 and make `SvgParseError` non_exhaustive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kurbo"
-version = "0.10.4"
+version = "0.11.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -51,4 +51,3 @@ rand = "0.8.0"
 
 [target.'cfg(target_arch="wasm32")'.dev-dependencies]
 getrandom = { version = "0.2.0", features = ["js"] }
-

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -239,6 +239,7 @@ impl BezPath {
 
 /// An error which can be returned when parsing an SVG.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum SvgParseError {
     /// A number was expected.
     Wrong,


### PR DESCRIPTION
#329 was a breaking change, forcing this release to be 0.11. 
To avoid a similar situation in future, mark the enum as `#[non_exhaustive]`

See [#kurbo > 0.10.5 release](https://xi.zulipchat.com/#narrow/stream/260979-kurbo/topic/0.2E10.2E5.20release)