### PR TITLE
Correctly calculate incenter in `Triangle::inscribed_circle`

### DIFF
--- a/src/triangle.rs
+++ b/src/triangle.rs
@@ -128,6 +128,8 @@ impl Triangle {
         let bc = self.b.distance(self.c);
         let ac = self.a.distance(self.c);
 
+        // [`Vec2::div`] also multiplies by the reciprocal of the argument, but as this reciprocal
+        // is reused below to calculate the radius, there's explicitly only one division needed.
         let perimeter_recip = 1. / (ab + bc + ac);
         let incenter = (self.a.to_vec2() * bc + self.b.to_vec2() * ac + self.c.to_vec2() * ab)
             * perimeter_recip;


### PR DESCRIPTION
The method erroneously calculated the circumcenter instead.

Tagging along on this PR are some changes to the triangle tests that I used to track down some issues. If desired I can bump these to a separate PR. The asserts testing approximate equality now take a relative epsilon, making them a bit more useful for testing values differing in orders of magnitude. I've also recalculated some of the test values to specify them at 17 significant digits (absolute limit of `f64`), and made the equality bounds tighter.