### PR TITLE
Move `rem_euclid` impl to `FloatFuncs`

### DIFF
--- a/kurbo/src/common.rs
+++ b/kurbo/src/common.rs
@@ -31,8 +31,9 @@ macro_rules! define_float_funcs {
         /// For documentation see the respective functions in the std library.
         #[cfg(not(feature = "std"))]
         pub trait FloatFuncs : Sized + sealed::FloatFuncsSealed {
-            /// Special implementation for signum, because libm doesn't have it.
+            /// Special implementations, because libm doesn't have them.
             fn signum(self) -> Self;
+            fn rem_euclid(self, rhs: Self) -> Self;
 
             $(fn $name(self $(,$arg: $arg_ty)*) -> $ret;)+
         }
@@ -48,6 +49,16 @@ macro_rules! define_float_funcs {
                     f32::NAN
                 } else {
                     1.0_f32.copysign(self)
+                }
+            }
+
+            #[inline]
+            fn rem_euclid(self, rhs: Self) -> Self {
+                let r = self % rhs;
+                if r < 0.0 {
+                    r + rhs.abs()
+                } else {
+                    r
                 }
             }
 
@@ -70,6 +81,16 @@ macro_rules! define_float_funcs {
                     f64::NAN
                 } else {
                     1.0_f64.copysign(self)
+                }
+            }
+
+            #[inline]
+            fn rem_euclid(self, rhs: Self) -> Self {
+                let r = self % rhs;
+                if r < 0.0 {
+                    r + rhs.abs()
+                } else {
+                    r
                 }
             }
 

--- a/kurbo/src/common.rs
+++ b/kurbo/src/common.rs
@@ -18,6 +18,9 @@ mod sealed {
 use arrayvec::ArrayVec;
 
 /// Defines a trait that chooses between libstd or libm implementations of float methods.
+///
+/// Some methods will eventually became available in core by
+/// [`core_float_math`](https://github.com/rust-lang/rust/issues/137578)
 macro_rules! define_float_funcs {
     ($(
         fn $name:ident(self $(,$arg:ident: $arg_ty:ty)*) -> $ret:ty

--- a/kurbo/src/common.rs
+++ b/kurbo/src/common.rs
@@ -31,8 +31,14 @@ macro_rules! define_float_funcs {
         /// For documentation see the respective functions in the std library.
         #[cfg(not(feature = "std"))]
         pub trait FloatFuncs : Sized + sealed::FloatFuncsSealed {
-            /// Special implementations, because libm doesn't have them.
+            /// For documentation see <https://doc.rust-lang.org/std/primitive.f64.html#method.signum>
+            ///
+            /// Special implementation, because libm doesn't have it.
             fn signum(self) -> Self;
+
+            /// For documentation see <https://doc.rust-lang.org/std/primitive.f64.html#method.rem_euclid>
+            ///
+            /// Special implementation, because libm doesn't have it.
             fn rem_euclid(self, rhs: Self) -> Self;
 
             $(fn $name(self $(,$arg: $arg_ty)*) -> $ret;)+

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -650,19 +650,9 @@ fn dash_impl<T: Iterator<Item = PathEl>>(
     dash_offset: f64,
     dashes: &[f64],
 ) -> DashIterator<'_, T> {
-    // This is needed because f64::rem_euclid is not yet available in core
-    // https://github.com/rust-lang/rust/issues/137578
-    fn rem_euclid(lhs: f64, rhs: f64) -> f64 {
-        let r = lhs % rhs;
-        if r < 0.0 {
-            r + rhs.abs()
-        } else {
-            r
-        }
-    }
     // ensure that offset is positive and minimal by normalization using period
     let period = dashes.iter().sum();
-    let dash_offset = rem_euclid(dash_offset, period);
+    let dash_offset = dash_offset.rem_euclid(period);
 
     let mut dash_ix = 0;
     let mut dash_remaining = dashes[dash_ix] - dash_offset;


### PR DESCRIPTION
kurbo already have mechanism to provide missing no_std impls of float methods using `FloatFuncs`, but I didn't know that in #454.