### PR TITLE
lints: Enable `warn(unused_qualifications)`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.11.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+# TODO: When this hits 1.74, move lint configuration into this file via a lints table.
 rust-version = "1.65" # When updating this, also update the README.md and CI.
 keywords = ["graphics", "curve", "curves", "bezier", "geometry"]
 repository = "https://github.com/linebender/kurbo"

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -1084,7 +1084,7 @@ impl PathSeg {
                 let c1 = dy * px1 - dx * py1;
                 let c2 = dy * px2 - dx * py2;
                 let invlen2 = (dx * dx + dy * dy).recip();
-                for t in crate::common::solve_quadratic(c0, c1, c2) {
+                for t in solve_quadratic(c0, c1, c2) {
                     if (-EPSILON..=(1.0 + EPSILON)).contains(&t) {
                         let x = px0 + t * px1 + t * t * px2;
                         let y = py0 + t * py1 + t * t * py2;
@@ -1104,7 +1104,7 @@ impl PathSeg {
                 let c2 = dy * px2 - dx * py2;
                 let c3 = dy * px3 - dx * py3;
                 let invlen2 = (dx * dx + dy * dy).recip();
-                for t in crate::common::solve_cubic(c0, c1, c2, c3) {
+                for t in solve_cubic(c0, c1, c2, c3) {
                     if (-EPSILON..=(1.0 + EPSILON)).contains(&t) {
                         let x = px0 + t * px1 + t * t * px2 + t * t * t * px3;
                         let y = py0 + t * py1 + t * t * py2 + t * t * t * py3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@
 #![deny(missing_docs, clippy::trivially_copy_pass_by_ref)]
 #![warn(clippy::doc_markdown, rustdoc::broken_intra_doc_links)]
 #![warn(clippy::semicolon_if_nothing_returned)]
+#![warn(unused_qualifications)]
 #![allow(
     clippy::unreadable_literal,
     clippy::many_single_char_names,

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -609,7 +609,7 @@ mod tests {
 
         let length = rng.gen_range(0..MAX_LENGTH);
         for _ in 0..length {
-            let should_follow: bool = rand::random();
+            let should_follow: bool = random();
             let kind = rng.gen_range(0..3);
 
             let first = position
@@ -647,7 +647,7 @@ mod tests {
     #[test]
     fn test_serialize_deserialize() {
         const N_TESTS: u32 = 100;
-        let mut rng = rand::thread_rng();
+        let mut rng = thread_rng();
 
         for _ in 0..N_TESTS {
             let vec = gen_random_path_sequence(&mut rng);


### PR DESCRIPTION
This helps point out where the code can be more concise with an identifier already being in scope and not needing qualifications.