### PR TITLE
fix: parsing scientific notation in SVG path

### DIFF
--- a/src/svg.rs
+++ b/src/svg.rs
@@ -352,11 +352,11 @@ impl<'a> SvgLexer<'a> {
                 if c == b'-' || c == b'+' {
                     c = self.get_byte().ok_or(SvgParseError::Wrong)?;
                 }
-                if c.is_ascii_digit() {
+                if !c.is_ascii_digit() {
                     return Err(SvgParseError::Wrong);
                 }
                 while let Some(c) = self.get_byte() {
-                    if c.is_ascii_digit() {
+                    if !c.is_ascii_digit() {
                         self.unget();
                         break;
                     }
@@ -506,7 +506,7 @@ impl Arc {
 
 #[cfg(test)]
 mod tests {
-    use crate::{BezPath, CubicBez, Line, ParamCurve, PathSeg, Point, QuadBez, Shape};
+    use crate::{BezPath, CubicBez, Line, ParamCurve, PathEl, PathSeg, Point, QuadBez, Shape};
 
     #[test]
     fn test_parse_svg() {
@@ -541,6 +541,22 @@ mod tests {
     fn test_parse_svg_uninitialized() {
         let path = BezPath::from_svg("L10 10 100 0 0 100");
         assert!(path.is_err());
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn test_parse_scientific_notation() {
+        let path = BezPath::from_svg("M 0 0 L 1e-123 -4E+5").unwrap();
+        assert_eq!(
+            path.elements(),
+            &[
+                PathEl::MoveTo(Point { x: 0.0, y: 0.0 }),
+                PathEl::LineTo(Point {
+                    x: 1e-123,
+                    y: -4E+5
+                })
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Before this change

The SVG parsing code failed to parse scientific notation in `BezPath`. For example `M 0 0 L 1e-123 -4E+5` would fail to parse with `SvgParseError::Wrong` even though it is a valid SVG path. This error was introduced by 8d10d4e which [forgot to negate the conditional](https://github.com/linebender/kurbo/commit/8d10d4e00981238f1ba555fe44af000b81aa4ec1#diff-a0ea1370686e222812265cfdba79ff5c9458cfc267ebd7c8b2221dc735909483L317), causing the parser to fail when it should succeed.

## After this change

The change fixes the error and adds a test for it.