### PR TITLE
Enable `feature(doc_auto_cfg)` for docs.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,8 @@ jobs:
       # We test documentation using nightly to match docs.rs. This prevents potential breakages
       - name: cargo doc
         run: cargo doc --workspace --locked --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
+        env:
+          RUSTDOCFLAGS: '--cfg docsrs'
 
   # If this fails, consider changing your text or adding something to .typos.toml
   typos:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@
     clippy::excessive_precision,
     clippy::bool_to_int_with_if
 )]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 
 #[cfg(not(any(feature = "std", feature = "libm")))]


### PR DESCRIPTION
Docs built using this (like for docs.rs) will show what feature must be enabled for things that are `cfg(feature = ...)` gated.

This is a nightly only thing. If you want to run it locally, you can use:

    RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features