### PR TITLE
Fix `mismatched_lifetime_syntaxes`

### DIFF
--- a/src/stroke.rs
+++ b/src/stroke.rs
@@ -649,7 +649,7 @@ fn dash_impl<T: Iterator<Item = PathEl>>(
     inner: T,
     dash_offset: f64,
     dashes: &[f64],
-) -> DashIterator<T> {
+) -> DashIterator<'_, T> {
     let mut dash_ix = 0;
     let mut dash_remaining = dashes[dash_ix] - dash_offset;
     let mut is_active = true;

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -282,8 +282,8 @@ struct SvgLexer<'a> {
     pub last_pt: Point,
 }
 
-impl<'a> SvgLexer<'a> {
-    fn new(data: &str) -> SvgLexer {
+impl SvgLexer<'_> {
+    fn new(data: &str) -> SvgLexer<'_> {
         SvgLexer {
             data,
             ix: 0,


### PR DESCRIPTION
This warns since Rust 1.89.