### PR TITLE
Add `with_capacity` to BezPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This release has an [MSRV][] of 1.65.
 - Implement `Sum` for `Vec2`. ([#399][] by [@Philipp-M][])
 - Add triangle shape. ([#350][] by [@juliapaci][])
 - Add `Vec2::turn_90` and `Vec2::rotate_scale` methods ([#409] by [@raphlinus][])
+- Add `BezPath::with_capacity` method ([#418] by [@LaurenzV][])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Note: A changelog was not kept for or before this release
 [@dominikh]: https://github.com/dominikh
 [@GabrielDertoni]: https://github.com/GabrielDertoni
 [@juliapaci]: https://github.com/juliapaci
+[@LaurenzV]: https://github.com/LaurenzV
 [@nils-mathieu]: https://github.com/nils-mathieu
 [@Philipp-M]: https://github.com/Philipp-M
 [@platlas]: https://github.com/platlas
@@ -102,6 +103,7 @@ Note: A changelog was not kept for or before this release
 [#390]: https://github.com/linebender/kurbo/pull/390
 [#399]: https://github.com/linebender/kurbo/pull/399
 [#409]: https://github.com/linebender/kurbo/pull/409
+[#418]: https://github.com/linebender/kurbo/pull/418
 
 [Unreleased]: https://github.com/linebender/kurbo/compare/v0.11.1...HEAD
 [0.11.0]: https://github.com/linebender/kurbo/releases/tag/v0.11.0

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -179,6 +179,14 @@ impl BezPath {
         Default::default()
     }
 
+    /// Create a new path with the specified capacity.
+    ///
+    /// This can be useful if you already know how many path elements the path
+    /// will consist of, to prevent reallocations.
+    pub fn with_capacity(capacity: usize) -> BezPath {
+        BezPath(Vec::with_capacity(capacity))
+    }
+
     /// Create a path from a vector of path elements.
     ///
     /// `BezPath` also implements `FromIterator<PathEl>`, so it works with `collect`:


### PR DESCRIPTION
The reason I want this is that it makes convert `usvg` paths to kurbo `BezPath` more efficient.