### PR TITLE
Update typos to 1.29.7, fix spelling of "collinear"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,4 +285,4 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: check typos
-        uses: crate-ci/typos@v1.28.1
+        uses: crate-ci/typos@v1.29.7

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -923,7 +923,7 @@ mod tests {
         verify((a * c).nearest(a * Point::new(0.1, 0.001), 1e-6), 0.1);
     }
 
-    // ensure to_quads returns something given colinear points
+    // ensure to_quads returns something given collinear points
     #[test]
     fn degenerate_to_quads() {
         let c = CubicBez::new((0., 9.), (6., 6.), (12., 3.0), (18., 0.0));


### PR DESCRIPTION
This was news to me about how that word is spelled. Interesting.