### PR TITLE
Add an `INIFNITY` constant to `Size`.

### DIFF
--- a/src/size.rs
+++ b/src/size.rs
@@ -27,6 +27,9 @@ impl Size {
     /// A size with zero width or height.
     pub const ZERO: Size = Size::new(0., 0.);
 
+    /// A size with width and height set to `f64::INFINITY`.
+    pub const INFINITY: Size = Size::new(f64::INFINITY, f64::INFINITY);
+
     /// Create a new `Size` with the provided `width` and `height`.
     #[inline]
     pub const fn new(width: f64, height: f64) -> Self {


### PR DESCRIPTION
This pull request adds the `INFINITY` constant to `Size`.

```rust
const INFINITY: Size = Size::new(f64::INFINITY, f64::INFINITY);
```

I found myself writing a lot of infinite sizes manually to represent "no constraint", and thought it would be cleaner to have it as an associated constant instead.

# Potential questions

Is there any other constants we might want for `Size`? `INFINITY` is the only one I personally needed, but maybe there are others.