### PR TITLE
Remove a bunch of deprecated utility functions/aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ It was increased to support floating point math in const functions.
 - The implementation of stroking is much faster. ([#427][] by [@raphlinus][])
 - More `Vec2` methods can now be called in `const` contexts. ([#479][] by [@tomcur][])
 
+### Removed
+
+- Breaking change: The previously deprecated `BezPath::flatten`, `Ellipse::[with_]x_rotation`, `{Rect, Size}::is_empty`, `Shape::[in]to_bez_path`, 
+  and `TranslateScale::as_tuple` have been removed.([#487][] by [@DJMcNab][])
+
 ## [0.11.3][] (2025-07-21)
 
 This release has an [MSRV][] of 1.65.
@@ -173,6 +178,7 @@ Note: A changelog was not kept for or before this release
 [#466]: https://github.com/linebender/kurbo/pull/466
 [#469]: https://github.com/linebender/kurbo/pull/469
 [#479]: https://github.com/linebender/kurbo/pull/479
+[#487]: https://github.com/linebender/kurbo/pull/487
 
 [Unreleased]: https://github.com/linebender/kurbo/compare/v0.11.3...HEAD
 [0.11.0]: https://github.com/linebender/kurbo/releases/tag/v0.11.0

--- a/kurbo/src/bezpath.rs
+++ b/kurbo/src/bezpath.rs
@@ -299,14 +299,6 @@ impl BezPath {
         self.0.truncate(len);
     }
 
-    /// Flatten the path, invoking the callback repeatedly.
-    ///
-    /// See [`flatten`] for more discussion.
-    #[deprecated(since = "0.11.1", note = "use the free function flatten instead")]
-    pub fn flatten(&self, tolerance: f64, callback: impl FnMut(PathEl)) {
-        flatten(self, tolerance, callback);
-    }
-
     /// Get the segment at the given element index.
     ///
     /// If you need to access all segments, [`segments`] provides a better

--- a/kurbo/src/ellipse.rs
+++ b/kurbo/src/ellipse.rs
@@ -94,13 +94,6 @@ impl Ellipse {
         Ellipse::private_new(translation, scale.x, scale.y, rotation)
     }
 
-    #[deprecated(since = "0.7.0", note = "use with_rotation instead")]
-    #[must_use]
-    #[doc(hidden)]
-    pub fn with_x_rotation(self, rotation_radians: f64) -> Ellipse {
-        self.with_rotation(rotation_radians)
-    }
-
     /// This gives us an internal method without any type conversions.
     #[inline]
     fn private_new(center: Vec2, scale_x: f64, scale_y: f64, x_rotation: f64) -> Ellipse {
@@ -158,12 +151,6 @@ impl Ellipse {
     #[inline]
     pub fn is_nan(&self) -> bool {
         self.inner.is_nan()
-    }
-
-    #[doc(hidden)]
-    #[deprecated(since = "0.7.0", note = "use rotation() instead")]
-    pub fn x_rotation(&self) -> f64 {
-        self.rotation()
     }
 }
 

--- a/kurbo/src/rect.rs
+++ b/kurbo/src/rect.rs
@@ -168,15 +168,6 @@ impl Rect {
         self.area() == 0.0
     }
 
-    /// Whether this rectangle has zero area.
-    ///
-    /// Note: a rectangle with negative area is not considered empty.
-    #[inline]
-    #[deprecated(since = "0.11.1", note = "use is_zero_area instead")]
-    pub fn is_empty(&self) -> bool {
-        self.is_zero_area()
-    }
-
     /// The center point of the rectangle.
     #[inline]
     pub fn center(&self) -> Point {

--- a/kurbo/src/shape.rs
+++ b/kurbo/src/shape.rs
@@ -68,12 +68,6 @@ pub trait Shape {
         self.path_elements(tolerance).collect()
     }
 
-    #[deprecated(since = "0.7.0", note = "Use path_elements instead")]
-    #[doc(hidden)]
-    fn to_bez_path(&self, tolerance: f64) -> Self::PathElementsIter<'_> {
-        self.path_elements(tolerance)
-    }
-
     /// Convert into a Bézier path.
     ///
     /// This allocates in the general case, but is zero-cost if the
@@ -87,15 +81,6 @@ pub trait Shape {
         Self: Sized,
     {
         self.to_path(tolerance)
-    }
-
-    #[deprecated(since = "0.7.0", note = "Use into_path instead")]
-    #[doc(hidden)]
-    fn into_bez_path(self, tolerance: f64) -> BezPath
-    where
-        Self: Sized,
-    {
-        self.into_path(tolerance)
     }
 
     /// Returns an iterator over this shape expressed as Bézier path

--- a/kurbo/src/size.rs
+++ b/kurbo/src/size.rs
@@ -75,15 +75,6 @@ impl Size {
         self.area() == 0.0
     }
 
-    /// Whether this size has zero area.
-    ///
-    /// Note: a size with negative area is not considered empty.
-    #[inline]
-    #[deprecated(since = "0.11.1", note = "use is_zero_area instead")]
-    pub fn is_empty(self) -> bool {
-        self.is_zero_area()
-    }
-
     /// Returns the component-wise minimum of `self` and `other`.
     ///
     /// # Examples

--- a/kurbo/src/translate_scale.rs
+++ b/kurbo/src/translate_scale.rs
@@ -67,13 +67,6 @@ impl TranslateScale {
         TranslateScale::new(translation.into(), 1.0)
     }
 
-    /// Decompose transformation into translation and scale.
-    #[deprecated(note = "use the struct fields directly")]
-    #[inline(always)]
-    pub const fn as_tuple(self) -> (Vec2, f64) {
-        (self.translation, self.scale)
-    }
-
     /// Create a transform that scales about a point other than the origin.
     ///
     /// # Examples


### PR DESCRIPTION
The main potentially controversial thing here is changes to the `Shape` trait But it's only removing items which already had default impls

I'm not fully involved with Kurbo development, so this is done semi-blindly.