### PR TITLE
Remove dead link targets.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,6 @@
 //! efficient as the standard library, and that this crate still uses the
 //! `alloc` crate regardless.
 //!
-//! [`Piet`]: https://docs.rs/piet
-//! [`Druid`]: https://docs.rs/druid
 //! [`libm`]: https://docs.rs/libm
 
 #![forbid(unsafe_code)]


### PR DESCRIPTION
Nothing points at these link targets for `Piet` or `Druid` any longer in this body of text.