### PR TITLE
Fix documentation of cross product; add convenience Vec2 methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,16 @@ This release has an [MSRV][] of 1.65.
 - `Stroke` is now `PartialEq`, `StrokeOpts` is now `Clone`, `Copy`, `Debug`, `Eq`, `PartialEq`. ([#379][] by [@waywardmonkeys][])
 - Implement `Sum` for `Vec2`. ([#399][] by [@Philipp-M][])
 - Add triangle shape. ([#350][] by [@juliapaci][])
+- Add `Vec2::turn_90` and `Vec2::rotate_scale` methods ([#409] by [@raphlinus][])
 
 ### Changed
 
 - Reduce number of operations in `Triangle::circumscribed_circle`. ([#390][] by [@tomcur][])
 - Numerically approximate ellipse perimeter. ([#383] by [@tomcur][])
+
+### Fixed
+
+- Fix documentation of cross product. ([#409] by [@raphlinus][])
 
 ## [0.11.1][] (2024-09-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Note: A changelog was not kept for or before this release
 [#388]: https://github.com/linebender/kurbo/pull/388
 [#390]: https://github.com/linebender/kurbo/pull/390
 [#399]: https://github.com/linebender/kurbo/pull/399
+[#409]: https://github.com/linebender/kurbo/pull/409
 
 [Unreleased]: https://github.com/linebender/kurbo/compare/v0.11.1...HEAD
 [0.11.0]: https://github.com/linebender/kurbo/releases/tag/v0.11.0

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -336,9 +336,9 @@ impl Vec2 {
     /// Combine two vectors interpreted as rotation and scaling.
     ///
     /// Interpret both vectors as a rotation and a scale, and combine
-    /// their effects. This operation is equivalent to multiplication
-    /// when the vectors are interpreted as complex numbers. It is
-    /// commutative.
+    /// their effects.  by adding the angles and multiplying the magnitudes.
+    /// This operation is equivalent to multiplication when the vectors
+    /// are interpreted as complex numbers. It is commutative.
     #[inline]
     pub fn rotate_scale(self, rhs: Vec2) -> Vec2 {
         Vec2::new(


### PR DESCRIPTION
I managed to get this wrong when I was trying to nail down the sign conventions, and it's been bothering me since I noticed it.

The PR adds a couple of simple convenience methods I find myself using quite a bit as I implement stroke expansion.

Note that a lot of methods can become const when we bump the MSRV, but that should happen separately.