### PR TITLE
Add `BezPath.current_position()`

### DIFF
--- a/kurbo/src/bezpath.rs
+++ b/kurbo/src/bezpath.rs
@@ -2086,6 +2086,7 @@ mod tests {
             .all(|el| !matches!(el, PathEl::MoveTo(_))));
     }
 
+    #[test]
     fn test_current_position() {
         let mut path = BezPath::new();
         assert_eq!(path.current_position(), None);

--- a/kurbo/src/bezpath.rs
+++ b/kurbo/src/bezpath.rs
@@ -395,8 +395,9 @@ impl BezPath {
 
     /// Returns current position in the path, if path is not empty.
     ///
-    /// Unlike the `end_point` method, this also handles [`PathEl::ClosePath`],
-    /// by finding the first point of subpath, hence the time complexity is O(n).
+    /// This is different from calling [`PathEl::end_point`] on the last entry of [`BezPath::elements`]:
+    /// this method handles [`PathEl::ClosePath`],
+    /// by finding the first point of our last subpath, hence the time complexity is O(n).
     pub fn current_position(&self) -> Option<Point> {
         match self.0.last()? {
             PathEl::MoveTo(p) => Some(*p),


### PR DESCRIPTION
Sometimes it is useful to obtain current position (sometimes also called last point/current point) of path. That's the one that also takes ClosePath into account. Implementation is very similar to [`PathEl.end_point`](https://docs.rs/kurbo/0.11.2/kurbo/enum.PathEl.html#method.end_point), except that it handles close path.