### PR TITLE
Match CI doc testing with docs.rs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,17 +260,17 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
 
-      # We test documentation using nightly to match docs.rs. This prevents potential breakages
+      # We test documentation using nightly to match docs.rs.
       - name: cargo doc
-        run: cargo doc --workspace --locked --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
+        run: cargo doc --workspace --locked --all-features --no-deps --document-private-items
         env:
-          RUSTDOCFLAGS: '--cfg docsrs'
+          RUSTDOCFLAGS: '--cfg docsrs -D warnings'
 
-  # If this fails, consider changing your text or adding something to .typos.toml
+  # If this fails, consider changing your text or adding something to .typos.toml.
   typos:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: check typos
-        uses: crate-ci/typos@v1.26.1
+        uses: crate-ci/typos@v1.27.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 categories = ["graphics"]
 
 [package.metadata.docs.rs]
-features = ["mint", "schemars", "serde"]
+all-features = true
 
 [lints]
 # This can be removed once we fix the benchmarks.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ categories = ["graphics"]
 
 [package.metadata.docs.rs]
 all-features = true
+# There are no platform specific docs.
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
 
 [lints]
 # This can be removed once we fix the benchmarks.

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -43,7 +43,7 @@ impl Affine {
     /// [Wikipedia](https://en.wikipedia.org/wiki/Affine_transformation)
     /// formulation of affine transformation as augmented matrix. The
     /// idea is that `(A * B) * v == A * (B * v)`, where `*` is the
-    /// [`Mul`](std::ops::Mul) trait.
+    /// [`Mul`] trait.
     #[inline]
     pub const fn new(c: [f64; 6]) -> Affine {
         Affine(c)

--- a/src/point.rs
+++ b/src/point.rs
@@ -14,7 +14,7 @@ use crate::common::FloatFuncs;
 
 /// A 2D point.
 ///
-/// This type represents a point in 2D space. It has the same layout as [`Vec2`][crate::Vec2], but
+/// This type represents a point in 2D space. It has the same layout as [`Vec2`], but
 /// its meaning is different: `Vec2` represents a change in location (for example velocity).
 ///
 /// In general, `kurbo` overloads math operators where it makes sense, for example implementing


### PR DESCRIPTION
* Remove `-Zunstable-options -Zrustdoc-scrape-examples` from CI. It wasn't even enabled for docs.rs and the examples we have lead to more noise than anything in the docs, so not worth enabling scraping at this point.
* Treat doc warnings as errors. Historically we've not done so due to various `rustdoc` bugs giving false positives but I got it to pass without failure right now, so perhaps better times have arrived.
* Pass `--all-features` at docs.rs to match our CI and reduce the maintenance burden of manually syncing the features list.
* Target only `x86_64-unknown-linux-gnu` on docs.rs as we don't have any platform specific docs.