### PR TITLE
Add `Rect::is_zero_area`, `Size::is_zero_area`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This release has an [MSRV][] of 1.65.
 - Add `CubicBez::tangents` ([#288] by [@raphlinus])
 - Add `Arc::flipped`. ([#367] by [@waywardmonkeys])
 - Add `CircleSegment::inner_arc` and `CircleSegment::outer_arc` ([#368] by [@waywardmonkeys])
+- Add `Rect::is_zero_area` and `Size::is_zero_area` and deprecate their `is_empty` methods. ([#370] by [@waywardmonkeys])
 
 ### Changed
 
@@ -59,6 +60,7 @@ Note: A changelog was not kept for or before this release
 [#361]: https://github.com/linebender/kurbo/pull/361
 [#367]: https://github.com/linebender/kurbo/pull/367
 [#368]: https://github.com/linebender/kurbo/pull/368
+[#370]: https://github.com/linebender/kurbo/pull/370
 
 [Unreleased]: https://github.com/linebender/kurbo/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/linebender/kurbo/releases/tag/v0.11.0

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -160,11 +160,18 @@ impl Rect {
     }
 
     /// Whether this rectangle has zero area.
+    #[inline]
+    pub fn is_zero_area(&self) -> bool {
+        self.area() == 0.0
+    }
+
+    /// Whether this rectangle has zero area.
     ///
     /// Note: a rectangle with negative area is not considered empty.
     #[inline]
+    #[deprecated(since = "0.11.1", note = "use is_zero_area instead")]
     pub fn is_empty(&self) -> bool {
-        self.area() == 0.0
+        self.is_zero_area()
     }
 
     /// The center point of the rectangle.

--- a/src/size.rs
+++ b/src/size.rs
@@ -66,11 +66,18 @@ impl Size {
     }
 
     /// Whether this size has zero area.
+    #[inline]
+    pub fn is_zero_area(self) -> bool {
+        self.area() == 0.0
+    }
+
+    /// Whether this size has zero area.
     ///
     /// Note: a size with negative area is not considered empty.
     #[inline]
+    #[deprecated(since = "0.11.1", note = "use is_zero_area instead")]
     pub fn is_empty(self) -> bool {
-        self.area() == 0.0
+        self.is_zero_area()
     }
 
     /// Returns a new size bounded by `min` and `max.`


### PR DESCRIPTION
These replace `Rect::is_empty` and `Size::is_empty` (which are now deprecated) as the treatment of negative areas as not being empty can be slightly confusing, so using a more specific name makes things more clear.