### PR TITLE
Add Linebender lint set v2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.11.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-# TODO: When this hits 1.74, move lint configuration into this file via a lints table.
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the README.md file,
 # and with the MSRV in the `Unreleased` section of CHANGELOG.md.
 rust-version = "1.65"
@@ -21,8 +20,67 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [lints]
-# This can be removed once we fix the benchmarks.
+rust.unsafe_code = "forbid"
+
+# LINEBENDER LINT SET - Cargo.toml - v2
+# See https://linebender.org/wiki/canonical-lints/
+rust.keyword_idents_2024 = "forbid"
+rust.non_ascii_idents = "forbid"
+rust.non_local_definitions = "forbid"
+rust.unsafe_op_in_unsafe_fn = "forbid"
+
+rust.elided_lifetimes_in_paths = "warn"
+rust.let_underscore_drop = "warn"
+rust.missing_debug_implementations = "warn"
+rust.missing_docs = "warn"
+rust.single_use_lifetimes = "warn"
+rust.trivial_numeric_casts = "warn"
+# Setting check-cfg can be removed once we fix the benchmarks.
 rust.unexpected_cfgs = { level = "warn", check-cfg = ['cfg(nightly)'] }
+rust.unit_bindings = "warn"
+rust.unnameable_types = "warn"
+rust.unreachable_pub = "warn"
+rust.unused_import_braces = "warn"
+rust.unused_lifetimes = "warn"
+rust.unused_macro_rules = "warn"
+rust.unused_qualifications = "warn"
+rust.variant_size_differences = "warn"
+
+clippy.allow_attributes = "warn"
+clippy.allow_attributes_without_reason = "warn"
+clippy.cast_possible_truncation = "warn"
+clippy.collection_is_never_read = "warn"
+clippy.dbg_macro = "warn"
+clippy.debug_assert_with_mut_call = "warn"
+clippy.doc_markdown = "warn"
+clippy.exhaustive_enums = "warn"
+clippy.fn_to_numeric_cast_any = "forbid"
+clippy.infinite_loop = "warn"
+clippy.large_include_file = "warn"
+clippy.large_stack_arrays = "warn"
+clippy.match_same_arms = "warn"
+clippy.mismatching_type_param_order = "warn"
+clippy.missing_assert_message = "warn"
+clippy.missing_errors_doc = "warn"
+clippy.missing_fields_in_debug = "warn"
+clippy.missing_panics_doc = "warn"
+clippy.partial_pub_fields = "warn"
+clippy.return_self_not_must_use = "warn"
+clippy.same_functions_in_if_condition = "warn"
+clippy.semicolon_if_nothing_returned = "warn"
+clippy.shadow_unrelated = "warn"
+clippy.should_panic_without_expect = "warn"
+clippy.todo = "warn"
+clippy.trivially_copy_pass_by_ref = "warn"
+clippy.unseparated_literal_suffix = "warn"
+clippy.use_self = "warn"
+clippy.wildcard_imports = "warn"
+
+clippy.cargo_common_metadata = "warn"
+clippy.negative_feature_names = "warn"
+clippy.redundant_feature_names = "warn"
+clippy.wildcard_dependencies = "warn"
+# END LINEBENDER LINT SET
 
 [features]
 default = ["std"]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,13 @@
-# The default clippy value for this is 8 bytes, which is chosen to improve performance on 32-bit.
-# Given that kurbo is being designed for the future and already even mobile phones have 64-bit CPUs,
+# LINEBENDER LINT SET - .clippy.toml - v1
+# See https://linebender.org/wiki/canonical-lints/
+
+# The default Clippy value is capped at 8 bytes, which was chosen to improve performance on 32-bit.
+# Given that we are building for the future and even low-end mobile phones have 64-bit CPUs,
 # it makes sense to optimize for 64-bit and accept the performance hits on 32-bit.
 # 16 bytes is the number of bytes that fits into two 64-bit CPU registers.
 trivial-copy-size-limit = 16
+
+# END LINEBENDER LINT SET
+
 # Don't warn about these identifiers when using clippy::doc_markdown.
 doc-valid-idents = ["Direct2D", "PostScript", ".."]

--- a/examples/arclen_accuracy.rs
+++ b/examples/arclen_accuracy.rs
@@ -18,7 +18,7 @@ use kurbo::{ParamCurve, ParamCurveArclen, ParamCurveDeriv, QuadBez};
 use kurbo::common::{GAUSS_LEGENDRE_COEFFS_24, GAUSS_LEGENDRE_COEFFS_5, GAUSS_LEGENDRE_COEFFS_7};
 
 /// Calculate arclength using Gauss-Legendre quadrature using formula from Behdad
