### PR TITLE
Conversions between Euclid and Kurbo types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +37,15 @@ name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
+name = "euclid"
+version = "0.22.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "getrandom"
@@ -67,6 +82,7 @@ name = "kurbo"
 version = "0.11.2"
 dependencies = [
  "arrayvec",
+ "euclid",
  "getrandom",
  "libm",
  "mint",
@@ -105,6 +121,16 @@ name = "mint"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
 
 [[package]]
 name = "once_cell"

--- a/kurbo/Cargo.toml
+++ b/kurbo/Cargo.toml
@@ -21,14 +21,16 @@ workspace = true
 
 [features]
 default = ["std"]
-std = []
-libm = ["dep:libm"]
+std = ["euclid?/std"]
+libm = ["dep:libm", "euclid?/libm"]
 mint = ["dep:mint"]
 serde = ["smallvec/serde", "dep:serde"]
 schemars = ["schemars/smallvec", "dep:schemars"]
+euclid = ["dep:euclid"]
 
 [dependencies]
 smallvec = "1.15.0"
+euclid = { version = "0.22", optional = true, default-features = false }
 
 [dependencies.arrayvec]
 version = "0.7.6"

--- a/kurbo/src/interop_euclid.rs
+++ b/kurbo/src/interop_euclid.rs
@@ -1,0 +1,79 @@
+// Copyright 2025 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use euclid::UnknownUnit;
+
+impl From<euclid::Vector2D<f64, UnknownUnit>> for crate::Vec2 {
+    fn from(value: euclid::Vector2D<f64, UnknownUnit>) -> Self {
+        Self::new(value.x, value.y)
+    }
+}
+
+impl From<crate::Vec2> for euclid::Vector2D<f64, UnknownUnit> {
+    fn from(value: crate::Vec2) -> Self {
+        Self::new(value.x, value.y)
+    }
+}
+
+impl From<euclid::Point2D<f64, UnknownUnit>> for crate::Point {
+    fn from(value: euclid::Point2D<f64, UnknownUnit>) -> Self {
+        Self::new(value.x, value.y)
+    }
+}
+
+impl From<crate::Point> for euclid::Point2D<f64, UnknownUnit> {
+    fn from(value: crate::Point) -> Self {
+        Self::new(value.x, value.y)
+    }
+}
+
+impl From<euclid::Size2D<f64, UnknownUnit>> for crate::Size {
+    fn from(value: euclid::Size2D<f64, UnknownUnit>) -> Self {
+        Self::new(value.width, value.height)
+    }
+}
+
+impl From<crate::Size> for euclid::Size2D<f64, UnknownUnit> {
+    fn from(value: crate::Size) -> Self {
+        Self::new(value.width, value.height)
+    }
+}
+
+impl From<euclid::Rect<f64, UnknownUnit>> for crate::Rect {
+    fn from(value: euclid::Rect<f64, UnknownUnit>) -> Self {
+        Self::from_origin_size(value.origin, value.size)
+    }
+}
+
+impl From<crate::Rect> for euclid::Rect<f64, UnknownUnit> {
+    fn from(value: crate::Rect) -> Self {
+        Self::new(value.origin().into(), value.size().into())
+    }
+}
+
+impl From<euclid::Box2D<f64, UnknownUnit>> for crate::Rect {
+    fn from(value: euclid::Box2D<f64, UnknownUnit>) -> Self {
+        Self::from_points(value.min, value.max)
+    }
+}
+
+impl From<crate::Rect> for euclid::Box2D<f64, UnknownUnit> {
+    fn from(value: crate::Rect) -> Self {
+        Self::new(
+            euclid::Point2D::new(value.min_x(), value.min_y()),
+            euclid::Point2D::new(value.max_x(), value.max_y()),
+        )
+    }
+}
+
+impl From<euclid::Transform2D<f64, UnknownUnit, UnknownUnit>> for crate::Affine {
+    fn from(t: euclid::Transform2D<f64, UnknownUnit, UnknownUnit>) -> Self {
+        Self::new(t.to_array())
+    }
+}
+
+impl From<crate::Affine> for euclid::Transform2D<f64, UnknownUnit, UnknownUnit> {
+    fn from(a: crate::Affine) -> Self {
+        Self::from_array(a.as_coeffs())
+    }
+}

--- a/kurbo/src/lib.rs
+++ b/kurbo/src/lib.rs
@@ -142,6 +142,9 @@ mod translate_scale;
 mod triangle;
 mod vec2;
 
+#[cfg(feature = "euclid")]
+mod interop_euclid;
+
 pub use crate::affine::Affine;
 pub use crate::arc::{Arc, ArcAppendIter};
 pub use crate::bezpath::{


### PR DESCRIPTION
Inspired after https://github.com/linebender/kurbo/pull/450

We could use those in servo and blitz.
Theoretically they could also live in euclid, but given higher number of breaking releases in kurbo, kurbo seems better place for this.