### PR TITLE
Numerically approximate arc perimeter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This release has an [MSRV][] of 1.65.
 - `Stroke` is now `PartialEq`, `StrokeOpts` is now `Clone`, `Copy`, `Debug`, `Eq`, `PartialEq`. ([#379][] by [@waywardmonkeys][])
 - Implement `Sum` for `Vec2`. ([#399][] by [@Philipp-M][])
 - Add triangle shape. ([#350][] by [@juliapaci][])
+- `Arc` now implements `ParamCurve` and `ParamCurveArclen`. ([#378] by [@waywardmonkeys])
 
 ### Changed
 
@@ -90,6 +91,7 @@ Note: A changelog was not kept for or before this release
 [#370]: https://github.com/linebender/kurbo/pull/370
 [#375]: https://github.com/linebender/kurbo/pull/375
 [#376]: https://github.com/linebender/kurbo/pull/376
+[#378]: https://github.com/linebender/kurbo/pull/378
 [#379]: https://github.com/linebender/kurbo/pull/379
 [#383]: https://github.com/linebender/kurbo/pull/383
 [#388]: https://github.com/linebender/kurbo/pull/388

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This release has an [MSRV][] of 1.65.
 
 - Reduce number of operations in `Triangle::circumscribed_circle`. ([#390][] by [@tomcur][])
 - Numerically approximate ellipse perimeter. ([#383] by [@tomcur][])
+- Numerically approximate elliptic arc perimeter. ([#381] by [@tomcur][])
 
 ## [0.11.1][] (2024-09-12)
 
@@ -93,6 +94,7 @@ Note: A changelog was not kept for or before this release
 [#376]: https://github.com/linebender/kurbo/pull/376
 [#378]: https://github.com/linebender/kurbo/pull/378
 [#379]: https://github.com/linebender/kurbo/pull/379
+[#381]: https://github.com/linebender/kurbo/pull/381
 [#383]: https://github.com/linebender/kurbo/pull/383
 [#388]: https://github.com/linebender/kurbo/pull/388
 [#390]: https://github.com/linebender/kurbo/pull/390

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -385,7 +385,6 @@ fn carlson_rf(accuracy: f64, x: f64, y: f64, z: f64) -> f64 {
     let mut e = a - x.min(y).min(z);
     let mut r = accuracy * 4. * e.powi(-6);
 
-    // let mut q = 1. / (3. * f64::EPSILON).cbrt().sqrt() * (a - x.min(y).min(z));
     loop {
         if 1. <= r * a.powi(6) * a.sqrt() * (1. - e / a) {
             break;

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -327,6 +327,9 @@ impl Mul<Arc> for Affine {
 ///
 /// RF = 1/2 ∫ 1 / ( sqrt(t+x) sqrt(t+y) sqrt(t+z) ) dt from 0 to inf
 fn carlson_rf(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
+    // At most one of (x, y, z) may be 0.
+    debug_assert!((x == 0.) as u8 + (y == 0.) as u8 + (z == 0.) as u8 <= 1);
+
     let mut x = x;
     let mut y = y;
     let mut z = z;
@@ -368,6 +371,10 @@ fn carlson_rf(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
 ///
 /// RD = 3/2 ∫ 1 / ( sqrt(t+x) sqrt(t+y) (t+z)^(3/2) ) dt from 0 to inf
 fn carlson_rd(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
+    // At most one of (x, y) may be 0, z must be nonzero.
+    debug_assert!(z != 0.);
+    debug_assert!(x != 0. || y != 0.);
+
     let mut x = x;
     let mut y = y;
     let mut z = z;

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -340,7 +340,7 @@ fn carlson_rf(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
     let e2 = x * y - z.powi(2);
     let e3 = x * y * z;
 
-    a.powf(-1. / 2.)
+    1. / a.sqrt()
         * (1. - 1. / 10. * e2 + 1. / 14. * e3 + 1. / 24. * e2.powi(2) - 3. / 44. * e2 * e3)
 }
 
@@ -384,8 +384,7 @@ fn carlson_rd(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
     let e4 = 3. * x * y - z.powi(2) * z.powi(2);
     let e5 = x * y * z.powi(3);
 
-    4f64.powi(-m)
-        * a.powf(-3. / 2.)
+    4f64.powi(-m) * 1. / (a * a.sqrt())
         * (1. - 3. / 14. * e2 + 1. / 6. * e3 + 9. / 88. * e2.powi(2)
             - 3. / 22. * e4
             - 9. / 52. * e2 * e3

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -220,7 +220,7 @@ impl ParamCurveArclen for Arc {
         // Normalize sweep angle to be non-negative
         let mut sweep_angle = self.sweep_angle;
         if sweep_angle < 0. {
-            start_angle -= sweep_angle;
+            start_angle = PI - start_angle;
             sweep_angle = -sweep_angle;
         }
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -535,7 +535,7 @@ fn incomplete_elliptic_integral_second_kind(accuracy: f64, phi: f64, m: f64) -> 
     let term2 = if sin == 0. || m == 0. {
         0.
     } else {
-        1. / 3. * m * sin3 * carlson_rd(accuracy * 3. / 2. / (m * sin3), cos2, 1. - m * sin2, 1.)
+        1. / 3. * m * sin3 * carlson_rd(accuracy * (3. / 2.) / (m * sin3), cos2, 1. - m * sin2, 1.)
     };
 
     term1 - term2

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -519,11 +519,11 @@ mod tests {
 
         // Numerical checks from section 3 of "Numerical computation of real or complex elliptic
         // integrals" (Carlson, Bille C.): https://arxiv.org/abs/math/9409227v1 (real-valued calls)
-        assert!((carlson_rf(1e-20, 1., 2., 0.) - 1.3110_28777_1461).abs() <= EPSILON);
-        assert!((carlson_rf(1e-20, 2., 3., 4.) - 0.58408_28416_7715).abs() <= EPSILON);
+        assert!((carlson_rf(1e-20, 1., 2., 0.) - 1.311_028_777_146_1).abs() <= EPSILON);
+        assert!((carlson_rf(1e-20, 2., 3., 4.) - 0.584_082_841_677_15).abs() <= EPSILON);
 
-        assert!((carlson_rd(1e-20, 0., 2., 1.) - 1.7972_10352_1034).abs() <= EPSILON);
-        assert!((carlson_rd(1e-20, 2., 3., 4.) - 0.16510_52729_4261).abs() <= EPSILON);
+        assert!((carlson_rd(1e-20, 0., 2., 1.) - 1.797_210_352_103_4).abs() <= EPSILON);
+        assert!((carlson_rd(1e-20, 2., 3., 4.) - 0.165_105_272_942_61).abs() <= EPSILON);
     }
 
     #[test]

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -228,7 +228,7 @@ impl ParamCurveArclen for Arc {
         start_angle = start_angle.rem_euclid(PI);
 
         let mut arclen = 0.;
-        let half_turns = (sweep_angle / PI).floor();
+        let half_turns = (sweep_angle / PI).trunc();
         if half_turns > 0. {
             // Half of the ellipse circumference is a complete elliptic integral and could be special-cased
             arclen += half_turns * half_ellipse_arc_length(relative_error, radii, 0., PI);

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -313,23 +313,23 @@ fn carlson_rf(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
     let mut z = z;
 
     let a0 = (x + y + z) / 3.;
-    let q = (3. * relative_error).powf(-1. / 6.)
+    let mut q = (3. * relative_error).powf(-1. / 6.)
         * (a0 - x).abs().max((a0 - y).abs()).max((a0 - z).abs());
 
     let mut a = a0;
     let mut m = 0;
     loop {
-        if 4f64.powi(-m) * q <= a.abs() {
+        if q <= a.abs() {
             break;
         }
 
         let lambda = x.sqrt() * y.sqrt() + x.sqrt() * z.sqrt() + y.sqrt() * z.sqrt();
-
         a = (a + lambda) / 4.;
         x = (x + lambda) / 4.;
         y = (y + lambda) / 4.;
         z = (z + lambda) / 4.;
 
+        q /= 4.;
         m += 1;
     }
 
@@ -354,14 +354,14 @@ fn carlson_rd(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
     let mut z = z;
 
     let a0 = (x + y + 3. * z) / 5.;
-    let q = (relative_error / 4.).powf(-1. / 6.)
+    let mut q = (relative_error / 4.).powf(-1. / 6.)
         * (a0 - x).abs().max((a0 - y).abs()).max((a0 - z).abs());
 
     let mut sum = 0.;
     let mut a = a0;
     let mut m = 0;
     loop {
-        if 4f64.powi(-m) * q <= a.abs() {
+        if q <= a.abs() {
             break;
         }
 
@@ -372,6 +372,7 @@ fn carlson_rd(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
         y = (y + lambda) / 4.;
         z = (z + lambda) / 4.;
 
+        q /= 4.;
         m += 1;
     }
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -378,7 +378,7 @@ fn carlson_rf(accuracy: f64, x: f64, y: f64, z: f64) -> f64 {
     let mut y = y;
     let mut z = z;
 
-    let mut a = (x + y + z) / 3.;
+    let mut a = (x + y + z) * (1. / 3.);
 
     // These are partial terms of the inequality derived above. The multiply by (powers of) 4 are
     // performed per iteration for computational efficiency.
@@ -450,7 +450,7 @@ fn carlson_rd(accuracy: f64, x: f64, y: f64, z: f64) -> f64 {
     let mut y = y;
     let mut z = z;
 
-    let a0 = (x + y + 3. * z) / 5.;
+    let a0 = (x + y + 3. * z) * (1. / 5.);
     let mut a = a0;
 
     let mut sum = 0.;

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -502,6 +502,27 @@ mod tests {
     }
 
     #[test]
+    fn length_compare_with_bez_length() {
+        const EPSILON: f64 = 1e-3;
+
+        for radii in [(1., 1.), (0.5, 1.), (2., 1.)] {
+            for start_angle in [0., 0.5, 1., 2., PI, -1.] {
+                for sweep_angle in [0., 0.5, 1., 2., PI, -1.] {
+                    let a = Arc::new((0., 0.), radii, start_angle, sweep_angle, 0.);
+
+                    let arc_length = a.arclen(0.000_1);
+                    let bez_length = a.path_segments(0.000_1).perimeter(0.000_1);
+
+                    assert!(
+                         (arc_length - bez_length).abs() < EPSILON,
+                         "Numerically approximated arc length ({arc_length}) does not match bezier segment perimeter length ({bez_length}) for arc {a:?}"
+                     );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn carlson_numerical_checks() {
         // TODO: relative bound on error doesn't seem to be quite correct yet, use a large epsilon
         // for now

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -3,7 +3,10 @@
 
 //! An ellipse arc.
 
-use crate::{Affine, Ellipse, ParamCurve, ParamCurveArclen, PathEl, Point, Rect, Shape, Vec2};
+use crate::{
+    ellipse::complete_elliptic_perimeter, Affine, Ellipse, ParamCurve, ParamCurveArclen, PathEl,
+    Point, Rect, Shape, Vec2,
+};
 use core::{
     f64::consts::{FRAC_PI_2, PI},
     iter,
@@ -259,12 +262,12 @@ impl ParamCurveArclen for Arc {
         } else {
             arclen += incomplete_elliptic_integral_second_kind(relative_error, end_angle, m);
         }
+        arclen *= radii.y;
 
         // Note: this uses the complete elliptic integral, which can be special-cased.
-        arclen +=
-            quarter_turns * incomplete_elliptic_integral_second_kind(relative_error, PI / 2., m);
+        arclen += 0.25 * quarter_turns * complete_elliptic_perimeter(self.radii, relative_error);
 
-        radii.y * arclen
+        arclen
     }
 }
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -345,7 +345,7 @@ fn carlson_rf(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
             break;
         }
 
-        let lambda = x.sqrt() * y.sqrt() + x.sqrt() * z.sqrt() + y.sqrt() * z.sqrt();
+        let lambda = (x * y).sqrt() + (x * z).sqrt() + (y * z).sqrt();
         a = (a + lambda) / 4.;
         x = (x + lambda) / 4.;
         y = (y + lambda) / 4.;
@@ -391,7 +391,7 @@ fn carlson_rd(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
             break;
         }
 
-        let lambda = x.sqrt() * y.sqrt() + x.sqrt() * z.sqrt() + y.sqrt() * z.sqrt();
+        let lambda = (x * y).sqrt() + (x * z).sqrt() + (y * z).sqrt();
         sum += 4f64.powi(-m) / (z.sqrt() * (z + lambda));
         a = (a + lambda) / 4.;
         x = (x + lambda) / 4.;

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -236,7 +236,8 @@ impl ParamCurveArclen for Arc {
 
         if start_angle + sweep_angle > PI {
             arclen += half_ellipse_arc_length(relative_error, radii, start_angle, PI);
-            arclen += half_ellipse_arc_length(relative_error, radii, 0., PI - sweep_angle);
+            arclen +=
+                half_ellipse_arc_length(relative_error, radii, 0., start_angle + sweep_angle - PI);
         } else {
             arclen += half_ellipse_arc_length(
                 relative_error,
@@ -473,6 +474,22 @@ mod tests {
         // TODO: when arclen actually uses specified accuracy, update EPSILON and the accuracy
         // params
         const EPSILON: f64 = 1e-6;
+
+        // Circular checks:
+        for (start_angle, sweep_angle, length) in [
+            (0., 1., 1.),
+            (0., 2., 2.),
+            (0., 5., 5.),
+            (1.0, 3., 3.),
+            (1.5, 10., 10.),
+        ] {
+            let a = Arc::new((0., 0.), (1., 1.), start_angle, sweep_angle, 0.);
+            let arc_length = a.arclen(0.000_1);
+            assert!(
+                (arc_length - length).abs() <= EPSILON,
+                "Got arc length {arc_length}, expected {length} for circular arc {a:?}"
+            );
+        }
 
         let a = Arc::new((0., 0.), (1., 1.), 0., PI * 4., 0.);
         assert!((a.arclen(0.000_1) - PI * 4.).abs() <= EPSILON);

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -304,7 +304,7 @@ impl Mul<Arc> for Affine {
 }
 
 /// Approximation of Carlson RF function as defined in "Numerical computation of real or complex
-/// elliptic integrals" (Carlson, Bille C.): https://arxiv.org/abs/math/9409227v1
+/// elliptic integrals" (Carlson, Bille C.): <https://arxiv.org/abs/math/9409227v1>
 fn carlson_rf(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
     let mut x = x;
     let mut y = y;
@@ -343,7 +343,7 @@ fn carlson_rf(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
 }
 
 /// Approximation of Carlson RD function as defined in "Numerical computation of real or complex
-/// elliptic integrals" (Carlson, Bille C.): https://arxiv.org/abs/math/9409227v1
+/// elliptic integrals" (Carlson, Bille C.): <https://arxiv.org/abs/math/9409227v1>
 fn carlson_rd(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
     let mut x = x;
     let mut y = y;
@@ -411,9 +411,9 @@ fn incomplete_elliptic_integral_second_kind(relative_error: f64, phi: f64, m: f6
 
 /// Calculate the length of an arc along an ellipse defined by `radii`, from `start_angle` to
 /// `end_angle`, with the angles being inside the upper half of the ellipse, i.e.,
-/// 0 <= start_angle <= end_angle <= PI.
+/// 0 <= `start_angle` <= `end_angle` <= PI.
 ///
-/// This assumes radii.x >= radii.y
+/// This assumes `radii.x` >= `radii.y`
 fn half_ellipse_arc_length(
     relative_error: f64,
     radii: Vec2,

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -418,8 +418,8 @@ fn incomplete_elliptic_integral_second_kind(relative_error: f64, phi: f64, m: f6
             )
 }
 
-/// Calculate the length of an arc along an ellipse defined by `radii`, from `start_angle`
-/// to `end_angle`, with the angles being inside the first two quadrants, i.e.,
+/// Calculate the length of an arc along an ellipse defined by `radii`, from `start_angle` to
+/// `end_angle`, with the angles being inside the upper half of the ellipse, i.e.,
 /// 0 <= start_angle <= end_angle <= PI.
 ///
 /// This assumes radii.x >= radii.y
@@ -434,12 +434,16 @@ fn half_ellipse_arc_length(
     debug_assert!(end_angle >= start_angle);
     debug_assert!(end_angle <= PI);
 
+    // This function takes angles from 0 to pi for convenience of the caller, but the numerical
+    // methods used here operate from -1/2 pi to 1/2 pi. Rotate the ellipse by 1/2 pi radians (a
+    // quarter turn):
     let radii = Vec2::new(radii.y, radii.x);
     let start_angle = start_angle - PI / 2.;
     let end_angle = end_angle - PI / 2.;
 
-    // Ellipse arc length calculated through the incomplete elliptic integral of the second
-    // kind:
+    // The arc length is equal to radii.y * (E(end_angle | m) - E(start_angle | m)) with E the
+    // incomplete elliptic integral of the second kind and parameter
+    // m = 1 - (radii.x / radii.y)^2 = k^2. See also:
     // https://en.wikipedia.org/w/index.php?title=Ellipse&oldid=1248023575#Arc_length
 
     let m = 1. - (radii.x / radii.y).powi(2);

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -8,7 +8,10 @@ use crate::{
     Point, Rect, Shape, Vec2,
 };
 use core::{
-    f64::consts::{FRAC_PI_2, PI},
+    f64::{
+        self,
+        consts::{FRAC_PI_2, PI},
+    },
     iter,
     ops::{Mul, Range},
 };
@@ -205,11 +208,7 @@ impl ParamCurve for Arc {
 }
 
 impl ParamCurveArclen for Arc {
-    fn arclen(&self, _accuracy: f64) -> f64 {
-        // TODO: wire up accuracy. The Carlson numerical approximation provides a bound on the relative
-        // error
-        let relative_error = 1e-20;
-
+    fn arclen(&self, accuracy: f64) -> f64 {
         // Normalize ellipse to have radius y >= radius x, required for the parameter assumptions
         // of `incomplete_elliptic_integral_second_kind`.
         let (radii, mut start_angle) = if self.radii.y >= self.radii.x {
@@ -248,23 +247,43 @@ impl ParamCurveArclen for Arc {
         // that range.
         let mut arclen = 0.;
 
+        // The available accuracy (tolerance) is distributed over the calculation of the two
+        // incomplete and one complete elliptic integrals.
+        let accuracy_per_incomplete_integral = 1. / 3. * accuracy / radii.y;
         if start_angle >= PI / 2. {
-            arclen += incomplete_elliptic_integral_second_kind(relative_error, PI - start_angle, m);
+            arclen += incomplete_elliptic_integral_second_kind(
+                accuracy_per_incomplete_integral,
+                PI - start_angle,
+                m,
+            );
             quarter_turns -= 1.;
         } else {
-            arclen -= incomplete_elliptic_integral_second_kind(relative_error, start_angle, m);
+            arclen -= incomplete_elliptic_integral_second_kind(
+                accuracy_per_incomplete_integral,
+                start_angle,
+                m,
+            );
         }
 
         if end_angle >= PI / 2. {
-            arclen -= incomplete_elliptic_integral_second_kind(relative_error, PI - end_angle, m);
+            arclen -= incomplete_elliptic_integral_second_kind(
+                accuracy_per_incomplete_integral,
+                PI - end_angle,
+                m,
+            );
             quarter_turns += 1.;
         } else {
-            arclen += incomplete_elliptic_integral_second_kind(relative_error, end_angle, m);
+            arclen += incomplete_elliptic_integral_second_kind(
+                accuracy_per_incomplete_integral,
+                end_angle,
+                m,
+            );
         }
         arclen *= radii.y;
 
-        // Note: this uses the complete elliptic integral, which can be special-cased.
-        arclen += 0.25 * quarter_turns * complete_elliptic_perimeter(self.radii, relative_error);
+        arclen += 1. / 4.
+            * quarter_turns
+            * complete_elliptic_perimeter(radii, 1. / 4. / 3. * accuracy * quarter_turns.max(1.));
 
         arclen
     }
@@ -326,22 +345,49 @@ impl Mul<Arc> for Affine {
 /// elliptic integrals" (Carlson, Bille C.): <https://arxiv.org/abs/math/9409227v1>
 ///
 /// RF = 1/2 ∫ 1 / ( sqrt(t+x) sqrt(t+y) sqrt(t+z) ) dt from 0 to inf
-fn carlson_rf(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
+fn carlson_rf(accuracy: f64, x: f64, y: f64, z: f64) -> f64 {
     // At most one of (x, y, z) may be 0.
     debug_assert!((x == 0.) as u8 + (y == 0.) as u8 + (z == 0.) as u8 <= 1);
+
+    // This mostly follows "Numerical computation of real or complex elliptic integrals", but using
+    // an absolute upper error bound rather than a relative one.
+    //
+    // From "Numerical computation of real or complex elliptic integrals" we have
+    //
+    // X_n = (a_0 - x_0) / (4^n a_n)
+    // (and the same for variables (Y,y), (Z,z)).
+    //
+    // From "Computing Elliptic Integrals by Duplication" we have an upper error bound of
+    //
+    // |err_n| < a_n^(-1/2) epsilon_n^6 / (4 (1 - epsilon_n))
+    // with epsilon_n = max(X_n, Y_n, Z_n)
+    //                = max(a_0 - x_0, a_0 - y_0, a_0 - z_0) / (4^n a_n).
+    //
+    // Define e_0 = max(a_0 - x_0, a_0 - y_0, a_0 - z_0). Rewrite for ease of computation,
+    //
+    //    |err_n| < a_n^(-1/2) epsilon_n^6 / (4 (1 - epsilon_n))
+    //            = a_n^(-1/2) e_0^6 / (4^n a_n)^6 / (4 (1 - epsilon_n))
+    // -> |err_n| a_n^(1/2) (4^n a_n)^6  / e_0^6 < 1 / (4 (1 - epsilon_n))
+    // -> |err_n| a_n^(1/2) a_n^6 4^(6n + 1) / e_0^6 < 1 / (1 - epsilon_n)
+    // -> |err_n| a_n^(1/2) a_n^6 4^(6n + 1) / e_0^6 (1 - epsilon_n) < 1.
+    //
+    // To reach an error upper bound of `accuracy`, iterate until
+    // 1 <= accuracy * a_n^(1/2) a_n^6 4^(6n + 1) / e_0^6 (1 - epsilon_n).
 
     let mut x = x;
     let mut y = y;
     let mut z = z;
 
-    let a0 = (x + y + z) / 3.;
-    let mut q = (3. * relative_error).powf(-1. / 6.)
-        * (a0 - x).abs().max((a0 - y).abs()).max((a0 - z).abs());
+    let mut a = (x + y + z) / 3.;
 
-    let mut a = a0;
-    let mut m = 0;
+    // These are partial terms of the inequality derived above. The multiply by (powers of) 4 are
+    // performed per iteration for computational efficiency.
+    let mut e = a - x.min(y).min(z);
+    let mut r = accuracy * 4. * e.powi(-6);
+
+    // let mut q = 1. / (3. * f64::EPSILON).cbrt().sqrt() * (a - x.min(y).min(z));
     loop {
-        if q <= a.abs() {
+        if 1. <= r * a.powi(6) * a.sqrt() * (1. - e / a) {
             break;
         }
 
@@ -351,81 +397,114 @@ fn carlson_rf(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
         y = (y + lambda) / 4.;
         z = (z + lambda) / 4.;
 
-        q /= 4.;
-        m += 1;
+        r *= 4f64.powi(6);
+        e /= 4.;
     }
 
-    let x = (a0 - x) / 4f64.powi(m) * a;
-    let y = (a0 - y) / 4f64.powi(m) * a;
+    let x = 1. - x / a;
+    let y = 1. - y / a;
     let z = -x - y;
 
     let e2 = x * y - z.powi(2);
     let e3 = x * y * z;
 
-    1. / a.sqrt()
-        * (1. - 1. / 10. * e2 + 1. / 14. * e3 + 1. / 24. * e2.powi(2) - 3. / 44. * e2 * e3)
+    (1. + (-1. / 10. * e2 + 1. / 14. * e3 + 1. / 24. * e2.powi(2) - 3. / 44. * e2 * e3)) / a.sqrt()
 }
 
 /// Approximation of the Carlson RD function as defined in "Numerical computation of real or
 /// complex elliptic integrals" (Carlson, Bille C.): <https://arxiv.org/abs/math/9409227v1>
 ///
 /// RD = 3/2 ∫ 1 / ( sqrt(t+x) sqrt(t+y) (t+z)^(3/2) ) dt from 0 to inf
-fn carlson_rd(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
+fn carlson_rd(accuracy: f64, x: f64, y: f64, z: f64) -> f64 {
     // At most one of (x, y) may be 0, z must be nonzero.
     debug_assert!(z != 0.);
     debug_assert!(x != 0. || y != 0.);
+
+    // As above for RF, find the absolute upper error bound rather than a relative one, the
+    // derivation of which is along the same lines.
+    //
+    // Again,
+    //
+    // X_n = (a_0 - x_0) / (4^n a_n)
+    // (and the same for variables (Y,y), (Z,z)).
+    //
+    // From "Computing Elliptic Integrals by Duplication" we have
+    //
+    // |err_n| < 4^-n a_n^(-3/2) 3 epsilon_n^6 / (1 - epsilon_n)^(3/2)
+    // with epsilon_n = max(X_n, Y_n, Z_n)
+    //                = max(a_0 - x_0, a_0 - y_0, a_0 - z_0) / (4^n a_n).
+    //
+    // Define e_0 = max(a_0 - x_0, a_0 - y_0, a_0 - z_0). Rewriting for ease of computation,
+    //
+    // |err_n| < 4^-n a_n^(-3/2) 3 epsilon_n^6 / (1 - epsilon_n)^(3/2)
+    //         = 4^-n a_n^(-3/2) 3 e_0^6 / 4^(6n) a_n^6 / (1 - epsilon_n)^(3/2)
+    // -> |err_n| 4^(7n) a_n^(3/2) a_n^6 / (3 e_0^6) < 1 / (1 - epsilon_n)^(3/2)
+    // -> |err_n| 4^(7n) a_n^(3/2) a_n^6 (1/3) / e_0^6 < (1 / 1 - epsilon_n)^(3/2),
+    // raise to the power 2/3,
+    // -> |err_n|^(2/3) 4^(14/3 n) a_n a_n^4 (1/3)^(2/3) / e_0^4 < 1 / (1 - epsilon_n)
+    // -> |err_n|^(2/3) 4^(14/3 n) a_n^5 (1/3)^(2/3) / e_0^4 (1 - epsilon_n) < 1
+    //
+    // That means, to reach an error upper bound of `accuracy`, iterate until
+    // 1 <= accuracy^(2/3) 4^(14/3 n) a_n^5 (1/3)^(2/3) / e_0^4 (1 - epsilon)
 
     let mut x = x;
     let mut y = y;
     let mut z = z;
 
     let a0 = (x + y + 3. * z) / 5.;
-    let mut q = (relative_error / 4.).powf(-1. / 6.)
-        * (a0 - x).abs().max((a0 - y).abs()).max((a0 - z).abs());
+    let mut a = a0;
 
     let mut sum = 0.;
-    let mut a = a0;
-    let mut m = 0;
+    let mut mul = 1.;
+
+    // These are partial terms of the inequality derived above. The multiply by (powers of) 4 are
+    // performed per iteration for computational efficiency.
+    let mut e = a - x.min(y).min(z);
+    let mut r = (accuracy / 3.).powf(2. / 3.) * e.powi(-4);
+
     loop {
-        if q <= a.abs() {
+        if 1. <= r * a.powi(5) * (1. - e / a) {
             break;
         }
 
         let lambda = (x * y).sqrt() + (x * z).sqrt() + (y * z).sqrt();
-        sum += 4f64.powi(-m) / (z.sqrt() * (z + lambda));
+        sum += mul / (z.sqrt() * (z + lambda));
         a = (a + lambda) / 4.;
         x = (x + lambda) / 4.;
         y = (y + lambda) / 4.;
         z = (z + lambda) / 4.;
 
-        q /= 4.;
-        m += 1;
+        r *= 4f64.powf(14. / 3.);
+        e /= 4.;
+        mul /= 4.;
     }
 
-    let x = (a0 - x) / (4f64.powi(4) * a);
-    let y = (a0 - y) / (4f64.powi(4) * a);
-    let z = -(x + y) / 3.;
+    let x = 1. - x / a;
+    let y = 1. - y / a;
+    let z = (-x - y) / 3.;
 
     let e2 = x * y - 6. * z.powi(2);
     let e3 = (3. * x * y - 8. * z.powi(2)) * z;
-    let e4 = 3. * x * y - z.powi(2) * z.powi(2);
+    let e4 = 3. * (x * y - z.powi(2)) * z.powi(2);
     let e5 = x * y * z.powi(3);
 
-    4f64.powi(-m) * 1. / (a * a.sqrt())
-        * (1. - 3. / 14. * e2 + 1. / 6. * e3 + 9. / 88. * e2.powi(2)
-            - 3. / 22. * e4
-            - 9. / 52. * e2 * e3
-            + 3. / 26. * e5)
+    (1. - 3. / 14. * e2 + 1. / 6. * e3 + 9. / 88. * e2.powi(2) - 3. / 22. * e4 - 9. / 52. * e2 * e3
+        + 3. / 26. * e5)
+        * mul
+        / (a * a.sqrt())
         + 3. * sum
 }
 
 /// Numerically approximate the incomplete elliptic integral of the second kind from 0 to `phi`
 /// parameterized by `m = k^2` in Legendre's trigonometric form.
 ///
+/// The absolute error between the calculated integral and the true integral is bounded by
+/// `accuracy` (modulo floating point rounding errors).
+///
 /// Assumes:
 /// 0 <= phi <= pi / 2
 /// and 0 <= m sin^2(phi) <= 1
-fn incomplete_elliptic_integral_second_kind(relative_error: f64, phi: f64, m: f64) -> f64 {
+fn incomplete_elliptic_integral_second_kind(accuracy: f64, phi: f64, m: f64) -> f64 {
     // Approximate the incomplete elliptic integral through Carlson symmetric forms:
     // https://en.wikipedia.org/w/index.php?title=Carlson_symmetric_form&oldid=1223277638#Incomplete_elliptic_integrals
 
@@ -442,8 +521,25 @@ fn incomplete_elliptic_integral_second_kind(relative_error: f64, phi: f64, m: f6
     // note: this actually allows calculating from -1/2 pi <= phi <= 1/2 pi, but there are some
     // alternative translations from the Legendre form that are potentially better, that do
     // restrict the domain to 0 <= phi <= 1/2 pi.
-    sin * carlson_rf(relative_error, cos2, 1. - m * sin2, 1.)
-        - 1. / 3. * m * sin3 * carlson_rd(relative_error, cos2, 1. - m * sin2, 1.)
+    let term1 = if sin == 0. {
+        0.
+    } else {
+        sin * carlson_rf(
+            accuracy / (2. * sin),
+            // 1e-30,
+            cos2,
+            1. - m * sin2,
+            1.,
+        )
+    };
+
+    let term2 = if sin == 0. || m == 0. {
+        0.
+    } else {
+        1. / 3. * m * sin3 * carlson_rd(accuracy * 3. / 2. / (m * sin3), cos2, 1. - m * sin2, 1.)
+    };
+
+    term1 - term2
 }
 
 #[cfg(test)]
@@ -468,10 +564,6 @@ mod tests {
 
     #[test]
     fn length() {
-        // TODO: when arclen actually uses specified accuracy, update EPSILON and the accuracy
-        // params
-        const EPSILON: f64 = 1e-6;
-
         // Circular checks:
         for (start_angle, sweep_angle, length) in [
             (0., 1., 1.),
@@ -482,37 +574,35 @@ mod tests {
             (2.5, 10., 10.),
         ] {
             let a = Arc::new((0., 0.), (1., 1.), start_angle, sweep_angle, 0.);
-            let arc_length = a.arclen(0.000_1);
+            let arc_length = a.arclen(1e-7);
             assert!(
-                (arc_length - length).abs() <= EPSILON,
+                (arc_length - length).abs() <= 1e-6,
                 "Got arc length {arc_length}, expected {length} for circular arc {a:?}"
             );
         }
 
         let a = Arc::new((0., 0.), (1., 1.), 0., PI * 4., 0.);
-        assert!((a.arclen(0.000_1) - PI * 4.).abs() <= EPSILON);
+        assert!((a.arclen(1e-13) - PI * 4.).abs() <= 1e-12);
 
         let a = Arc::new((0., 0.), (2.23, 3.05), 0., 0.2, 0.);
-        assert!((a.arclen(0.000_1) - 0.60811714277).abs() <= EPSILON);
+        assert!((a.arclen(1e-13) - 0.608_117_142_773_153_8).abs() <= 1e-12);
 
         let a = Arc::new((0., 0.), (3.05, 2.23), 0., 0.2, 0.);
-        assert!((a.arclen(0.000_1) - 0.448555).abs() <= EPSILON);
+        assert!((a.arclen(1e-13) - 0.448_554_961_296_305_9).abs() <= 1e-12);
     }
 
     #[test]
     fn length_compare_with_bez_length() {
-        const EPSILON: f64 = 1e-3;
-
         for radii in [(1., 1.), (0.5, 1.), (2., 1.)] {
             for start_angle in [0., 0.5, 1., 2., PI, -1.] {
                 for sweep_angle in [0., 0.5, 1., 2., PI, -1.] {
                     let a = Arc::new((0., 0.), radii, start_angle, sweep_angle, 0.);
 
-                    let arc_length = a.arclen(0.000_1);
-                    let bez_length = a.path_segments(0.000_1).perimeter(0.000_1);
+                    let arc_length = a.arclen(1e-8);
+                    let bez_length = a.path_segments(1e-8).perimeter(1e-8);
 
                     assert!(
-                        (arc_length - bez_length).abs() < EPSILON,
+                        (arc_length - bez_length).abs() < 1e-7,
                         "Numerically approximated arc length ({arc_length}) does not match bezier segment perimeter length ({bez_length}) for arc {a:?}"
                         );
                 }
@@ -522,33 +612,27 @@ mod tests {
 
     #[test]
     fn carlson_numerical_checks() {
-        // TODO: relative bound on error doesn't seem to be quite correct yet, use a large epsilon
-        // for now
-        const EPSILON: f64 = 1e-6;
-
         // Numerical checks from section 3 of "Numerical computation of real or complex elliptic
         // integrals" (Carlson, Bille C.): https://arxiv.org/abs/math/9409227v1 (real-valued calls)
-        assert!((carlson_rf(1e-20, 1., 2., 0.) - 1.311_028_777_146_1).abs() <= EPSILON);
-        assert!((carlson_rf(1e-20, 2., 3., 4.) - 0.584_082_841_677_15).abs() <= EPSILON);
+        assert!((carlson_rf(1e-13, 1., 2., 0.) - 1.311_028_777_146_1).abs() <= 1e-12);
+        assert!((carlson_rf(1e-13, 2., 3., 4.) - 0.584_082_841_677_15).abs() <= 1e-12);
 
-        assert!((carlson_rd(1e-20, 0., 2., 1.) - 1.797_210_352_103_4).abs() <= EPSILON);
-        assert!((carlson_rd(1e-20, 2., 3., 4.) - 0.165_105_272_942_61).abs() <= EPSILON);
+        assert!((carlson_rd(1e-13, 0., 2., 1.) - 1.797_210_352_103_4).abs() <= 1e-12);
+        assert!((carlson_rd(1e-13, 2., 3., 4.) - 0.165_105_272_942_61).abs() <= 1e-12);
     }
 
     #[test]
     fn elliptic_e_numerical_checks() {
-        const EPSILON: f64 = 1e-6;
-
         for (phi, m, elliptic_e) in [
             (0.0, 0.0, 0.0),
             (0.5, 0.0, 0.5),
             (1.0, 0.0, 1.0),
             (0.0, 1.0, 0.0),
-            (1.0, 1.0, 0.84147098),
+            (1.0, 1.0, 0.841_470_984_807_896_5),
         ] {
-            let elliptic_e_approx = incomplete_elliptic_integral_second_kind(1e-20, phi, m);
+            let elliptic_e_approx = incomplete_elliptic_integral_second_kind(1e-13, phi, m);
             assert!(
-                (elliptic_e_approx - elliptic_e).abs() < EPSILON,
+                (elliptic_e_approx - elliptic_e).abs() < 1e-12,
                 "Approximated elliptic e {elliptic_e_approx} does not match known value {elliptic_e} for E({phi}|{m})"
             );
         }

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -220,10 +220,11 @@ impl ParamCurveArclen for Arc {
         // Normalize sweep angle to be non-negative
         let mut sweep_angle = self.sweep_angle;
         if sweep_angle < 0. {
-            start_angle = PI - start_angle;
+            start_angle = -start_angle;
             sweep_angle = -sweep_angle;
         }
 
+        // Normalize start angle to be on the upper half of the ellipse
         start_angle = start_angle.rem_euclid(PI);
 
         let mut arclen = 0.;

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -392,8 +392,8 @@ fn carlson_rd(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
         + 3. * sum
 }
 
-/// Numerically approximate the incomplete elliptic integral of the second kind
-/// parameterized by `phi` and `m = k^2` in Legendre's trigonometric form.
+/// Numerically approximate the incomplete elliptic integral of the second kind to `phi`
+/// parameterized by `m = k^2` in Legendre's trigonometric form.
 fn incomplete_elliptic_integral_second_kind(relative_error: f64, phi: f64, m: f64) -> f64 {
     // Approximate the incomplete elliptic integral through Carlson symmetric forms:
     // https://en.wikipedia.org/w/index.php?title=Carlson_symmetric_form&oldid=1223277638#Incomplete_elliptic_integrals

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -412,7 +412,7 @@ fn carlson_rd(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
         + 3. * sum
 }
 
-/// Numerically approximate the incomplete elliptic integral of the second kind to `phi`
+/// Numerically approximate the incomplete elliptic integral of the second kind from 0 to `phi`
 /// parameterized by `m = k^2` in Legendre's trigonometric form.
 ///
 /// Assumes:

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -231,10 +231,9 @@ impl ParamCurveArclen for Arc {
 
         // Normalize start angle to be on the upper half of the ellipse
         let start_angle = start_angle.rem_euclid(PI);
-
         let end_angle = start_angle + sweep_angle;
 
-        let mut quarter_turns = (end_angle / PI * 2.).trunc() - (start_angle / PI * 2.).trunc();
+        let mut quarter_turns = (2. / PI * end_angle).trunc() - (2. / PI * start_angle).trunc();
         let end_angle = end_angle % PI;
 
         // The elliptic arc length is equal to radii.y * (E(end_angle | m) - E(start_angle | m))

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -303,8 +303,10 @@ impl Mul<Arc> for Affine {
     }
 }
 
-/// Approximation of Carlson RF function as defined in "Numerical computation of real or complex
+/// Approximation of the Carlson RF function as defined in "Numerical computation of real or complex
 /// elliptic integrals" (Carlson, Bille C.): <https://arxiv.org/abs/math/9409227v1>
+///
+/// RF = 1/2 ∫ 1 / ( sqrt(t+x) sqrt(t+y) sqrt(t+z) ) dt from 0 to inf
 fn carlson_rf(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
     let mut x = x;
     let mut y = y;
@@ -342,8 +344,10 @@ fn carlson_rf(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
         * (1. - 1. / 10. * e2 + 1. / 14. * e3 + 1. / 24. * e2.powi(2) - 3. / 44. * e2 * e3)
 }
 
-/// Approximation of Carlson RD function as defined in "Numerical computation of real or complex
-/// elliptic integrals" (Carlson, Bille C.): <https://arxiv.org/abs/math/9409227v1>
+/// Approximation of the Carlson RD function as defined in "Numerical computation of real or
+/// complex elliptic integrals" (Carlson, Bille C.): <https://arxiv.org/abs/math/9409227v1>
+///
+/// RD = 3/2 ∫ 1 / ( sqrt(t+x) sqrt(t+y) (t+z)^(3/2) ) dt from 0 to inf
 fn carlson_rd(relative_error: f64, x: f64, y: f64, z: f64) -> f64 {
     let mut x = x;
     let mut y = y;

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -400,22 +400,13 @@ fn incomplete_elliptic_integral_second_kind(relative_error: f64, phi: f64, m: f6
     debug_assert!(m * phi.sin().powi(2) >= 0.);
     debug_assert!(m * phi.sin().powi(2) <= 1.);
 
-    phi.sin()
-        * carlson_rf(
-            relative_error,
-            phi.cos().powi(2),
-            1. - m * phi.sin().powi(2),
-            1.,
-        )
-        - 1. / 3.
-            * m
-            * phi.sin().powi(3)
-            * carlson_rd(
-                relative_error,
-                phi.cos().powi(2),
-                1. - m * phi.sin().powi(2),
-                1.,
-            )
+    let (sin, cos) = phi.sin_cos();
+    let sin2 = sin.powi(2);
+    let sin3 = sin.powi(3);
+    let cos2 = cos.powi(2);
+
+    sin * carlson_rf(relative_error, cos2, 1. - m * sin2, 1.)
+        - 1. / 3. * m * sin3 * carlson_rd(relative_error, cos2, 1. - m * sin2, 1.)
 }
 
 /// Calculate the length of an arc along an ellipse defined by `radii`, from `start_angle` to

--- a/src/common.rs
+++ b/src/common.rs
@@ -34,6 +34,9 @@ macro_rules! define_float_funcs {
             /// Special implementation for signum, because libm doesn't have it.
             fn signum(self) -> Self;
 
+            /// Special implementation for `rem_euclid`, because libm doesn't have it.
+            fn rem_euclid(self, rhs: Self) -> Self;
+
             $(fn $name(self $(,$arg: $arg_ty)*) -> $ret;)+
         }
 
@@ -48,6 +51,16 @@ macro_rules! define_float_funcs {
                     f32::NAN
                 } else {
                     1.0_f32.copysign(self)
+                }
+            }
+
+            #[inline]
+            fn rem_euclid(self, rhs: f32) -> f32 {
+                let r = self % rhs;
+                if r < 0.0 {
+                    r + rhs.abs()
+                } else {
+                    r
                 }
             }
 
@@ -70,6 +83,16 @@ macro_rules! define_float_funcs {
                     f64::NAN
                 } else {
                     1.0_f64.copysign(self)
+                }
+            }
+
+            #[inline]
+            fn rem_euclid(self, rhs: f64) -> f64 {
+                let r = self % rhs;
+                if r < 0.0 {
+                    r + rhs.abs()
+                } else {
+                    r
                 }
             }
 

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -243,7 +243,7 @@ impl Shape for Ellipse {
         // Note: the radii are calculated from an inner affine map (`self.inner`), and may be NaN.
         // Currently, constructing an ellipse with infinite radii will produce an ellipse whose
         // calculated radii are NaN.
-        if !self.radii().is_finite() {
+        if !radii.is_finite() {
             return f64::NAN;
         }
 

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -376,7 +376,7 @@ fn agm_elliptic_perimeter(accuracy: f64, radii: Vec2) -> f64 {
         Vec2::new(radii.y, radii.x)
     };
 
-    let accuracy = accuracy / (2. * PI * radii.x);
+    let accuracy = accuracy / (2. * PI * x);
 
     let mut sum = 1.;
     let mut a = 1.;
@@ -427,7 +427,7 @@ fn agm_elliptic_perimeter(accuracy: f64, radii: Vec2) -> f64 {
         a = a_next;
     }
 
-    2. * PI * radii.x / a * sum
+    2. * PI * x / a * sum
 }
 
 #[cfg(test)]

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -247,19 +247,7 @@ impl Shape for Ellipse {
             return f64::NAN;
         }
 
-        // Check for the trivial case where the ellipse has one of its radii equal to 0, i.e.,
-        // where it describes a line, as the numerical method used breaks down with this extreme.
-        if radii.x == 0. || radii.y == 0. {
-            return 4. * f64::max(radii.x, radii.y);
-        }
-
-        // Evaluate an approximation based on a truncated infinite series. If it returns a good
-        // enough value, we do not need to iterate.
-        if kummer_elliptic_perimeter_range(radii) <= accuracy {
-            return kummer_elliptic_perimeter(radii);
-        }
-
-        agm_elliptic_perimeter(accuracy, radii)
+        complete_elliptic_perimeter(radii, accuracy)
     }
 
     fn winding(&self, pt: Point) -> i32 {
@@ -302,6 +290,25 @@ impl Shape for Ellipse {
             y1: cy + range_y,
         }
     }
+}
+
+/// See [`Ellipse::perimeter`]. This is extracted to its own function for use by
+/// [`crate::Arc::perimeter`] without having to construct an [`Ellipse`].
+#[inline]
+pub(crate) fn complete_elliptic_perimeter(radii: Vec2, accuracy: f64) -> f64 {
+    // Check for the trivial case where the ellipse has one of its radii equal to 0, i.e.,
+    // where it describes a line, as the numerical method used breaks down with this extreme.
+    if radii.x == 0. || radii.y == 0. {
+        return 4. * f64::max(radii.x, radii.y);
+    }
+
+    // Evaluate an approximation based on a truncated infinite series. If it returns a good
+    // enough value, we do not need to iterate.
+    if kummer_elliptic_perimeter_range(radii) <= accuracy {
+        return kummer_elliptic_perimeter(radii);
+    }
+
+    agm_elliptic_perimeter(accuracy, radii)
 }
 
 /// Calculates circumference C of an ellipse with radii (x, y) as the infinite series


### PR DESCRIPTION
This is on top of PR https://github.com/linebender/kurbo/pull/378.

This implementation uses Carlson symmetric forms (https://arxiv.org/abs/math/9409227v1) of incomplete elliptic integrals of the second kind to numerically approximate elliptical arc lengths. These forms have nice computational properties allowing quick convergence of the approximations (each iteration reduces the error bound by 4⁶). Boost and Gnu Scientific Library are some other projects using them.

For the complete elliptic parts of the arc, the existing complete elliptic integral approximation (#383) is used.