### PR TITLE
Narrow and document the `getrandom` `js` feature usage.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,5 +61,7 @@ features = ["alloc", "derive"]
 [dev-dependencies]
 rand = "0.8.5"
 
-[target.'cfg(target_arch="wasm32")'.dev-dependencies]
+[target.wasm32-unknown-unknown.dev-dependencies]
+# We have a transitive dependency on getrandom and it does not automatically
+# support wasm32-unknown-unknown. We need to enable the js feature.
 getrandom = { version = "0.2.15", features = ["js"] }


### PR DESCRIPTION
As was pointed out in [velato#39](https://github.com/linebender/velato/pull/39) this `js` feature specification can be more narrow than all of `wasm32` and should also be documented.