### PR TITLE
Use more `Into<Point>` instead of `Point` for arguments

### DIFF
--- a/kurbo/src/affine.rs
+++ b/kurbo/src/affine.rs
@@ -69,8 +69,8 @@ impl Affine {
     ///
     /// See [`Affine::scale()`] for more info.
     #[inline]
-    pub fn scale_about(s: f64, center: Point) -> Affine {
-        let center = center.to_vec2();
+    pub fn scale_about(s: f64, center: impl Into<Point>) -> Affine {
+        let center = center.into().to_vec2();
         Self::translate(-center)
             .then_scale(s)
             .then_translate(center)
@@ -94,8 +94,8 @@ impl Affine {
     ///
     /// See [`Affine::rotate()`] for more info.
     #[inline]
-    pub fn rotate_about(th: f64, center: Point) -> Affine {
-        let center = center.to_vec2();
+    pub fn rotate_about(th: f64, center: impl Into<Point>) -> Affine {
+        let center = center.into().to_vec2();
         Self::translate(-center)
             .then_rotate(th)
             .then_translate(center)
@@ -188,7 +188,7 @@ impl Affine {
     /// [rotation]: Affine::rotate_about
     #[inline]
     #[must_use]
-    pub fn pre_rotate_about(self, th: f64, center: Point) -> Self {
+    pub fn pre_rotate_about(self, th: f64, center: impl Into<Point>) -> Self {
         Affine::rotate_about(th, center) * self
     }
 
@@ -243,7 +243,7 @@ impl Affine {
     /// [rotation]: Affine::rotate_about
     #[inline]
     #[must_use]
-    pub fn then_rotate_about(self, th: f64, center: Point) -> Self {
+    pub fn then_rotate_about(self, th: f64, center: impl Into<Point>) -> Self {
         Affine::rotate_about(th, center) * self
     }
 
@@ -276,7 +276,7 @@ impl Affine {
     /// [scale]: Affine::scale_about
     #[inline]
     #[must_use]
-    pub fn then_scale_about(self, scale: f64, center: Point) -> Self {
+    pub fn then_scale_about(self, scale: f64, center: impl Into<Point>) -> Self {
         Affine::scale_about(scale, center) * self
     }
 

--- a/kurbo/src/ellipse.rs
+++ b/kurbo/src/ellipse.rs
@@ -67,8 +67,8 @@ impl Ellipse {
     /// Create a new `Ellipse` centered on the provided point.
     #[inline]
     #[must_use]
-    pub fn with_center(self, new_center: Point) -> Ellipse {
-        let Point { x: cx, y: cy } = new_center;
+    pub fn with_center(self, new_center: impl Into<Point>) -> Ellipse {
+        let Point { x: cx, y: cy } = new_center.into();
         Ellipse {
             inner: self.inner.with_translation(Vec2 { x: cx, y: cy }),
         }

--- a/kurbo/src/rect.rs
+++ b/kurbo/src/rect.rs
@@ -183,7 +183,8 @@ impl Rect {
 
     /// Returns `true` if `point` lies within `self`.
     #[inline]
-    pub fn contains(&self, point: Point) -> bool {
+    pub fn contains(&self, point: impl Into<Point>) -> bool {
+        let point = point.into();
         point.x >= self.x0 && point.x < self.x1 && point.y >= self.y0 && point.y < self.y1
     }
 
@@ -217,7 +218,8 @@ impl Rect {
     /// points yields their enclosing rectangle.
     ///
     /// Results are valid only if width and height are non-negative.
-    pub fn union_pt(&self, pt: Point) -> Rect {
+    pub fn union_pt(&self, pt: impl Into<Point>) -> Rect {
+        let pt = pt.into();
         Rect::new(
             self.x0.min(pt.x),
             self.y0.min(pt.y),


### PR DESCRIPTION
We already did for most of `Point` arguments. This is especially relevant for users of euclid now that we have #463.