-/// in https://github.com/Pomax/BezierInfo-2/issues/77
+/// in <https://github.com/Pomax/BezierInfo-2/issues/77>
 fn gauss_arclen_3(q: QuadBez) -> f64 {
     let v0 = (-0.492943519233745 * q.p0.to_vec2()
         + 0.430331482911935 * q.p1.to_vec2()

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -12,10 +12,13 @@ fn main() {
     println!("<html>");
     println!("<body>");
     println!("<svg height=\"800\" width=\"800\">");
-    let path = circle.to_path(1e-3).to_svg();
-    println!("  <path d=\"{}\" stroke=\"black\" fill=\"none\" />", path);
-    let path = circle.to_path(1.0).to_svg();
-    println!("  <path d=\"{}\" stroke=\"red\" fill=\"none\" />", path);
+    let black_path = circle.to_path(1e-3).to_svg();
+    println!(
+        "  <path d=\"{}\" stroke=\"black\" fill=\"none\" />",
+        black_path
+    );
+    let red_path = circle.to_path(1.0).to_svg();
+    println!("  <path d=\"{}\" stroke=\"red\" fill=\"none\" />", red_path);
     println!("</svg>");
     println!("</body>");
     println!("</html>");

--- a/examples/cubic_arclen.rs
+++ b/examples/cubic_arclen.rs
@@ -8,13 +8,13 @@
 #![allow(clippy::unreadable_literal)]
 #![allow(clippy::many_single_char_names)]
 
-use kurbo::common::*;
+use kurbo::common::{GAUSS_LEGENDRE_COEFFS_11, GAUSS_LEGENDRE_COEFFS_7, GAUSS_LEGENDRE_COEFFS_9};
 use kurbo::{
     CubicBez, ParamCurve, ParamCurveArclen, ParamCurveCurvature, ParamCurveDeriv, Point, Vec2,
 };
 
 /// Calculate arclength using Gauss-Legendre quadrature using formula from Behdad
-/// in https://github.com/Pomax/BezierInfo-2/issues/77
+/// in <https://github.com/Pomax/BezierInfo-2/issues/77>
 fn gauss_arclen_5(c: CubicBez) -> f64 {
     let v0 = (c.p1 - c.p0).hypot() * 0.15;
     let v1 = (-0.558983582205757 * c.p0.to_vec2()

--- a/examples/ellipse.rs
+++ b/examples/ellipse.rs
@@ -13,10 +13,13 @@ fn main() {
     println!("<html>");
     println!("<body>");
     println!("<svg height=\"800\" width=\"800\" style=\"background-color: #999\">");
-    let path = ellipse.to_path(1e-3).to_svg();
-    println!("  <path d=\"{}\" stroke=\"black\" fill=\"none\" />", path);
-    let path = ellipse.to_path(1.0).to_svg();
-    println!("  <path d=\"{}\" stroke=\"red\" fill=\"none\" />", path);
+    let black_path = ellipse.to_path(1e-3).to_svg();
+    println!(
+        "  <path d=\"{}\" stroke=\"black\" fill=\"none\" />",
+        black_path
+    );
+    let red_path = ellipse.to_path(1.0).to_svg();
+    println!("  <path d=\"{}\" stroke=\"red\" fill=\"none\" />", red_path);
     println!("</svg>");
     println!("</body>");
     println!("</html>");

--- a/examples/fit_poly.rs
+++ b/examples/fit_poly.rs
@@ -41,14 +41,14 @@ impl ParamCurveFit for MyPoly {
     }
 }
 
-pub fn to_svg_economical(path: &BezPath) -> String {
+fn to_svg_economical(path: &BezPath) -> String {
     let mut buffer = Vec::new();
     write_to(path, &mut buffer).unwrap();
     String::from_utf8(buffer).unwrap()
 }
 
 /// Write the SVG representation of this path to the provided buffer.
-pub fn write_to<W: Write>(path: &BezPath, mut writer: W) -> std::io::Result<()> {
+fn write_to<W: Write>(path: &BezPath, mut writer: W) -> std::io::Result<()> {
     for el in path.elements() {
         match *el {
             PathEl::MoveTo(p) => write!(writer, "M{:.2} {:.2}", p.x, p.y)?,

--- a/examples/quad_intersect.rs
+++ b/examples/quad_intersect.rs
@@ -34,7 +34,7 @@ impl ImplicitQuad {
         let (u0, u1, u2) = (by - cy, cx - bx, bx * cy - by * cx);
         let (v0, v1, v2) = (cy - ay, ax - cx, cx * ay - cy * ax);
         let (w0, w1, w2) = (ay - by, bx - ax, ax * by - ay * bx);
-        ImplicitQuad {
+        Self {
             x2: 4. * u0 * w0 - v0 * v0,
             xy: 4. * (u0 * w1 + u1 * w0) - 2. * v0 * v1,
             y2: 4. * u1 * w1 - v1 * v1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,22 +66,51 @@
 //!
 //! [`libm`]: https://docs.rs/libm
 
-#![forbid(unsafe_code)]
-#![deny(missing_docs, clippy::trivially_copy_pass_by_ref)]
-#![warn(clippy::doc_markdown, rustdoc::broken_intra_doc_links)]
-#![warn(clippy::semicolon_if_nothing_returned)]
-#![warn(unused_qualifications)]
+// LINEBENDER LINT SET - lib.rs - v1
+// See https://linebender.org/wiki/canonical-lints/
+// These lints aren't included in Cargo.toml because they
+// shouldn't apply to examples and tests
+#![warn(unused_crate_dependencies)]
+#![warn(clippy::print_stdout, clippy::print_stderr)]
+// END LINEBENDER LINT SET
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![allow(
     clippy::unreadable_literal,
     clippy::many_single_char_names,
     clippy::excessive_precision,
     clippy::bool_to_int_with_if
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+// The following lints are part of the Linebender standard set,
+// but resolving them has been deferred for now.
+// Feel free to send a PR that solves one or more of these.
+#![allow(
+    missing_debug_implementations,
+    elided_lifetimes_in_paths,
+    single_use_lifetimes,
+    trivial_numeric_casts,
+    unnameable_types,
+    clippy::use_self,
+    clippy::return_self_not_must_use,
+    clippy::cast_possible_truncation,
+    clippy::wildcard_imports,
+    clippy::shadow_unrelated,
+    clippy::missing_assert_message,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::exhaustive_enums,
+    clippy::match_same_arms,
+    clippy::partial_pub_fields,
+    clippy::unseparated_literal_suffix,
+    clippy::duplicated_attributes
+)]
 
 #[cfg(not(any(feature = "std", feature = "libm")))]
 compile_error!("kurbo requires either the `std` or `libm` feature");
+
+// Suppress the unused_crate_dependencies lint when both std and libm are specified.
+#[cfg(all(feature = "std", feature = "libm"))]
+use libm as _;
 
 extern crate alloc;
 

--- a/src/quadspline.rs
+++ b/src/quadspline.rs
@@ -66,12 +66,12 @@ mod tests {
     use crate::{Point, QuadBez, QuadSpline};
 
     #[test]
-    pub fn no_points_no_quads() {
+    fn no_points_no_quads() {
         assert!(QuadSpline::new(Vec::new()).to_quads().next().is_none());
     }
 
     #[test]
-    pub fn one_point_no_quads() {
+    fn one_point_no_quads() {
         assert!(QuadSpline::new(vec![Point::new(1.0, 1.0)])
             .to_quads()
             .next()
@@ -79,7 +79,7 @@ mod tests {
     }
 
     #[test]
-    pub fn two_points_no_quads() {
+    fn two_points_no_quads() {
         assert!(
             QuadSpline::new(vec![Point::new(1.0, 1.0), Point::new(1.0, 1.0)])
                 .to_quads()
@@ -89,7 +89,7 @@ mod tests {
     }
 
     #[test]
-    pub fn three_points_same_quad() {
+    fn three_points_same_quad() {
         let p0 = Point::new(1.0, 1.0);
         let p1 = Point::new(2.0, 2.0);
         let p2 = Point::new(3.0, 3.0);
@@ -102,7 +102,7 @@ mod tests {
     }
 
     #[test]
-    pub fn four_points_implicit_on_curve() {
+    fn four_points_implicit_on_curve() {
         let p0 = Point::new(1.0, 1.0);
         let p1 = Point::new(3.0, 3.0);
         let p2 = Point::new(5.0, 5.0);

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -626,6 +626,13 @@ mod tests {
     }
 
     use rand::prelude::*;
+    // Suppress the unused_crate_dependencies lint for getrandom.
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    ))]
+    use getrandom as _;
 
     fn gen_random_path_sequence(rng: &mut impl Rng) -> Vec<PathSeg> {
         const MAX_LENGTH: u32 = 10;
@@ -640,23 +647,23 @@ mod tests {
 
             let first = position
                 .filter(|_| should_follow)
-                .unwrap_or_else(|| Point::new(rng.gen(), rng.gen()));
+                .unwrap_or_else(|| Point::new(rng.r#gen(), rng.r#gen()));
 
             let element: PathSeg = match kind {
-                0 => Line::new(first, Point::new(rng.gen(), rng.gen())).into(),
+                0 => Line::new(first, Point::new(rng.r#gen(), rng.r#gen())).into(),
 
                 1 => QuadBez::new(
                     first,
-                    Point::new(rng.gen(), rng.gen()),
-                    Point::new(rng.gen(), rng.gen()),
+                    Point::new(rng.r#gen(), rng.r#gen()),
+                    Point::new(rng.r#gen(), rng.r#gen()),
                 )
                 .into(),
 
                 2 => CubicBez::new(
                     first,
-                    Point::new(rng.gen(), rng.gen()),
-                    Point::new(rng.gen(), rng.gen()),
-                    Point::new(rng.gen(), rng.gen()),
+                    Point::new(rng.r#gen(), rng.r#gen()),
+                    Point::new(rng.r#gen(), rng.r#gen()),
+                    Point::new(rng.r#gen(), rng.r#gen()),
                 )
                 .into(),
 


### PR DESCRIPTION
Actually satisfying a good chunk of these lints is deferred and they are in an `allow` block in `lib.rs`.

Still, I did satisfy some of the lints.

The `rand` method `gen` has to be a raw `r#gen` until they publish a new version. They have that method renamed in [`master`](https://github.com/rust-random/rand).