### PR TITLE
cubic_to_quadratic: better handle edge cases when cubic degenerates to a line or single point

### DIFF
--- a/kurbo/src/cubicbez.rs
+++ b/kurbo/src/cubicbez.rs
@@ -163,7 +163,16 @@ impl CubicBez {
     /// Returns a quadratic approximating the given cubic that maintains
     /// endpoint tangents if that is within tolerance, or `None` otherwise.
     fn try_approx_quadratic(&self, accuracy: f64) -> Option<QuadBez> {
-        if let Some(q1) = Line::new(self.p0, self.p1).intersect(Line::new(self.p2, self.p3)) {
+        if let Some(q1) = Line::new(self.p0, self.p1)
+            .crossing_point(Line::new(self.p2, self.p3))
+            .or_else(|| {
+                // with 3 to 4 consecutive equal points (with no valid crossing_point),
+                // we can try to use the common point as the quadratic control point.
+                // This matches fonttools' cu2qu: https://github.com/fonttools/fonttools/pull/3904
+                (self.p1 == self.p2 && (self.p0 == self.p1 || self.p2 == self.p3))
+                    .then_some(self.p1)
+            })
+        {
             let c1 = self.p0.lerp(q1, 2.0 / 3.0);
             let c2 = self.p3.lerp(q1, 2.0 / 3.0);
             if !CubicBez::new(

--- a/kurbo/src/line.rs
+++ b/kurbo/src/line.rs
@@ -9,8 +9,8 @@ use arrayvec::ArrayVec;
 
 use crate::{
     Affine, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea, ParamCurveCurvature,
-    ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest, PathEl, Point, Rect, Shape, Triangle,
-    Vec2, DEFAULT_ACCURACY, MAX_EXTREMA,
+    ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest, PathEl, Point, Rect, Shape, Vec2,
+    DEFAULT_ACCURACY, MAX_EXTREMA,
 };
 
 /// A single line.
@@ -71,36 +71,6 @@ impl Line {
         }
         let h = ab.cross(self.p0 - other.p0) / pcd;
         Some(other.p0 + cd * h)
-    }
-
-    /// Computes the point where two lines intersect (have a point in common).
-    ///
-    /// If either line is degenerate (zero length) and corresponds to a single
-    /// point, that point is considered to be the intersection if overlaps or is
-    /// collinear with the other line.
-    ///
-    /// Use ``Line::crossing_point`` if you only care about the unique transverse
-    /// crossing point, which excludes such degenerate cases.
-    pub fn intersect(&self, other: Line) -> Option<Point> {
-        if self.p1 == other.p0 && (self.p0 == self.p1 || other.p0 == other.p1) {
-            // three consecutive collinear points, return the shared point
-            return Some(self.p1);
-        }
-        if self.p0 == self.p1
-            && other.p0 != other.p1
-            && Triangle::new(self.p0, other.p0, other.p1).is_zero_area()
-        {
-            // self is a single point collinear with other
-            return Some(self.p0);
-        }
-        if other.p0 == other.p1
-            && self.p0 != self.p1
-            && Triangle::new(self.p0, self.p1, other.p0).is_zero_area()
-        {
-            // other is a single point collinear with self
-            return Some(other.p0);
-        }
-        self.crossing_point(other)
     }
 
     /// Is this line `finite`?
@@ -423,75 +393,5 @@ mod tests {
             }
         })
         .is_finite());
-    }
-
-    #[test]
-    fn line_line_intersection() {
-        let l1 = Line::new((0.0, 0.0), (1.0, 1.0));
-        let l2 = Line::new((0.0, 1.0), (1.0, 0.0));
-        assert_eq!(l1.intersect(l2), Some(Point::new(0.5, 0.5)));
-    }
-
-    #[test]
-    fn parallel_lines_dont_intersect() {
-        let l1 = Line::new((0.0, 0.0), (1.0, 1.0));
-        let l2 = Line::new((0.0, 2.0), (1.0, 3.0));
-        assert_eq!(l1.intersect(l2), None);
-    }
-
-    #[test]
-    fn line_doesnt_intersect_non_collinear_point() {
-        let l1 = Line::new((0.0, 0.0), (1.0, 1.0));
-        let l2 = Line::new((0.0, 1.0), (0.0, 1.0));
-        assert_eq!(l1.intersect(l2), None);
-    }
-
-    #[test]
-    fn line_intersects_collinear_point_beyond_end() {
-        let l1 = Line::new((0.0, 0.0), (1.0, 1.0));
-        let l2 = Line::new((1.333, 1.333), (1.333, 1.333));
-        assert_eq!(l1.intersect(l2), Some(Point::new(1.333, 1.333)));
-    }
-
-    #[test]
-    fn line_intersects_collinear_point_in_between() {
-        let l1 = Line::new((0.0, 0.0), (1.0, 1.0));
-        let l2 = Line::new((0.5, 0.5), (0.5, 0.5));
-        assert_eq!(l1.intersect(l2), Some(Point::new(0.5, 0.5)));
-    }
-
-    #[test]
-    fn line_intersect_collinear_point_in_between_horizontal() {
-        let l1 = Line::new((0.333, 0.0), (0.333, 0.0));
-        let l2 = Line::new((0.0, 0.0), (1.0, 0.0));
-        assert_eq!(l1.intersect(l2), Some(Point::new(0.333, 0.0)));
-    }
-
-    #[test]
-    fn line_intersect_collinear_point_in_between_vertical() {
-        let l1 = Line::new((0.0, 0.0), (0.0, 1.0));
-        let l2 = Line::new((0.0, 0.333), (0.0, 0.333));
-        assert_eq!(l1.intersect(l2), Some(Point::new(0.0, 0.333)));
-    }
-
-    #[test]
-    fn line_line_intersection_last_3_consecutive_points_equal() {
-        let l1 = Line::new((0.0, 0.0), (1.0, 1.0));
-        let l2 = Line::new((1.0, 1.0), (1.0, 1.0));
-        assert_eq!(l1.intersect(l2), Some(Point::new(1.0, 1.0)));
-    }
-
-    #[test]
-    fn line_line_intersection_first_3_consecutive_points_equal() {
-        let l1 = Line::new((1.0, 1.0), (1.0, 1.0));
-        let l2 = Line::new((1.0, 1.0), (0.0, 0.0));
-        assert_eq!(l1.intersect(l2), Some(Point::new(1.0, 1.0)));
-    }
-
-    #[test]
-    fn line_line_intersection_all_points_equal() {
-        let l1 = Line::new((1.234, 1.234), (1.234, 1.234));
-        let l2 = Line::new((1.234, 1.234), (1.234, 1.234));
-        assert_eq!(l1.intersect(l2), Some(Point::new(1.234, 1.234)));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/linebender/kurbo/pull/484

This is intended to match https://github.com/fonttools/fonttools/pull/3904

~~In addition to the above fonttools PR which only handles 3 to 4 consecutive cubic control points, in here I also consider intersections when a point is collinear and lies in between the endpoints of the other line.
I think this is a logical consequence if we agree that when there are 3 consecutive equal points at the front/back of cubic bezier then there's an intersection at the common (start/end) point.~~

~~kurbo's `try_approx_quadratic` uses `Line::crossing_point` method, so I modified that one to behave like that~~.

