### PR TITLE
Fix `clippy::mismatched_lifetime_syntaxes` lints

### DIFF
--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -649,7 +649,7 @@ fn dash_impl<T: Iterator<Item = PathEl>>(
     inner: T,
     dash_offset: f64,
     dashes: &[f64],
-) -> DashIterator<T> {
+) -> DashIterator<'_, T> {
     let mut dash_ix = 0;
     let mut dash_remaining = dashes[dash_ix] - dash_offset;
     let mut is_active = true;

--- a/kurbo/src/svg.rs
+++ b/kurbo/src/svg.rs
@@ -283,7 +283,7 @@ struct SvgLexer<'a> {
 }
 
 impl SvgLexer<'_> {
-    fn new(data: &str) -> SvgLexer {
+    fn new(data: &str) -> SvgLexer<'_> {
         SvgLexer {
             data,
             ix: 0,


### PR DESCRIPTION
This is new in nightly.