### PR TITLE
Always inline trivial casts, splats, and swizzles.

### DIFF
--- a/src/affine.rs
+++ b/src/affine.rs
@@ -44,20 +44,20 @@ impl Affine {
     /// formulation of affine transformation as augmented matrix. The
     /// idea is that `(A * B) * v == A * (B * v)`, where `*` is the
     /// [`Mul`] trait.
-    #[inline]
+    #[inline(always)]
     pub const fn new(c: [f64; 6]) -> Affine {
         Affine(c)
     }
 
     /// An affine transform representing uniform scaling.
-    #[inline]
+    #[inline(always)]
     pub const fn scale(s: f64) -> Affine {
         Affine([s, 0.0, 0.0, s, 0.0, 0.0])
     }
 
     /// An affine transform representing non-uniform scaling
     /// with different scale values for x and y
-    #[inline]
+    #[inline(always)]
     pub const fn scale_non_uniform(s_x: f64, s_y: f64) -> Affine {
         Affine([s_x, 0.0, 0.0, s_y, 0.0, 0.0])
     }
@@ -102,7 +102,7 @@ impl Affine {
     }
 
     /// An affine transform representing translation.
-    #[inline]
+    #[inline(always)]
     pub fn translate<V: Into<Vec2>>(p: V) -> Affine {
         let p = p.into();
         Affine([1.0, 0.0, 0.0, 1.0, p.x, p.y])
@@ -121,7 +121,7 @@ impl Affine {
     /// ```
     /// let oblique_transform = kurbo::Affine::skew(20f64.to_radians().tan(), 0.0);
     /// ```
-    #[inline]
+    #[inline(always)]
     pub fn skew(skew_x: f64, skew_y: f64) -> Affine {
         Affine([1.0, skew_y, skew_x, 1.0, 0.0, 0.0])
     }
@@ -302,7 +302,7 @@ impl Affine {
     }
 
     /// Get the coefficients of the transform.
-    #[inline]
+    #[inline(always)]
     pub fn as_coeffs(self) -> [f64; 6] {
         self.0
     }
@@ -415,7 +415,7 @@ impl Affine {
     }
 
     /// Returns the translation part of this affine map (`(self.0[4], self.0[5])`).
-    #[inline]
+    #[inline(always)]
     pub fn translation(self) -> Vec2 {
         Vec2 {
             x: self.0[4],
@@ -427,7 +427,7 @@ impl Affine {
     ///
     /// The translation can be seen as being applied after the linear part of the map.
     #[must_use]
-    #[inline]
+    #[inline(always)]
     pub fn with_translation(mut self, trans: Vec2) -> Affine {
         self.0[4] = trans.x;
         self.0[5] = trans.y;
@@ -436,7 +436,7 @@ impl Affine {
 }
 
 impl Default for Affine {
-    #[inline]
+    #[inline(always)]
     fn default() -> Affine {
         Affine::IDENTITY
     }
@@ -496,7 +496,7 @@ impl Mul<Affine> for f64 {
 // Conversions to and from mint
 #[cfg(feature = "mint")]
 impl From<Affine> for mint::ColumnMatrix2x3<f64> {
-    #[inline]
+    #[inline(always)]
     fn from(a: Affine) -> mint::ColumnMatrix2x3<f64> {
         mint::ColumnMatrix2x3 {
             x: mint::Vector2 {
@@ -517,7 +517,7 @@ impl From<Affine> for mint::ColumnMatrix2x3<f64> {
 
 #[cfg(feature = "mint")]
 impl From<mint::ColumnMatrix2x3<f64>> for Affine {
-    #[inline]
+    #[inline(always)]
     fn from(m: mint::ColumnMatrix2x3<f64>) -> Affine {
         Affine([m.x.x, m.x.y, m.y.x, m.y.y, m.z.x, m.z.y])
     }

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -33,6 +33,7 @@ pub struct Arc {
 
 impl Arc {
     /// Create a new `Arc`.
+    #[inline(always)]
     pub fn new(
         center: impl Into<Point>,
         radii: impl Into<Vec2>,

--- a/src/bezpath.rs
+++ b/src/bezpath.rs
@@ -175,6 +175,7 @@ pub struct MinDistance {
 
 impl BezPath {
     /// Create a new path.
+    #[inline(always)]
     pub fn new() -> BezPath {
         Default::default()
     }
@@ -272,11 +273,13 @@ impl BezPath {
     }
 
     /// Get the path elements.
+    #[inline(always)]
     pub fn elements(&self) -> &[PathEl] {
         &self.0
     }
 
     /// Get the path elements (mut version).
+    #[inline(always)]
     pub fn elements_mut(&mut self) -> &mut [PathEl] {
         &mut self.0
     }
@@ -1233,6 +1236,7 @@ impl PathSeg {
 }
 
 impl LineIntersection {
+    #[inline(always)]
     fn new(line_t: f64, segment_t: f64) -> Self {
         LineIntersection { line_t, segment_t }
     }
@@ -1268,18 +1272,21 @@ fn cubic_bez_coefs(x0: f64, x1: f64, x2: f64, x3: f64) -> (f64, f64, f64, f64) {
 }
 
 impl From<CubicBez> for PathSeg {
+    #[inline(always)]
     fn from(cubic_bez: CubicBez) -> PathSeg {
         PathSeg::Cubic(cubic_bez)
     }
 }
 
 impl From<Line> for PathSeg {
+    #[inline(always)]
     fn from(line: Line) -> PathSeg {
         PathSeg::Line(line)
     }
 }
 
 impl From<QuadBez> for PathSeg {
+    #[inline(always)]
     fn from(quad_bez: QuadBez) -> PathSeg {
         PathSeg::Quad(quad_bez)
     }
@@ -1296,6 +1303,7 @@ impl Shape for BezPath {
         self.clone()
     }
 
+    #[inline(always)]
     fn into_path(self, _tolerance: f64) -> BezPath {
         self
     }
@@ -1318,6 +1326,7 @@ impl Shape for BezPath {
         self.elements().bounding_box()
     }
 
+    #[inline(always)]
     fn as_path_slice(&self) -> Option<&[PathEl]> {
         Some(&self.0)
     }
@@ -1397,7 +1406,7 @@ impl<'a> Shape for &'a [PathEl] {
         segments(self.iter().copied()).bounding_box()
     }
 
-    #[inline]
+    #[inline(always)]
     fn as_path_slice(&self) -> Option<&[PathEl]> {
         Some(self)
     }
@@ -1437,7 +1446,7 @@ impl<const N: usize> Shape for [PathEl; N] {
         segments(self.iter().copied()).bounding_box()
     }
 
-    #[inline]
+    #[inline(always)]
     fn as_path_slice(&self) -> Option<&[PathEl]> {
         Some(self)
     }
@@ -1452,7 +1461,7 @@ pub struct PathSegIter {
 impl Shape for PathSeg {
     type PathElementsIter<'iter> = PathSegIter;
 
-    #[inline]
+    #[inline(always)]
     fn path_elements(&self, _tolerance: f64) -> PathSegIter {
         PathSegIter { seg: *self, ix: 0 }
     }
@@ -1469,6 +1478,7 @@ impl Shape for PathSeg {
         self.arclen(accuracy)
     }
 
+    #[inline(always)]
     fn winding(&self, _pt: Point) -> i32 {
         0
     }

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -27,7 +27,7 @@ pub struct Circle {
 
 impl Circle {
     /// A new circle from center and radius.
-    #[inline]
+    #[inline(always)]
     pub fn new(center: impl Into<Point>, radius: f64) -> Circle {
         Circle {
             center: center.into(),
@@ -36,6 +36,7 @@ impl Circle {
     }
 
     /// Create a [`CircleSegment`] by cutting out parts of this circle.
+    #[inline(always)]
     pub fn segment(self, inner_radius: f64, start_angle: f64, sweep_angle: f64) -> CircleSegment {
         CircleSegment {
             center: self.center,
@@ -153,6 +154,7 @@ impl Shape for Circle {
         Rect::new(x - r, y - r, x + r, y + r)
     }
 
+    #[inline(always)]
     fn as_circle(&self) -> Option<Circle> {
         Some(*self)
     }
@@ -212,6 +214,7 @@ pub struct CircleSegment {
 
 impl CircleSegment {
     /// Create a `CircleSegment` out of its constituent parts.
+    #[inline(always)]
     pub fn new(
         center: impl Into<Point>,
         outer_radius: f64,
@@ -230,7 +233,7 @@ impl CircleSegment {
 
     /// Return an arc representing the outer radius.
     #[must_use]
-    #[inline]
+    #[inline(always)]
     pub fn outer_arc(&self) -> Arc {
         Arc {
             center: self.center,

--- a/src/cubicbez.rs
+++ b/src/cubicbez.rs
@@ -55,7 +55,7 @@ pub enum CuspType {
 
 impl CubicBez {
     /// Create a new cubic Bézier segment.
-    #[inline]
+    #[inline(always)]
     pub fn new<P: Into<Point>>(p0: P, p1: P, p2: P, p3: P) -> CubicBez {
         CubicBez {
             p0: p0.into(),
@@ -491,6 +491,7 @@ impl Shape for CubicBez {
         }
     }
 
+    #[inline(always)]
     fn area(&self) -> f64 {
         0.0
     }
@@ -500,6 +501,7 @@ impl Shape for CubicBez {
         self.arclen(accuracy)
     }
 
+    #[inline(always)]
     fn winding(&self, _pt: Point) -> i32 {
         0
     }
@@ -567,12 +569,12 @@ impl ParamCurve for CubicBez {
         )
     }
 
-    #[inline]
+    #[inline(always)]
     fn start(&self) -> Point {
         self.p0
     }
 
-    #[inline]
+    #[inline(always)]
     fn end(&self) -> Point {
         self.p3
     }

--- a/src/ellipse.rs
+++ b/src/ellipse.rs
@@ -59,7 +59,7 @@ impl Ellipse {
     }
 
     /// Create an ellipse from an affine transformation of the unit circle.
-    #[inline]
+    #[inline(always)]
     pub fn from_affine(affine: Affine) -> Self {
         Ellipse { inner: affine }
     }
@@ -116,10 +116,9 @@ impl Ellipse {
     // Getters and setters.
 
     /// Returns the center of this ellipse.
-    #[inline]
+    #[inline(always)]
     pub fn center(&self) -> Point {
-        let Vec2 { x: cx, y: cy } = self.inner.translation();
-        Point { x: cx, y: cy }
+        self.inner.translation().to_point()
     }
 
     /// Returns the two radii of this ellipse.

--- a/src/insets.rs
+++ b/src/insets.rs
@@ -106,7 +106,7 @@ impl Insets {
     pub const ZERO: Insets = Insets::uniform(0.);
 
     /// New uniform insets.
-    #[inline]
+    #[inline(always)]
     pub const fn uniform(d: f64) -> Insets {
         Insets {
             x0: d,
@@ -117,7 +117,7 @@ impl Insets {
     }
 
     /// New insets with uniform values along each axis.
-    #[inline]
+    #[inline(always)]
     pub const fn uniform_xy(x: f64, y: f64) -> Insets {
         Insets {
             x0: x,
@@ -129,7 +129,7 @@ impl Insets {
 
     /// New insets. The ordering of the arguments is "left, top, right, bottom",
     /// assuming a y-down coordinate space.
-    #[inline]
+    #[inline(always)]
     pub const fn new(x0: f64, y0: f64, x1: f64, y1: f64) -> Insets {
         Insets { x0, y0, x1, y1 }
     }
@@ -315,18 +315,21 @@ impl Sub<Insets> for Rect {
 }
 
 impl From<f64> for Insets {
+    #[inline(always)]
     fn from(src: f64) -> Insets {
         Insets::uniform(src)
     }
 }
 
 impl From<(f64, f64)> for Insets {
+    #[inline(always)]
     fn from(src: (f64, f64)) -> Insets {
         Insets::uniform_xy(src.0, src.1)
     }
 }
 
 impl From<(f64, f64, f64, f64)> for Insets {
+    #[inline(always)]
     fn from(src: (f64, f64, f64, f64)) -> Insets {
         Insets::new(src.0, src.1, src.2, src.3)
     }

--- a/src/line.rs
+++ b/src/line.rs
@@ -26,7 +26,7 @@ pub struct Line {
 
 impl Line {
     /// Create a new line.
-    #[inline]
+    #[inline(always)]
     pub fn new(p0: impl Into<Point>, p1: impl Into<Point>) -> Line {
         Line {
             p0: p0.into(),
@@ -37,7 +37,7 @@ impl Line {
     /// Returns a copy of this `Line` with the end points swapped so that it
     /// points in the opposite direction.
     #[must_use]
-    #[inline]
+    #[inline(always)]
     pub fn reversed(&self) -> Line {
         Self {
             p0: self.p1,
@@ -91,12 +91,14 @@ impl Line {
 }
 
 impl From<(Point, Point)> for Line {
+    #[inline(always)]
     fn from((from, to): (Point, Point)) -> Self {
         Line::new(from, to)
     }
 }
 
 impl From<(Point, Vec2)> for Line {
+    #[inline(always)]
     fn from((origin, displacement): (Point, Vec2)) -> Self {
         Line::new(origin, origin + displacement)
     }
@@ -116,12 +118,12 @@ impl ParamCurve for Line {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     fn start(&self) -> Point {
         self.p0
     }
 
-    #[inline]
+    #[inline(always)]
     fn end(&self) -> Point {
         self.p1
     }
@@ -174,7 +176,7 @@ impl ParamCurveNearest for Line {
 }
 
 impl ParamCurveCurvature for Line {
-    #[inline]
+    #[inline(always)]
     fn curvature(&self, _t: f64) -> f64 {
         0.0
     }
@@ -212,12 +214,12 @@ impl ConstPoint {
 }
 
 impl ParamCurve for ConstPoint {
-    #[inline]
+    #[inline(always)]
     fn eval(&self, _t: f64) -> Point {
         self.0
     }
 
-    #[inline]
+    #[inline(always)]
     fn subsegment(&self, _range: Range<f64>) -> ConstPoint {
         *self
     }
@@ -226,19 +228,19 @@ impl ParamCurve for ConstPoint {
 impl ParamCurveDeriv for ConstPoint {
     type DerivResult = ConstPoint;
 
-    #[inline]
+    #[inline(always)]
     fn deriv(&self) -> ConstPoint {
         ConstPoint(Point::new(0.0, 0.0))
     }
 }
 
 impl ParamCurveArclen for ConstPoint {
-    #[inline]
+    #[inline(always)]
     fn arclen(&self, _accuracy: f64) -> f64 {
         0.0
     }
 
-    #[inline]
+    #[inline(always)]
     fn inv_arclen(&self, _arclen: f64, _accuracy: f64) -> f64 {
         0.0
     }
@@ -293,6 +295,7 @@ impl Shape for Line {
     /// only meaningful for closed shapes), but an argument can be made
     /// that the contract should be tightened to include the Green's
     /// theorem contribution.
+    #[inline(always)]
     fn area(&self) -> f64 {
         0.0
     }
@@ -303,16 +306,17 @@ impl Shape for Line {
     }
 
     /// Same consideration as `area`.
+    #[inline(always)]
     fn winding(&self, _pt: Point) -> i32 {
         0
     }
 
-    #[inline]
+    #[inline(always)]
     fn bounding_box(&self) -> Rect {
         Rect::from_points(self.p0, self.p1)
     }
 
-    #[inline]
+    #[inline(always)]
     fn as_line(&self) -> Option<Line> {
         Some(*self)
     }

--- a/src/point.rs
+++ b/src/point.rs
@@ -40,13 +40,13 @@ impl Point {
     pub const ORIGIN: Point = Point::new(0., 0.);
 
     /// Create a new `Point` with the provided `x` and `y` coordinates.
-    #[inline]
+    #[inline(always)]
     pub const fn new(x: f64, y: f64) -> Self {
         Point { x, y }
     }
 
     /// Convert this point into a `Vec2`.
-    #[inline]
+    #[inline(always)]
     pub const fn to_vec2(self) -> Vec2 {
         Vec2::new(self.x, self.y)
     }
@@ -205,7 +205,7 @@ impl Point {
 }
 
 impl From<(f32, f32)> for Point {
-    #[inline]
+    #[inline(always)]
     fn from(v: (f32, f32)) -> Point {
         Point {
             x: v.0 as f64,
@@ -215,14 +215,14 @@ impl From<(f32, f32)> for Point {
 }
 
 impl From<(f64, f64)> for Point {
-    #[inline]
+    #[inline(always)]
     fn from(v: (f64, f64)) -> Point {
         Point { x: v.0, y: v.1 }
     }
 }
 
 impl From<Point> for (f64, f64) {
-    #[inline]
+    #[inline(always)]
     fn from(v: Point) -> (f64, f64) {
         (v.x, v.y)
     }
@@ -319,7 +319,7 @@ impl fmt::Display for Point {
 
 #[cfg(feature = "mint")]
 impl From<Point> for mint::Point2<f64> {
-    #[inline]
+    #[inline(always)]
     fn from(p: Point) -> mint::Point2<f64> {
         mint::Point2 { x: p.x, y: p.y }
     }
@@ -327,7 +327,7 @@ impl From<Point> for mint::Point2<f64> {
 
 #[cfg(feature = "mint")]
 impl From<mint::Point2<f64>> for Point {
-    #[inline]
+    #[inline(always)]
     fn from(p: mint::Point2<f64>) -> Point {
         Point { x: p.x, y: p.y }
     }

--- a/src/quadspline.rs
+++ b/src/quadspline.rs
@@ -13,13 +13,13 @@ pub struct QuadSpline(Vec<Point>);
 
 impl QuadSpline {
     /// Construct a new `QuadSpline` from an array of [`Point`]s.
-    #[inline]
+    #[inline(always)]
     pub fn new(points: Vec<Point>) -> Self {
         Self(points)
     }
 
     /// Return the spline's control [`Point`]s.
-    #[inline]
+    #[inline(always)]
     pub fn points(&self) -> &[Point] {
         &self.0
     }
@@ -27,7 +27,7 @@ impl QuadSpline {
     /// Return an iterator over the implied [`QuadBez`] sequence.
     ///
     /// The returned quads are guaranteed to be G1 continuous.
-    #[inline]
+    #[inline(always)]
     pub fn to_quads(&self) -> impl Iterator<Item = QuadBez> + '_ {
         ToQuadBez {
             idx: 0,

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -31,7 +31,7 @@ impl Rect {
     pub const ZERO: Rect = Rect::new(0., 0., 0., 0.);
 
     /// A new rectangle from minimum and maximum coordinates.
-    #[inline]
+    #[inline(always)]
     pub const fn new(x0: f64, y0: f64, x1: f64, y1: f64) -> Rect {
         Rect { x0, y0, x1, y1 }
     }
@@ -142,7 +142,7 @@ impl Rect {
     ///
     /// This is the top left corner in a y-down space and with
     /// non-negative width and height.
-    #[inline]
+    #[inline(always)]
     pub fn origin(&self) -> Point {
         Point::new(self.x0, self.y0)
     }
@@ -613,6 +613,7 @@ impl Rect {
 }
 
 impl From<(Point, Point)> for Rect {
+    #[inline(always)]
     fn from(points: (Point, Point)) -> Rect {
         Rect::from_points(points.0, points.1)
     }
@@ -705,7 +706,7 @@ impl Shape for Rect {
         self.abs()
     }
 
-    #[inline]
+    #[inline(always)]
     fn as_rect(&self) -> Option<Rect> {
         Some(*self)
     }

--- a/src/rounded_rect.rs
+++ b/src/rounded_rect.rs
@@ -106,12 +106,13 @@ impl RoundedRect {
     }
 
     /// Radii of the rounded corners.
-    #[inline]
+    #[inline(always)]
     pub fn radii(&self) -> RoundedRectRadii {
         self.radii
     }
 
     /// The (non-rounded) rectangle.
+    #[inline(always)]
     pub fn rect(&self) -> Rect {
         self.rect
     }
@@ -119,7 +120,7 @@ impl RoundedRect {
     /// The origin of the rectangle.
     ///
     /// This is the top left corner in a y-down space.
-    #[inline]
+    #[inline(always)]
     pub fn origin(&self) -> Point {
         self.rect.origin()
     }
@@ -343,7 +344,7 @@ impl Shape for RoundedRect {
         self.rect.bounding_box()
     }
 
-    #[inline]
+    #[inline(always)]
     fn as_rounded_rect(&self) -> Option<RoundedRect> {
         Some(*self)
     }

--- a/src/rounded_rect_radii.rs
+++ b/src/rounded_rect_radii.rs
@@ -34,6 +34,7 @@ impl RoundedRectRadii {
     /// Create a new `RoundedRectRadii`. This function takes radius values for
     /// the four corners. The argument order is `top_left`, `top_right`,
     /// `bottom_right`, `bottom_left`, or clockwise starting from `top_left`.
+    #[inline(always)]
     pub const fn new(top_left: f64, top_right: f64, bottom_right: f64, bottom_left: f64) -> Self {
         RoundedRectRadii {
             top_left,
@@ -45,6 +46,7 @@ impl RoundedRectRadii {
 
     /// Create a new `RoundedRectRadii` from a single radius. The `radius`
     /// argument will be set as the radius for all four corners.
+    #[inline(always)]
     pub const fn from_single_radius(radius: f64) -> Self {
         RoundedRectRadii {
             top_left: radius,
@@ -107,12 +109,14 @@ impl RoundedRectRadii {
 }
 
 impl From<f64> for RoundedRectRadii {
+    #[inline(always)]
     fn from(radius: f64) -> Self {
         RoundedRectRadii::from_single_radius(radius)
     }
 }
 
 impl From<(f64, f64, f64, f64)> for RoundedRectRadii {
+    #[inline(always)]
     fn from(radii: (f64, f64, f64, f64)) -> Self {
         RoundedRectRadii::new(radii.0, radii.1, radii.2, radii.3)
     }

--- a/src/size.rs
+++ b/src/size.rs
@@ -31,7 +31,7 @@ impl Size {
     pub const INFINITY: Size = Size::new(f64::INFINITY, f64::INFINITY);
 
     /// Create a new `Size` with the provided `width` and `height`.
-    #[inline]
+    #[inline(always)]
     pub const fn new(width: f64, height: f64) -> Self {
         Size { width, height }
     }
@@ -140,7 +140,7 @@ impl Size {
 
     /// Convert this size into a [`Vec2`], with `width` mapped to `x` and `height`
     /// mapped to `y`.
-    #[inline]
+    #[inline(always)]
     pub const fn to_vec2(self) -> Vec2 {
         Vec2::new(self.width, self.height)
     }
@@ -263,7 +263,7 @@ impl Size {
     }
 
     /// Convert this `Size` into a [`Rect`] with origin `(0.0, 0.0)`.
-    #[inline]
+    #[inline(always)]
     pub const fn to_rect(self) -> Rect {
         Rect::new(0., 0., self.width, self.height)
     }
@@ -398,7 +398,7 @@ impl SubAssign<Size> for Size {
 }
 
 impl From<(f64, f64)> for Size {
-    #[inline]
+    #[inline(always)]
     fn from(v: (f64, f64)) -> Size {
         Size {
             width: v.0,
@@ -408,7 +408,7 @@ impl From<(f64, f64)> for Size {
 }
 
 impl From<Size> for (f64, f64) {
-    #[inline]
+    #[inline(always)]
     fn from(v: Size) -> (f64, f64) {
         (v.width, v.height)
     }

--- a/src/translate_scale.rs
+++ b/src/translate_scale.rs
@@ -50,26 +50,26 @@ pub struct TranslateScale {
 
 impl TranslateScale {
     /// Create a new transformation from translation and scale.
-    #[inline]
+    #[inline(always)]
     pub const fn new(translation: Vec2, scale: f64) -> TranslateScale {
         TranslateScale { translation, scale }
     }
 
     /// Create a new transformation with scale only.
-    #[inline]
+    #[inline(always)]
     pub const fn scale(s: f64) -> TranslateScale {
         TranslateScale::new(Vec2::ZERO, s)
     }
 
     /// Create a new transformation with translation only.
-    #[inline]
+    #[inline(always)]
     pub fn translate(translation: impl Into<Vec2>) -> TranslateScale {
         TranslateScale::new(translation.into(), 1.0)
     }
 
     /// Decompose transformation into translation and scale.
     #[deprecated(note = "use the struct fields directly")]
-    #[inline]
+    #[inline(always)]
     pub const fn as_tuple(self) -> (Vec2, f64) {
         (self.translation, self.scale)
     }
@@ -134,13 +134,14 @@ impl TranslateScale {
 }
 
 impl Default for TranslateScale {
-    #[inline]
+    #[inline(always)]
     fn default() -> TranslateScale {
         TranslateScale::new(Vec2::ZERO, 1.0)
     }
 }
 
 impl From<TranslateScale> for Affine {
+    #[inline(always)]
     fn from(ts: TranslateScale) -> Affine {
         let TranslateScale { translation, scale } = ts;
         Affine::new([scale, 0.0, 0.0, scale, translation.x, translation.y])

--- a/src/triangle.rs
+++ b/src/triangle.rs
@@ -45,7 +45,7 @@ impl Triangle {
     );
 
     /// A new [`Triangle`] from three vertices ([`Point`]s).
-    #[inline]
+    #[inline(always)]
     pub fn new(a: impl Into<Point>, b: impl Into<Point>, c: impl Into<Point>) -> Self {
         Self {
             a: a.into(),
@@ -57,7 +57,7 @@ impl Triangle {
     /// A new [`Triangle`] from three float vertex coordinates.
     ///
     /// Works as a constant [`Triangle::new`].
-    #[inline]
+    #[inline(always)]
     pub const fn from_coords(a: (f64, f64), b: (f64, f64), c: (f64, f64)) -> Self {
         Self {
             a: Point::new(a.0, a.1),

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -33,24 +33,25 @@ impl Vec2 {
     pub const ZERO: Vec2 = Vec2::new(0., 0.);
 
     /// Create a new vector.
-    #[inline]
+    #[inline(always)]
     pub const fn new(x: f64, y: f64) -> Vec2 {
         Vec2 { x, y }
     }
 
     /// Convert this vector into a [`Point`].
-    #[inline]
+    #[inline(always)]
     pub const fn to_point(self) -> Point {
         Point::new(self.x, self.y)
     }
 
     /// Convert this vector into a [`Size`].
-    #[inline]
+    #[inline(always)]
     pub const fn to_size(self) -> Size {
         Size::new(self.x, self.y)
     }
 
     /// Create a `Vec2` with the same value for x and y
+    #[inline(always)]
     pub(crate) const fn splat(v: f64) -> Self {
         Vec2 { x: v, y: v }
     }
@@ -349,14 +350,14 @@ impl Vec2 {
 }
 
 impl From<(f64, f64)> for Vec2 {
-    #[inline]
+    #[inline(always)]
     fn from(v: (f64, f64)) -> Vec2 {
         Vec2 { x: v.0, y: v.1 }
     }
 }
 
 impl From<Vec2> for (f64, f64) {
-    #[inline]
+    #[inline(always)]
     fn from(v: Vec2) -> (f64, f64) {
         (v.x, v.y)
     }
@@ -488,7 +489,7 @@ impl fmt::Display for Vec2 {
 // Conversions to and from mint
 #[cfg(feature = "mint")]
 impl From<Vec2> for mint::Vector2<f64> {
-    #[inline]
+    #[inline(always)]
     fn from(p: Vec2) -> mint::Vector2<f64> {
         mint::Vector2 { x: p.x, y: p.y }
     }
@@ -496,7 +497,7 @@ impl From<Vec2> for mint::Vector2<f64> {
 
 #[cfg(feature = "mint")]
 impl From<mint::Vector2<f64>> for Vec2 {
-    #[inline]
+    #[inline(always)]
     fn from(p: mint::Vector2<f64>) -> Vec2 {
         Vec2 { x: p.x, y: p.y }
     }


### PR DESCRIPTION
These functions are not even code, they only express changes in abstract type. Therefore, they should always be inlined (even in debug builds) because, being infallible, they will never be debugged.

rustc does not currently inline/eliminate these in debug builds, so they tend to contribute considerably to the size and slowness of debug builds.