### PR TITLE
Sketch out a constraint solver crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUST_MIN_VER: "1.65"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
-  RUST_MIN_VER_PKGS: "-p kurbo"
+  RUST_MIN_VER_PKGS: "-p kurbo -p kurbo_constraints"
   # List of features that depend on the standard library and will be excluded from no_std checks.
   FEATURES_DEPENDING_ON_STD: "std,default,schemars"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "getrandom"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +56,15 @@ dependencies = [
  "wasi",
  "wasm-bindgen",
  "windows-targets",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -80,6 +95,14 @@ dependencies = [
  "schemars",
  "serde",
  "smallvec",
+]
+
+[[package]]
+name = "kurbo_constraints"
+version = "0.11.1"
+dependencies = [
+ "hashbrown",
+ "kurbo",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["kurbo"]
+members = ["kurbo", "kurbo_constraints"]
 
 [workspace.package]
 # Kurbo version, also used by other packages which want to mimic Kurbo's version.

--- a/kurbo_constraints/Cargo.toml
+++ b/kurbo_constraints/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "kurbo_constraints"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "A constraint solver using Kurbo."
+keywords = ["constraints", "graphics", "cad"]
+categories = ["algorithms", "graphics"]
+repository.workspace = true
+rust-version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+# There are no platform specific docs.
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
+
+[lints]
+workspace = true
+
+[features]
+default = ["std"]
+std = ["kurbo/std"]
+libm = ["kurbo/libm"]
+
+[dependencies]
+hashbrown = { version = "0.15.2", default-features = false, features = ["default-hasher"] }
+kurbo.workspace = true

--- a/kurbo_constraints/LICENSE-APACHE
+++ b/kurbo_constraints/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/kurbo_constraints/LICENSE-MIT
+++ b/kurbo_constraints/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018 Raph Levien
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/kurbo_constraints/README.md
+++ b/kurbo_constraints/README.md
@@ -1,0 +1,65 @@
+<div align="center">
+
+# Kurbo Constraints
+
+**An experimental constraints system for Kurbo**
+
+[![Linebender Zulip, #kurbo channel](https://img.shields.io/badge/Linebender-%23kurbo-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/260979-kurbo)
+[![dependency status](https://deps.rs/repo/github/linebender/kurbo/status.svg)](https://deps.rs/repo/github/linebender/kurbo)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+[![Build status](https://github.com/linebender/kurbo/workflows/CI/badge.svg)](https://github.com/linebender/kurbo/actions)
+[![Crates.io](https://img.shields.io/crates/v/kurbo.svg)](https://crates.io/crates/kurbo)
+[![Docs](https://docs.rs/kurbo/badge.svg)](https://docs.rs/kurbo)
+
+</div>
+
+...
+
+The library is still in fairly early development stages.
+
+## Minimum supported Rust Version (MSRV)
+
+This version of Kurbo has been verified to compile with **Rust 1.65** and later.
+
+Future versions of Kurbo might increase the Rust version requirement.
+It will not be treated as a breaking change and as such can even happen with small patch releases.
+
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some of Kurbo's dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+
+</details>
+
+## Community
+
+[![Linebender Zulip](https://img.shields.io/badge/Linebender-%23kurbo-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/260979-kurbo)
+
+Discussion of Kurbo development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#kurbo channel](https://xi.zulipchat.com/#narrow/channel/260979-kurbo).
+All public content can be read without logging in.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
+Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be licensed as above, without any additional terms or conditions.
+
+[Rust Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[AUTHORS]: ./AUTHORS
+[CHANGELOG.md]: ./CHANGELOG.md

--- a/kurbo_constraints/src/constraint.rs
+++ b/kurbo_constraints/src/constraint.rs
@@ -1,0 +1,13 @@
+// Copyright 2025 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::{Handle, SolverError, SolverMeta, SolverState};
+use alloc::vec::Vec;
+
+pub trait Constraint: core::fmt::Debug {
+    fn apply(&self, state: &mut SolverState, meta: &SolverMeta) -> Result<(), SolverError>;
+    fn targets(&self, meta: &SolverMeta) -> Vec<Handle>;
+    fn type_name(&self) -> &'static str {
+        core::any::type_name::<Self>()
+    }
+}

--- a/kurbo_constraints/src/debuginfo.rs
+++ b/kurbo_constraints/src/debuginfo.rs
@@ -1,0 +1,12 @@
+// Copyright 2025 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::Handle;
+use alloc::vec::Vec;
+use hashbrown::HashMap;
+use kurbo::Point;
+
+#[derive(Debug, Default)]
+pub struct DebugInfo {
+    pub position_history: HashMap<Handle, Vec<Point>>,
+}

--- a/kurbo_constraints/src/handle.rs
+++ b/kurbo_constraints/src/handle.rs
@@ -1,0 +1,15 @@
+// Copyright 2025 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use core::sync::atomic::{AtomicU32, Ordering};
+
+static HANDLE_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Handle(u32);
+
+impl Handle {
+    pub fn new() -> Self {
+        Self(HANDLE_COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+}

--- a/kurbo_constraints/src/lib.rs
+++ b/kurbo_constraints/src/lib.rs
@@ -1,0 +1,35 @@
+// Copyright 2025 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Kurbo Constraints
+
+// LINEBENDER LINT SET - lib.rs - v3
+// See https://linebender.org/wiki/canonical-lints/
+// These lints shouldn't apply to examples or tests.
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+// These lints shouldn't apply to examples.
+#![warn(clippy::print_stdout, clippy::print_stderr)]
+// Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
+#![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
+// END LINEBENDER LINT SET
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![allow(
+    clippy::exhaustive_enums,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::new_without_default,
+    missing_docs
+)]
+#![no_std]
+
+extern crate alloc;
+
+mod constraint;
+mod debuginfo;
+mod handle;
+mod solver;
+
+pub use constraint::Constraint;
+pub use debuginfo::DebugInfo;
+pub use handle::Handle;
+pub use solver::{Solver, SolverError, SolverMeta, SolverState};

--- a/kurbo_constraints/src/solver.rs
+++ b/kurbo_constraints/src/solver.rs
@@ -1,0 +1,91 @@
+// Copyright 2025 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#![allow(dead_code)]
+
+use crate::{Constraint, DebugInfo, Handle};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use hashbrown::HashMap;
+use kurbo::Point;
+
+#[derive(Debug, Default)]
+pub struct Solver {
+    meta: SolverMeta,
+    state: SolverState,
+}
+
+#[derive(Debug)]
+pub struct SolverMeta {
+    constraints: Vec<Box<dyn Constraint>>,
+    tolerance: f64,
+    debug: DebugInfo,
+}
+
+#[derive(Debug, Default)]
+pub struct SolverState {
+    points: HashMap<Handle, Point>,
+}
+
+#[derive(Debug)]
+pub enum SolverError {
+    Diverged,
+    Infeasible,
+}
+
+impl Default for SolverMeta {
+    fn default() -> Self {
+        Self {
+            constraints: Vec::new(),
+            tolerance: 1e-6,
+            debug: DebugInfo::default(),
+        }
+    }
+}
+
+impl Solver {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_point(&mut self, pos: Point) -> Handle {
+        let handle = Handle::new();
+        self.state.points.insert(handle, pos);
+        handle
+    }
+
+    pub fn add_constraint(&mut self, constraint: impl Constraint + 'static) {
+        self.meta.constraints.push(Box::new(constraint));
+    }
+
+    pub fn solve(&mut self, iterations: usize) -> Result<(), SolverError> {
+        self.meta.debug.position_history.clear();
+
+        // Record initial state
+        for (handle, pos) in &self.state.points {
+            self.meta
+                .debug
+                .position_history
+                .entry(*handle)
+                .or_default()
+                .push(*pos);
+        }
+
+        for _ in 0..iterations {
+            for constraint in &self.meta.constraints {
+                constraint.apply(&mut self.state, &self.meta)?;
+            }
+
+            // Record positions
+            for (handle, pos) in &self.state.points {
+                self.meta
+                    .debug
+                    .position_history
+                    .get_mut(handle)
+                    .unwrap()
+                    .push(*pos);
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
This proposes the creation of a `kurbo_constraints` crate which is useful for CAD-style constraints (also useful in vector editors, graphics editors, etc.).

These would include:

* Coincident points
* Parallel lines
* Perpendicular lines
* Maintaining an angle
* Point on curve
* Tangents

There's a bunch of open questions ...

And things that will need to be added to this interface:
* Mark points as fixed / variable so the solver doesn't try to move everything
* Bring over the SVG debug visualization
* Name points for debug visualization and error reporting
* Provide error reporting
* Think about how to specify lines, curves, etc. (I have a couple of approaches locally.)

Right now, I've been writing with the Newton-Raphson method in the constraint implementations, but this may not be sufficient and we should consider multiple solver strategies. As such, it may make sense to rename `Solver` to `Problem` or something and allow for different solvers to tackle a given problem.