### PR TITLE
chore: update MSRV to 1.74

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,
   # plus all the README.md files of the affected packages.
-  RUST_MIN_VER: "1.65"
+  RUST_MIN_VER: "1.74"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
   RUST_MIN_VER_PKGS: "-p kurbo"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find its changes [documented below](#0111-2024-09-12).
 
 ## [Unreleased]
 
-This release has an [MSRV][] of 1.65.
+This release has an [MSRV][] of 1.74.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,37 @@ edition = "2021"
 # TODO: When this hits 1.74, move lint configuration into this file via a lints table.
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the README.md file,
 # and with the MSRV in the `Unreleased` section of CHANGELOG.md.
-rust-version = "1.65"
+rust-version = "1.74"
 keywords = ["graphics", "curve", "curves", "bezier", "geometry"]
 repository = "https://github.com/linebender/kurbo"
 description = "A 2D curves library"
 readme = "README.md"
 categories = ["graphics"]
+
+[lints.rust]
+unsafe_code = "forbid"
+missing_docs = "warn"
+missing_debug_implementations = "warn"
+unused_crate_dependencies = "warn"
+future_incompatible = "warn"
+rust_2018_idioms = "warn"
+rust_2021_compatibility = "warn"
+
+[lints.clippy]
+all = "warn"
+pedantic = "warn"
+nursery = "warn"
+cargo = "warn"
+dbg_macro = "warn"
+todo = "warn"
+unimplemented = "warn"
+unwrap_used = "warn"
+unwrap_in_result = "warn"
+enum_glob_use = "warn"
+use_self = "warn"
+integer_arithmetic = "warn"
+match_on_vec_items = "warn"
+imprecise_flops = "warn"
 
 [package.metadata.docs.rs]
 features = ["mint", "schemars", "serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::print_stdout, clippy::print_stderr, clippy::dbg_macro)]
 // Copyright 2018 the Kurbo Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 


### PR DESCRIPTION
- Update Minimum Supported Rust Version (MSRV) to 1.74
- Modify Cargo.toml to reflect new MSRV
- Update CI configuration in .github/workflows/ci.yml
- Update CHANGELOG.md with MSRV change