### PR TITLE
Add From (f32, f32) for Point

### DIFF
--- a/src/point.rs
+++ b/src/point.rs
@@ -187,6 +187,16 @@ impl Point {
     }
 }
 
+impl From<(f32, f32)> for Point {
+    #[inline]
+    fn from(v: (f32, f32)) -> Point {
+        Point {
+            x: v.0 as f64,
+            y: v.1 as f64,
+        }
+    }
+}
+
 impl From<(f64, f64)> for Point {
     #[inline]
     fn from(v: (f64, f64)) -> Point {


### PR DESCRIPTION
When building a BezPath from a source that provides f32, such as https://docs.rs/skrifa/latest/skrifa/outline/trait.OutlinePen.html, it would be nice to be able to pass `(f32, f32)` as `Into<Point>`