### PR TITLE
ci: Update stable Rust to 1.82

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ env:
   # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
   # come automatically. If the version specified here is no longer the latest stable version,
   # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
-  RUST_STABLE_VER: "1.79" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
+  RUST_STABLE_VER: "1.82" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
   # The purpose of checking with the minimum supported Rust toolchain is to detect its staleness.
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ categories = ["graphics"]
 [package.metadata.docs.rs]
 features = ["mint", "schemars", "serde"]
 
+[lints]
+# This can be removed once we fix the benchmarks.
+rust.unexpected_cfgs = { level = "warn", check-cfg = ['cfg(nightly)'] }
+
 [features]
 default = ["std"]
 std = []


### PR DESCRIPTION
This adds a config to silence the lint about the unexpected_cfg in the benchmarks.