### PR TITLE
Avoid calling f64::hypot, it is slow

### DIFF
--- a/kurbo/src/vec2.rs
+++ b/kurbo/src/vec2.rs
@@ -93,7 +93,8 @@ impl Vec2 {
     /// ```
     #[inline]
     pub fn hypot(self) -> f64 {
-        self.x.hypot(self.y)
+        // Avoid f64::hypot as it calls a slow library function.
+        self.hypot2().sqrt()
     }
 
     /// Magnitude of vector.


### PR DESCRIPTION
This PR changes the Vec2 hypot function to avoid calling f64::hypot.

While profiling Vello, I found that hypot was taking up a lot of time in the flamegraph. It turns out that f64::hypot calls a slow C standard library function which is much more complex than a simple dot-product, add, and square-root. The extra complexity most likely comes from how the C hypot function is designed to avoid "undue overflow or underflow at intermediate stages of the computation."

With this change, the vello_hybrid_winit example runs at a conspicuously better framerate.