### PR TITLE
Reduce number of operations in `Triangle::circumscribed_circle`

### DIFF
--- a/src/triangle.rs
+++ b/src/triangle.rs
@@ -126,7 +126,7 @@ impl Triangle {
         let c = self.c - self.a;
         let b_len2 = b.hypot2();
         let c_len2 = c.hypot2();
-        let d_recip = 1. / (2. * b.cross(c));
+        let d_recip = 0.5 / b.cross(c);
 
         let x = (c.y * b_len2 - b.y * c_len2) * d_recip;
         let y = (b.x * c_len2 - c.x * b_len2) * d_recip;

--- a/src/triangle.rs
+++ b/src/triangle.rs
@@ -130,7 +130,7 @@ impl Triangle {
 
         let x = (c.y * b_len2 - b.y * c_len2) * d_recip;
         let y = (b.x * c_len2 - c.x * b_len2) * d_recip;
-        let r = b_len2.sqrt() * c_len2.sqrt() * (c - b).hypot() * d_recip;
+        let r = (b_len2 * c_len2).sqrt() * (c - b).hypot() * d_recip;
 
         Circle::new(self.a + Vec2::new(x, y), r)
     }


### PR DESCRIPTION
This is based on the simplified form for Cartesian coordinates in https://en.wikipedia.org/w/index.php?title=Circumcircle&oldid=1247179617#Cartesian_coordinates_2

Also adds a test to check the circle radius' sign is equal to the sign of the triangle's area.