### PR TITLE
Add `point_on_shape`

### DIFF
--- a/kurbo/src/bezpath.rs
+++ b/kurbo/src/bezpath.rs
@@ -820,6 +820,10 @@ impl<I: Iterator<Item = PathEl>> Segments<I> {
         self.map(|seg| seg.winding(p)).sum()
     }
 
+    pub(crate) fn point_on_shape(mut self, p: Point, tolerance: f64) -> bool {
+        self.any(|seg| seg.point_on_shape(p, tolerance))
+    }
+
     // Same
     pub(crate) fn bounding_box(self) -> Rect {
         let mut bbox: Option<Rect> = None;
@@ -1486,6 +1490,14 @@ impl Shape for PathSeg {
     #[inline]
     fn bounding_box(&self) -> Rect {
         ParamCurveExtrema::bounding_box(self)
+    }
+
+    fn point_on_shape(&self, pt: Point, tolerance: f64) -> bool {
+        match self {
+            PathSeg::Line(line) => line.point_on_shape(pt, tolerance),
+            PathSeg::Quad(quad_bez) => quad_bez.point_on_shape(pt, tolerance),
+            PathSeg::Cubic(cubic_bez) => cubic_bez.point_on_shape(pt, tolerance),
+        }
     }
 
     fn as_line(&self) -> Option<Line> {

--- a/kurbo/src/circle.rs
+++ b/kurbo/src/circle.rs
@@ -158,6 +158,10 @@ impl Shape for Circle {
     fn as_circle(&self) -> Option<Circle> {
         Some(*self)
     }
+
+    fn point_on_shape(&self, pt: Point, tolerance: f64) -> bool {
+        (Point::distance(self.center, pt) - self.radius).abs() <= tolerance
+    }
 }
 
 impl Iterator for CirclePathIter {

--- a/kurbo/src/cubicbez.rs
+++ b/kurbo/src/cubicbez.rs
@@ -506,6 +506,10 @@ impl Shape for CubicBez {
         0
     }
 
+    fn point_on_shape(&self, pt: Point, tolerance: f64) -> bool {
+        self.nearest(pt, tolerance).distance_sq.sqrt() <= tolerance
+    }
+
     #[inline]
     fn bounding_box(&self) -> Rect {
         ParamCurveExtrema::bounding_box(self)

--- a/kurbo/src/line.rs
+++ b/kurbo/src/line.rs
@@ -13,6 +13,9 @@ use crate::{
     DEFAULT_ACCURACY, MAX_EXTREMA,
 };
 
+#[cfg(not(feature = "std"))]
+use crate::common::FloatFuncs;
+
 /// A single line.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -319,6 +322,10 @@ impl Shape for Line {
     #[inline(always)]
     fn as_line(&self) -> Option<Line> {
         Some(*self)
+    }
+
+    fn point_on_shape(&self, pt: Point, tolerance: f64) -> bool {
+        self.nearest(pt, tolerance).distance_sq.sqrt() <= tolerance
     }
 }
 

--- a/kurbo/src/quadbez.rs
+++ b/kurbo/src/quadbez.rs
@@ -139,6 +139,10 @@ impl Shape for QuadBez {
         0
     }
 
+    fn point_on_shape(&self, pt: Point, tolerance: f64) -> bool {
+        self.nearest(pt, tolerance).distance_sq.sqrt() <= tolerance
+    }
+
     #[inline]
     fn bounding_box(&self) -> Rect {
         ParamCurveExtrema::bounding_box(self)

--- a/kurbo/src/rect.rs
+++ b/kurbo/src/rect.rs
@@ -907,4 +907,25 @@ mod tests {
         let inner = Rect::new(11.0, 11.0, 15.0, 15.0);
         assert!(!outer.contains_rect(inner));
     }
+
+    #[test]
+    fn test_point_on_shape() {
+        let rect = Rect::from_origin_size((0., 0.), (20., 20.));
+        let tol = 1e-5;
+        assert!(rect.point_on_shape(Point::new(0.0, 0.0), tol));
+        assert!(rect.point_on_shape(Point::new(10.0, 0.0), tol));
+        assert!(rect.point_on_shape(Point::new(20.0, 0.0), tol));
+        assert!(rect.point_on_shape(Point::new(20.0, 10.0), tol));
+        assert!(rect.point_on_shape(Point::new(20.0, 20.0), tol));
+        assert!(rect.point_on_shape(Point::new(10.0, 20.0), tol));
+        assert!(rect.point_on_shape(Point::new(0.0, 20.0), tol));
+        assert!(rect.point_on_shape(Point::new(0.0, 10.0), tol));
+
+        assert!(!rect.point_on_shape(Point::new(10.0, 10.0), tol));
+        assert!(rect.point_on_shape(Point::new(10.0, 10.0), 10.));
+        assert!(!rect.point_on_shape(Point::new(10.0, -0.01), tol));
+        assert!(!rect.point_on_shape(Point::new(10.0, 20.01), tol));
+        assert!(!rect.point_on_shape(Point::new(-0.01, 10.0), tol));
+        assert!(!rect.point_on_shape(Point::new(20.01, 10.0), tol));
+    }
 }

--- a/kurbo/src/shape.rs
+++ b/kurbo/src/shape.rs
@@ -152,6 +152,15 @@ pub trait Shape {
         self.winding(pt) != 0
     }
 
+    /// Returns `true` if the [`Point`] is on the edge/bound of the shape
+    /// within provided tolerance.
+    ///
+    /// In worst case we create path segments with provided tolerance
+    /// and check if point lies on any of the segments (within the same tolerance).
+    fn point_on_shape(&self, pt: Point, tolerance: f64) -> bool {
+        self.path_segments(tolerance).point_on_shape(pt, tolerance)
+    }
+
     /// The smallest rectangle that encloses the shape.
     fn bounding_box(&self) -> Rect;
 
@@ -240,5 +249,9 @@ impl<'a, T: Shape> Shape for &'a T {
 
     fn as_path_slice(&self) -> Option<&[PathEl]> {
         (*self).as_path_slice()
+    }
+
+    fn point_on_shape(&self, pt: Point, tolerance: f64) -> bool {
+        (*self).point_on_shape(pt, tolerance)
     }
 }


### PR DESCRIPTION
For most of shapes we simply create path segments with provided tolerance and check if point lies on any of the segments (within the same tolerance). This means we need real implementation at least for `PathSeg` and consequently for `Line`, `Curve`, `QuadCurve`, using `nearest`. In the future we could create more specialized implementations.

Fix #455 