### PR TITLE
Numerically approximate ellipse perimeter

### DIFF
--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -341,6 +341,9 @@ fn kummer_elliptic_perimeter(accuracy: f64, radii: Vec2) -> f64 {
         //
         // As 0 ≤ h ≤ 1, this is an upper bound.
         if binom_sq_sum_remainder * h_m <= accuracy {
+            // `sum` currently underestimates the true value - by adding the upper bound just
+            // calculated the result will overestimate the true value, but not by more than
+            // the desired accuracy.
             sum += binom_sq_sum_remainder * h_m;
             break;
         }

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -229,6 +229,13 @@ impl Shape for Ellipse {
         PI * x * y
     }
 
+    /// Approximate the ellipse perimeter.
+    ///
+    /// This uses a numerical approximation. The absolute error between the calculated perimeter
+    /// and the true perimeter is bounded by `accuracy`.
+    ///
+    /// For circular ellipses (equal horizontal and vertical radii), the calculated perimeter is
+    /// exact.
     #[inline]
     fn perimeter(&self, accuracy: f64) -> f64 {
         let radii = self.radii();
@@ -370,12 +377,13 @@ mod tests {
             let ellipse = Ellipse::new((0., 0.), (radius, radius), 0.);
 
             let circle_p = circle.perimeter(0.);
-            let ellipse_p = ellipse.perimeter(0.000_000_000_000_1);
+            let ellipse_p = ellipse.perimeter(0.1);
 
-            assert!(
-                 (circle_p - ellipse_p).abs() <= 0.000_000_000_000_1,
-                 "Expected circular ellipse radius {ellipse_p} to be equal to circle radius {circle_p} for radius {radius}"
-             );
+            assert_eq!(
+                circle_p,
+                ellipse_p,
+                "Expected circular ellipse radius {ellipse_p} to be equal to circle radius {circle_p} for radius {radius}"
+            );
         }
     }
 

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -401,34 +401,39 @@ fn agm_elliptic_perimeter(accuracy: f64, radii: Vec2) -> f64 {
     let mut c = (1. - g.powi(2)).sqrt();
     let mut mul = 0.5;
 
-    loop {
+    for m in 0.. {
         let c2 = c.powi(2);
         let term = mul * c2;
         sum -= term;
 
-        // We have c_(n+1) < 1/2 c_n
+        // We have c_(n+1) ≤ 1/2 c_n
         // (for a derivation, see e.g. section 2.1 of  "Elliptic integrals, the
         // arithmetic-geometric mean and the Brent-Salamin algorithm for π" by G.J.O. Jameson:
         // <https://web.archive.org/web/20241002140956/https://www.maths.lancs.ac.uk/jameson/ellagm.pdf>)
         //
         // Therefore
-        // ∑ 2^(i-1) c_i^2 from i = 0 ≤ ∑ 2^(i-1) ((1/2)^i c_0)^2 from i = 0
-        //                            = ∑ 2^-(i+1) c_0^2          from i = 0
-        //                            = c_0^2
+        // ∑ 2^(i-1) c_i^2 from i = 1 ≤ ∑ 2^(i-1) ((1/2)^i c_0)^2 from i = 1
+        //                            = ∑ 2^-(i+1) c_0^2          from i = 1
+        //                            = 1/2 c_0^2
         //
-        // or, for arbitrary starting point n > 0:
-        // ∑ 2^(i-1) c_i^2 from i = n ≤ ∑ 2^(i-1) ((1/2)^(i-n) c_n)^2 from i = n
-        //                            = ∑ 2^(2n - i - 1) c_n^2        from i = n
-        //                            = 2^n ∑ 2^(-(i+1)) c_n^2        from i = n
-        //                            = 2^n 2^(2-n) c_n^2
-        //                            = 4 c_n^2
+        // or, for arbitrary starting point i = n+1:
+        // ∑ 2^(i-1) c_i^2 from i = n+1 ≤ ∑ 2^(i-1) ((1/2)^(i-n) c_n)^2 from i = n+1
+        //                              = ∑ 2^(2n - i - 1) c_n^2        from i = n+1
+        //                              = 2^(2n) ∑ 2^(-(i+1)) c_n^2     from i = n+1
+        //                              = 2^(2n) 2^(-(n+1)) c_n^2
+        //                              = 2^(n-1) c_n^2
         //
-        // Therefore, the remainder of the series sums to less than 4 c_n^2.
-        if 4. * c2 <= accuracy {
+        // Therefore, the remainder of the series sums to less than or equal to 2^(n-1) c_n^2.
+        //
+        // Furthermore, a_inf ≥ g_n.
+        //
+        // TODO: is there a way to directly specify a power-of-two float, i.e., directly setting
+        // the exponent part?
+        if 2f64.powi(m - 1) / g * c2 <= accuracy {
             // `sum` currently overestimates the true value - subtract the upper bound of the
             // remaining series. We will then underestimate the true value, but by no more than
             // `accuracy`.
-            sum -= 4. * c2;
+            sum -= 2f64.powi(m - 1) * c2;
             break;
         }
 

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -326,15 +326,15 @@ fn kummer_elliptic_perimeter(radii: Vec2) -> f64 {
     let h5 = h4 * h;
     let h6 = h5 * h;
 
-    let lower = 1.
-        + h / 4.
-        + h2 / 64.
-        + h3 / 256.
-        + 25. * h4 / 16384.
-        + 49. * h5 / 65536.
-        + 441. * h6 / 1048576.;
+    let lower = PI
+        + h * (PI / 4.)
+        + h2 * (PI / 64.)
+        + h3 * (PI / 256.)
+        + h4 * (PI * 25. / 16384.)
+        + h5 * (PI * 49. / 65536.)
+        + h6 * (PI * 441. / 1048576.);
 
-    PI * (x + y) * lower
+    (x + y) * lower
 }
 
 /// This calculates the error range of [`kummer_elliptic_perimeter`]. That function returns a lower
@@ -360,9 +360,7 @@ fn kummer_elliptic_perimeter_range(radii: Vec2) -> f64 {
     const BINOM_SQUARED_REMAINDER: f64 = 0.00101416479131503;
     // = 4. / PI - (1. + 1. / 4. + 1. / 64. + 1. / 256. + 25. / 16384. + 49. / 65536. + 441. / 1048576.)
 
-    let remainder = BINOM_SQUARED_REMAINDER * h.powi(7);
-
-    PI * (x + y) * remainder
+    PI * BINOM_SQUARED_REMAINDER * h.powi(7) * (x + y)
 }
 
 /// Calculates circumference C of an ellipse with radii (x, y) using the arithmetic-geometric mean,

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -307,7 +307,7 @@ impl Shape for Ellipse {
     }
 }
 
-/// Calculates circumference C of an ellipse with radii (x, y) as the truncated infinite series
+/// Calculates circumference C of an ellipse with radii (x, y) as the infinite series
 ///
 /// C = pi (x+y) * ∑ binom(1/2, n)^2 * h^n from n = 0 to inf
 /// with h = (x - y)^2 / (x + y)^2
@@ -319,9 +319,9 @@ impl Shape for Ellipse {
 /// The series converges very quickly for ellipses with only moderate eccentricity (`h` not close
 /// to 1).
 ///
-/// The series is truncated to the sixth power. A lower bound of the value is returned. Adding the
-/// value of [`kummer_elliptic_perimeter_range`] to the value returned by this function calculates
-/// an upper bound on the value.
+/// The series is truncated to the sixth power, meaning a lower bound on the true value is
+/// returned. Adding the value of [`kummer_elliptic_perimeter_range`] to the value returned by this
+/// function calculates an upper bound on the true value.
 //
 // Note: Kurbo's minimum supported Rust version doesn't support const floating point arithmetic
 // yet, but this function can be made const on stable Rust.
@@ -383,7 +383,9 @@ fn kummer_elliptic_perimeter_range(radii: Vec2) -> f64 {
     PI * (x + y) * remainder
 }
 
-/// Calculates circumference C of an ellipse with radii (x, y) using the arithmetic-geometric mean.
+/// Calculates circumference C of an ellipse with radii (x, y) using the arithmetic-geometric mean,
+/// as described in equation 19.8.6 of
+/// <https://web.archive.org/web/20240926233336/https://dlmf.nist.gov/19.8#i>.
 fn agm_elliptic_perimeter(accuracy: f64, radii: Vec2) -> f64 {
     let Vec2 { x, y } = if radii.x >= radii.y {
         radii

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -450,9 +450,11 @@ mod tests {
             let circle_p = circle.perimeter(0.);
             let ellipse_p = ellipse.perimeter(0.1);
 
-            assert_eq!(
-                circle_p,
-                ellipse_p,
+            // We expect the results to be identical, modulo potential roundoff errors. Compare
+            // with a very small relative epsilon.
+            let epsilon = f64::EPSILON * 8. * circle_p.max(ellipse_p);
+            assert!(
+                (circle_p - ellipse_p).abs() <= epsilon,
                 "Expected circular ellipse radius {ellipse_p} to be equal to circle radius {circle_p} for radius {radius}"
             );
         }

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -304,8 +304,7 @@ impl Shape for Ellipse {
 /// as described by Kummer ("Über die Hypergeometrische Reihe", 1837) and rediscovered by
 /// Linderholm and Segal ("An Overlooked Series for the Elliptic Perimeter", 1995).
 ///
-/// This converges quadratically in the worst case, and converges very quickly for ellipses with
-/// only moderate eccentricity (`h` not close to 1).
+/// This converges very quickly for ellipses with only moderate eccentricity (`h` not close to 1).
 fn kummer_elliptic_perimeter(accuracy: f64, radii: Vec2) -> f64 {
     let Vec2 { x, y } = radii;
 

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -316,9 +316,6 @@ impl Shape for Ellipse {
 /// The series is truncated to the sixth power, meaning a lower bound on the true value is
 /// returned. Adding the value of [`kummer_elliptic_perimeter_range`] to the value returned by this
 /// function calculates an upper bound on the true value.
-//
-// Note: Kurbo's minimum supported Rust version doesn't support const floating point arithmetic
-// yet, but this function can be made const on stable Rust.
 #[inline]
 fn kummer_elliptic_perimeter(radii: Vec2) -> f64 {
     let Vec2 { x, y } = radii;
@@ -355,24 +352,15 @@ fn kummer_elliptic_perimeter(radii: Vec2) -> f64 {
 /// 4 / pi - ∑ binom(1/2, n)^2 for n = 0 to m-1
 ///
 /// As 0 ≤ h ≤ 1, this is an upper bound.
-//
-// Note: Kurbo's minimum supported Rust version doesn't support const floating point arithmetic
-// yet, but this function can be made const on stable Rust.
 #[inline]
 fn kummer_elliptic_perimeter_range(radii: Vec2) -> f64 {
     let Vec2 { x, y } = radii;
     let h = ((x - y) / (x + y)) * ((x - y) / (x + y));
-    let h2 = h * h;
-    let h3 = h2 * h;
-    let h4 = h3 * h;
-    let h5 = h4 * h;
-    let h6 = h5 * h;
-    let h7 = h6 * h;
 
     const BINOM_SQUARED_REMAINDER: f64 = 0.00101416479131503;
     // = 4. / PI - (1. + 1. / 4. + 1. / 64. + 1. / 256. + 25. / 16384. + 49. / 65536. + 441. / 1048576.)
 
-    let remainder = BINOM_SQUARED_REMAINDER * h7;
+    let remainder = BINOM_SQUARED_REMAINDER * h.powi(7);
 
     PI * (x + y) * remainder
 }

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -322,7 +322,7 @@ impl Shape for Ellipse {
 #[inline]
 fn kummer_elliptic_perimeter(radii: Vec2) -> f64 {
     let Vec2 { x, y } = radii;
-    let h = ((x - y) / (x + y)) * ((x - y) / (x + y));
+    let h = ((x - y) / (x + y)).powi(2);
     let h2 = h * h;
     let h3 = h2 * h;
     let h4 = h3 * h;
@@ -358,7 +358,7 @@ fn kummer_elliptic_perimeter(radii: Vec2) -> f64 {
 #[inline]
 fn kummer_elliptic_perimeter_range(radii: Vec2) -> f64 {
     let Vec2 { x, y } = radii;
-    let h = ((x - y) / (x + y)) * ((x - y) / (x + y));
+    let h = ((x - y) / (x + y)).powi(2);
 
     const BINOM_SQUARED_REMAINDER: f64 = 0.00101416479131503;
     // = 4. / PI - (1. + 1. / 4. + 1. / 64. + 1. / 256. + 25. / 16384. + 49. / 65536. + 441. / 1048576.)

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -244,12 +244,6 @@ impl Shape for Ellipse {
             return f64::NAN;
         }
 
-        // Check for the trivial case where the ellipse has radii (0,0), as the numerical method
-        // used breaks down with this extreme.
-        if radii == Vec2::ZERO {
-            return 0.;
-        }
-
         // Check for the trivial case where the ellipse has one of its radii equal to 0, i.e.,
         // where it describes a line, as the numerical method used breaks down with this extreme.
         if radii.x == 0. || radii.y == 0. {

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -459,7 +459,15 @@ mod tests {
     fn compare_perimeter_with_bez() {
         const EPSILON: f64 = 0.000_002;
 
-        for radii in [(0.5, 1.), (2., 1.), (0.000_000_1, 1.), (0., 1.), (1., 0.)] {
+        for radii in [
+            (0.5, 1.),
+            (2., 1.),
+            (0.000_000_1, 1.),
+            (0., 1.),
+            (1., 0.),
+            (-0.5, 1.),
+            (-0.000_000_1, -1.),
+        ] {
             let ellipse = Ellipse::new((0., 0.), radii, 0.);
 
             let ellipse_p = ellipse.perimeter(0.000_001);

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -422,7 +422,7 @@ fn agm_elliptic_perimeter(accuracy: f64, radii: Vec2) -> f64 {
         // which is exactly the value of the nth term.
         //
         // Furthermore, a_m ≥ g_n, and g_n ≤ 1, for all m, n.
-        if term / g <= accuracy {
+        if term <= accuracy * g {
             // `sum` currently overestimates the true value - subtract the upper bound of the
             // remaining series. We will then underestimate the true value, but by no more than
             // `accuracy`.

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -322,8 +322,11 @@ impl Shape for Ellipse {
 /// The series is truncated to the sixth power. A lower bound of the value is returned. Adding the
 /// value of [`kummer_elliptic_perimeter_range`] to the value returned by this function calculates
 /// an upper bound on the value.
+//
+// Note: Kurbo's minimum supported Rust version support const floating point arithmetic yet, but
+// this function can be made const on stable Rust.
 #[inline]
-const fn kummer_elliptic_perimeter(radii: Vec2) -> f64 {
+fn kummer_elliptic_perimeter(radii: Vec2) -> f64 {
     let Vec2 { x, y } = radii;
     let h = ((x - y) / (x + y)) * ((x - y) / (x + y));
     let h2 = h * h;
@@ -358,8 +361,11 @@ const fn kummer_elliptic_perimeter(radii: Vec2) -> f64 {
 /// 4 / pi - ∑ binom(1/2, n)^2 for n = 0 to m-1
 ///
 /// As 0 ≤ h ≤ 1, this is an upper bound.
+//
+// Note: Kurbo's minimum supported Rust version support const floating point arithmetic yet, but
+// this function can be made const on stable Rust.
 #[inline]
-const fn kummer_elliptic_perimeter_range(radii: Vec2) -> f64 {
+fn kummer_elliptic_perimeter_range(radii: Vec2) -> f64 {
     let Vec2 { x, y } = radii;
     let h = ((x - y) / (x + y)) * ((x - y) / (x + y));
     let h2 = h * h;
@@ -369,8 +375,9 @@ const fn kummer_elliptic_perimeter_range(radii: Vec2) -> f64 {
     let h6 = h5 * h;
     let h7 = h6 * h;
 
-    const BINOM_SQUARED_REMAINDER: f64 = 4. / PI
-        - (1. + 1. / 4. + 1. / 64. + 1. / 256. + 25. / 16384. + 49. / 65536. + 441. / 1048576.);
+    const BINOM_SQUARED_REMAINDER: f64 = 0.00101416479131503;
+    // = 4. / PI - (1. + 1. / 4. + 1. / 64. + 1. / 256. + 25. / 16384. + 49. / 65536. + 441. / 1048576.)
+
     let remainder = BINOM_SQUARED_REMAINDER * h7;
 
     PI * (x + y) * remainder

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -323,8 +323,8 @@ impl Shape for Ellipse {
 /// value of [`kummer_elliptic_perimeter_range`] to the value returned by this function calculates
 /// an upper bound on the value.
 //
-// Note: Kurbo's minimum supported Rust version support const floating point arithmetic yet, but
-// this function can be made const on stable Rust.
+// Note: Kurbo's minimum supported Rust version doesn't support const floating point arithmetic
+// yet, but this function can be made const on stable Rust.
 #[inline]
 fn kummer_elliptic_perimeter(radii: Vec2) -> f64 {
     let Vec2 { x, y } = radii;
@@ -362,8 +362,8 @@ fn kummer_elliptic_perimeter(radii: Vec2) -> f64 {
 ///
 /// As 0 ≤ h ≤ 1, this is an upper bound.
 //
-// Note: Kurbo's minimum supported Rust version support const floating point arithmetic yet, but
-// this function can be made const on stable Rust.
+// Note: Kurbo's minimum supported Rust version doesn't support const floating point arithmetic
+// yet, but this function can be made const on stable Rust.
 #[inline]
 fn kummer_elliptic_perimeter_range(radii: Vec2) -> f64 {
     let Vec2 { x, y } = radii;

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -357,7 +357,7 @@ mod tests {
             assert!(
                  (circle_p - ellipse_p).abs() <= 0.000_000_000_000_1,
                  "Expected circular ellipse radius {ellipse_p} to be equal to circle radius {circle_p} for radius {radius}"
-             )
+             );
         }
     }
 

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -240,7 +240,10 @@ impl Shape for Ellipse {
     fn perimeter(&self, accuracy: f64) -> f64 {
         let radii = self.radii();
 
-        if radii.is_nan() {
+        // Note: the radii are calculated from an inner affine map (`self.inner`), and may be NaN.
+        // Currently, constructing an ellipse with infinite radii will produce an ellipse whose
+        // calculated radii are NaN.
+        if !self.radii().is_finite() {
             return f64::NAN;
         }
 

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -412,11 +412,12 @@ fn agm_elliptic_perimeter(accuracy: f64, radii: Vec2) -> f64 {
         // <https://web.archive.org/web/20241002140956/https://www.maths.lancs.ac.uk/jameson/ellagm.pdf>)
         //
         // Therefore
-        // ∑ 2^(i-1) c_i^2 from i = 0 ≤ ∑ 2^(i-1) * ((1/2)^i c_0)^2
-        //                 = ∑ 2^-(i+1) * c_0^2
+        // ∑ 2^(i-1) c_i^2 from i = 0 ≤ ∑ 2^(i-1) ((1/2)^i c_0)^2 from i = 0
+        //                            = ∑ 2^-(i+1) c_0^2          from i = 0
+        //                            = c_0^2
         //
-        // or, for arbitrary starting point n:
-        // ∑ 2^(i-1) c_i^2 from i = n ≤ ∑ 2^(i-1) ((1/2)^(i-n) c_i)^2 from i = n
+        // or, for arbitrary starting point n > 0:
+        // ∑ 2^(i-1) c_i^2 from i = n ≤ ∑ 2^(i-1) ((1/2)^(i-n) c_n)^2 from i = n
         //                            = ∑ 2^(2n - i - 1) c_n^2        from i = n
         //                            = 2^n ∑ 2^(-(i+1)) c_n^2        from i = n
         //                            = 2^n 2^(2-n) c_n^2

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -232,7 +232,7 @@ impl Shape for Ellipse {
     /// Approximate the ellipse perimeter.
     ///
     /// This uses a numerical approximation. The absolute error between the calculated perimeter
-    /// and the true perimeter is bounded by `accuracy`.
+    /// and the true perimeter is bounded by `accuracy` (modulo floating point rounding errors).
     ///
     /// For circular ellipses (equal horizontal and vertical radii), the calculated perimeter is
     /// exact.

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -395,8 +395,9 @@ fn agm_elliptic_perimeter(accuracy: f64, radii: Vec2) -> f64 {
     let mut c = (1. - g.powi(2)).sqrt();
     let mut mul = 0.5;
 
-    for m in 0.. {
+    loop {
         let c2 = c.powi(2);
+        // term = 2^(n-1) c_n^2
         let term = mul * c2;
         sum -= term;
 
@@ -417,17 +418,15 @@ fn agm_elliptic_perimeter(accuracy: f64, radii: Vec2) -> f64 {
         //                              = 2^(2n) 2^(-(n+1)) c_n^2
         //                              = 2^(n-1) c_n^2
         //
-        // Therefore, the remainder of the series sums to less than or equal to 2^(n-1) c_n^2.
+        // Therefore, the remainder of the series sums to less than or equal to 2^(n-1) c_n^2,
+        // which is exactly the value of the nth term.
         //
-        // Furthermore, a_inf ≥ g_n.
-        //
-        // TODO: is there a way to directly specify a power-of-two float, i.e., directly setting
-        // the exponent part?
-        if 2f64.powi(m - 1) / g * c2 <= accuracy {
+        // Furthermore, a_m ≥ g_n, and g_n ≤ 1, for all m, n.
+        if term / g <= accuracy {
             // `sum` currently overestimates the true value - subtract the upper bound of the
             // remaining series. We will then underestimate the true value, but by no more than
             // `accuracy`.
-            sum -= 2f64.powi(m - 1) * c2;
+            sum -= term;
             break;
         }
 


### PR DESCRIPTION
This implements the (truncated) infinite series for the ellipse perimeter as described by Kummer (1837) and rediscovered by Linderholm and Segal (1995), and the iterative arithmetic-geometric mean method.

In the common case of ellipses that are only moderately eccentric and for "normal" accuracy (say, 0.001), the infinite series converges quickly. The series is known at compile-time, truncated to the 6th power. For a given ellipse and accuracy, a quick check is performed at runtime, to determine whether the truncated series' approximation is within the desired accuracy. If so, the truncated series is evaluated.

If the check determines the approximation is not good enough, the problem is handed to the iterative arithmetic-geometric mean method. This method converges quadratically for all cases.