### PR TITLE
clippy: Fix `doc_markdown` lint

### DIFF
--- a/src/quadbez.rs
+++ b/src/quadbez.rs
@@ -163,7 +163,7 @@ pub(crate) struct FlattenParams {
     a2: f64,
     u0: f64,
     uscale: f64,
-    /// The number of subdivisions * 2 * sqrt_tol.
+    /// The number of `subdivisions * 2 * sqrt_tol`.
     pub(crate) val: f64,
 }
 


### PR DESCRIPTION
These became stricter in Rust 1.78 so we need to appease it.