### PR TITLE
[cu2qu] Add some failing edge case tests (and a question)

### DIFF
--- a/kurbo/src/cubicbez.rs
+++ b/kurbo/src/cubicbez.rs
@@ -1130,6 +1130,44 @@ mod tests {
     }
 
     #[test]
+    fn cubic_to_quadratic_pathological_front() {
+        let cubic = CubicBez::new(Point::ZERO, Point::ZERO, Point::ZERO, (10., 10.).into());
+        let quads = cubics_to_quadratic_splines(&[cubic], 0.1).unwrap();
+        assert_eq!(
+            quads,
+            [QuadSpline::new(vec![
+                Point::ZERO,
+                Point::ZERO,
+                (10., 10.).into()
+            ])]
+        );
+    }
+
+    #[test]
+    fn cubic_to_quadratic_pathological_back() {
+        let cubic = CubicBez::new((10., 10.).into(), Point::ZERO, Point::ZERO, Point::ZERO);
+        let quads = cubics_to_quadratic_splines(&[cubic], 0.1).unwrap();
+        assert_eq!(
+            quads,
+            [QuadSpline::new(vec![
+                (10., 10.).into(),
+                Point::ZERO,
+                Point::ZERO
+            ])]
+        );
+    }
+
+    #[test]
+    fn cubic_to_quadratic_all_points_equal() {
+        let cubic = CubicBez::new(Point::ZERO, Point::ZERO, Point::ZERO, Point::ZERO);
+        let quads = cubics_to_quadratic_splines(&[cubic], 0.1).unwrap();
+        assert_eq!(
+            quads,
+            [QuadSpline::new(vec![Point::ZERO, Point::ZERO, Point::ZERO])]
+        );
+    }
+
+    #[test]
     fn cubics_to_quadratic_splines_matches_python() {
         // https://github.com/linebender/kurbo/pull/273
         let light = CubicBez::new((378., 608.), (378., 524.), (355., 455.), (266., 455.));


### PR DESCRIPTION
Hi all,

In the course of investigating a difference in font compilation between rust and python I found some behaviour of the cubic to quadratic conversion code (in both implementations) that I think is counter intuitive, and which might be worth special-casing.

Specifically, if a cubic bezier has three identical points in a row (as in, the two control points + either the start or end) I would expect conversion to return a single quadratic bezier that just drops one of the input control points. (There could also be a special case if there are three equal points with unequal control points, but in that case there are at least several reasonable representations, so i'm ignoring it.)

That said, the current behaviour is not _wrong_, it's just somewhat unintuitive/sub-optimal.

I'm opening this as a PR but ultimately it's a discussion question; there's a patch open to change this in the python, but I'd only want to land that if we're also going to change it here.

see https://github.com/fonttools/fonttools/pull/3904