### PR TITLE
Add inline to `Mul<PathEl>` implementation for `Affine`

### DIFF
--- a/kurbo/src/bezpath.rs
+++ b/kurbo/src/bezpath.rs
@@ -651,6 +651,9 @@ pub fn flatten(
 impl Mul<PathEl> for Affine {
     type Output = PathEl;
 
+    // TODO: Inlining this leads to a huge performance benefit, perhaps the same should be done for
+    // other methods.
+    #[inline(always)]
     fn mul(self, other: PathEl) -> PathEl {
         match other {
             PathEl::MoveTo(p) => PathEl::MoveTo(self * p),
@@ -664,7 +667,7 @@ impl Mul<PathEl> for Affine {
 
 impl Mul<PathSeg> for Affine {
     type Output = PathSeg;
-
+    
     fn mul(self, other: PathSeg) -> PathSeg {
         match other {
             PathSeg::Line(line) => PathSeg::Line(self * line),

--- a/kurbo/src/bezpath.rs
+++ b/kurbo/src/bezpath.rs
@@ -667,7 +667,7 @@ impl Mul<PathEl> for Affine {
 
 impl Mul<PathSeg> for Affine {
     type Output = PathSeg;
-    
+
     fn mul(self, other: PathSeg) -> PathSeg {
         match other {
             PathSeg::Line(line) => PathSeg::Line(self * line),


### PR DESCRIPTION
This leads to an absolutely astonishing speedup:

Before:
```
Runtime 41.35825ms
Runtime 36.621166ms
Runtime 35.912875ms
Runtime 34.93625ms
Runtime 35.844334ms
Runtime 35.372958ms
Runtime 35.987125ms
Runtime 35.29925ms
Runtime 34.922959ms
Runtime 35.655667ms
Runtime 35.19875ms
Runtime 36.095208ms
Runtime 35.748834ms
Runtime 35.378667ms
Runtime 35.05925ms
Runtime 36.067ms
Runtime 36.201417ms
Runtime 35.969625ms
Runtime 36.046833ms
Runtime 36.201208ms
Runtime 36.211ms
Runtime 36.006292ms
Runtime 35.82975ms
Runtime 36.645125ms
Runtime 36.384292ms
Runtime 35.789625ms
Runtime 35.644875ms
Runtime 35.045292ms
Runtime 35.812792ms
Runtime 35.201625ms
Runtime 35.456584ms
Runtime 35.42075ms
Runtime 35.935583ms
Runtime 35.732167ms
Runtime 35.202334ms
Runtime 35.349334ms
Runtime 35.797083ms
Runtime 35.299125ms
Runtime 35.655ms
Runtime 35.815375ms
Runtime 35.956375ms
Runtime 35.770958ms
Runtime 35.896833ms
Runtime 36.356208ms
Runtime 36.6005ms
Runtime 35.837417ms
Runtime 35.710542ms
Runtime 34.730834ms
Runtime 35.5285ms
Runtime 35.894291ms
```

After:
```
Runtime 33.98375ms
Runtime 28.6545ms
Runtime 25.634041ms
Runtime 25.798875ms
Runtime 26.097292ms
Runtime 26.016417ms
Runtime 26.184709ms
Runtime 25.937042ms
Runtime 25.924625ms
Runtime 26.006333ms
Runtime 26.745ms
Runtime 26.757917ms
Runtime 27.1695ms
Runtime 27.008459ms
Runtime 26.678209ms
Runtime 26.891375ms
Runtime 26.269083ms
Runtime 26.597208ms
Runtime 27.359333ms
Runtime 25.995666ms
Runtime 25.944166ms
Runtime 25.6945ms
Runtime 26.545917ms
Runtime 26.94025ms
Runtime 26.809792ms
Runtime 26.767583ms
Runtime 26.940208ms
Runtime 26.873667ms
Runtime 26.134583ms
Runtime 26.729ms
Runtime 27.103292ms
Runtime 26.598ms
Runtime 27.591417ms
Runtime 27.269625ms
Runtime 27.28375ms
Runtime 26.658417ms
Runtime 27.339958ms
Runtime 27.345083ms
Runtime 26.289583ms
Runtime 26.58175ms
Runtime 26.14975ms
Runtime 27.213625ms
Runtime 27.297709ms
Runtime 26.956709ms
Runtime 26.379166ms
Runtime 27.126958ms
Runtime 27.076458ms
Runtime 26.903667ms
Runtime 26.902ms
Runtime 27.442542ms
```

This probably should be done for other methods as well, but I didn't want to start randomly slapping `inline`s on every method, so I've only done it for the one relevant for `vello_common` for now.