### PR TITLE
Allow some of the SVG support in `no_std`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This release has an [MSRV][] of 1.65.
 ### Changed
 
 - Move `Self: Sized` bound from `Shape` to methods. ([#340] by [@waywardmonkeys])
+- Enable partial SVG path support in `no_std` builds. ([#356] by [@waywardmonkeys])
 
 ### Fixed
 
@@ -49,6 +50,7 @@ Note: A changelog was not kept for or before this release
 [#343]: https://github.com/linebender/kurbo/pull/343
 [#347]: https://github.com/linebender/kurbo/pull/347
 [#354]: https://github.com/linebender/kurbo/pull/354
+[#356]: https://github.com/linebender/kurbo/pull/356
 
 [Unreleased]: https://github.com/linebender/kurbo/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/linebender/kurbo/releases/tag/v0.11.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,6 @@ mod shape;
 pub mod simplify;
 mod size;
 mod stroke;
-#[cfg(feature = "std")]
 mod svg;
 mod translate_scale;
 mod vec2;
@@ -134,7 +133,6 @@ pub use crate::rounded_rect_radii::*;
 pub use crate::shape::*;
 pub use crate::size::*;
 pub use crate::stroke::*;
-#[cfg(feature = "std")]
 pub use crate::svg::*;
 pub use crate::translate_scale::*;
 pub use crate::vec2::*;

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -3,12 +3,19 @@
 
 //! SVG path representation.
 
+use alloc::vec::Vec;
+use core::f64::consts::PI;
+use core::fmt::{self, Display, Formatter};
+// MSRV: Once our MSRV is 1.81, we can switch to `core::error`
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::f64::consts::PI;
-use std::fmt::{self, Display, Formatter};
+#[cfg(feature = "std")]
 use std::io::{self, Write};
 
 use crate::{Arc, BezPath, ParamCurve, PathEl, PathSeg, Point, Vec2};
+
+#[cfg(not(feature = "std"))]
+use crate::common::FloatFuncs;
 
 // Note: the SVG arc logic is heavily adapted from https://github.com/nical/lyon
 
@@ -60,6 +67,7 @@ impl BezPath {
     ///
     /// The current implementation doesn't take any special care to produce a
     /// short string (reducing precision, using relative movement).
+    #[cfg(feature = "std")]
     pub fn to_svg(&self) -> String {
         let mut buffer = Vec::new();
         self.write_to(&mut buffer).unwrap();
@@ -67,6 +75,7 @@ impl BezPath {
     }
 
     /// Write the SVG representation of this path to the provided buffer.
+    #[cfg(feature = "std")]
     pub fn write_to<W: Write>(&self, mut writer: W) -> io::Result<()> {
         for (i, el) in self.elements().iter().enumerate() {
             if i > 0 {
@@ -264,6 +273,7 @@ impl Display for SvgParseError {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for SvgParseError {}
 
 struct SvgLexer<'a> {


### PR DESCRIPTION
Some of the SVG functionality builds with `no_std` and can reasonably be enabled.