### PR TITLE
Fixes aspect ratio calculation.

### DIFF
--- a/kurbo/src/size.rs
+++ b/kurbo/src/size.rs
@@ -256,7 +256,7 @@ impl Size {
 
     /// Returns the aspect ratio of a rectangle with the given size.
     ///
-    /// If the width is `0`, the output will be `sign(self.height) * infinity`. If The width and
+    /// If the height is `0`, the output will be `sign(self.width) * infinity`. If The width and
     /// height are `0`, then the output will be `NaN`.
     pub fn aspect_ratio(self) -> f64 {
         // ratio is determined by width / height

--- a/kurbo/src/size.rs
+++ b/kurbo/src/size.rs
@@ -259,7 +259,10 @@ impl Size {
     /// If the width is `0`, the output will be `sign(self.height) * infinity`. If The width and
     /// height are `0`, then the output will be `NaN`.
     pub fn aspect_ratio(self) -> f64 {
-        self.height / self.width
+        // ratio is determined by width / height
+        // https://en.wikipedia.org/wiki/Aspect_ratio_(image)
+        // https://en.wikipedia.org/wiki/Ratio
+        self.width / self.height
     }
 
     /// Convert this `Size` into a [`Rect`] with origin `(0.0, 0.0)`.


### PR DESCRIPTION
Aspect ratio was calculated with `height / width`, but that's incorrect. It should be `width / height`.

https://en.wikipedia.org/wiki/Aspect_ratio_(image)
https://en.wikipedia.org/wiki/Ratio#Notation_and_terminology