### PR TITLE
Make `DashIterator` private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ It was increased to support floating point math in const functions.
 
 ### Removed
 
+- Breaking change: `DashIterator` is no longer exported publicly. Replace `DashIterator::new` with `dash` ([#488][] by [@DJMcNab][])
 - Breaking change: The previously deprecated `BezPath::flatten`, `Ellipse::[with_]x_rotation`, `{Rect, Size}::is_empty`, `Shape::[in]to_bez_path`,
   and `TranslateScale::as_tuple` have been removed.([#487][] by [@DJMcNab][])
 
@@ -186,6 +187,7 @@ Note: A changelog was not kept for or before this release
 [#479]: https://github.com/linebender/kurbo/pull/479
 [#486]: https://github.com/linebender/kurbo/pull/486
 [#487]: https://github.com/linebender/kurbo/pull/487
+[#488]: https://github.com/linebender/kurbo/pull/488
 
 [Unreleased]: https://github.com/linebender/kurbo/compare/v0.11.3...HEAD
 [0.11.0]: https://github.com/linebender/kurbo/releases/tag/v0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ It was increased to support floating point math in const functions.
 
 ### Removed
 
-- Breaking change: `DashIterator` is no longer exported publicly. Replace `DashIterator::new` with `dash` ([#488][] by [@DJMcNab][])
+- Breaking change: `DashIterator` has been removed. Replace `DashIterator::new` with `dash`. ([#488][] by [@DJMcNab][])
 - Breaking change: The previously deprecated `BezPath::flatten`, `Ellipse::[with_]x_rotation`, `{Rect, Size}::is_empty`, `Shape::[in]to_bez_path`,
   and `TranslateScale::as_tuple` have been removed.([#487][] by [@DJMcNab][])
 

--- a/kurbo/src/lib.rs
+++ b/kurbo/src/lib.rs
@@ -187,8 +187,7 @@ pub use crate::rounded_rect_radii::RoundedRectRadii;
 pub use crate::shape::Shape;
 pub use crate::size::Size;
 pub use crate::stroke::{
-    dash, stroke, stroke_with, Cap, DashIterator, Dashes, Join, Stroke, StrokeCtx, StrokeOptLevel,
-    StrokeOpts,
+    dash, stroke, stroke_with, Cap, Dashes, Join, Stroke, StrokeCtx, StrokeOptLevel, StrokeOpts,
 };
 pub use crate::svg::{SvgArc, SvgParseError};
 pub use crate::translate_scale::TranslateScale;

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -573,8 +573,7 @@ impl StrokeCtx {
 }
 
 /// An implementation of dashing as an iterator-to-iterator transformation.
-#[doc(hidden)]
-pub struct DashIterator<'a, T> {
+struct DashIterator<'a, T> {
     inner: T,
     input_done: bool,
     closepath_pending: bool,
@@ -680,15 +679,6 @@ pub fn dash<'a>(
     dash_offset: f64,
     dashes: &'a [f64],
 ) -> impl Iterator<Item = PathEl> + 'a {
-    dash_impl(inner, dash_offset, dashes)
-}
-
-// This is only a separate function to make `DashIterator::new()` typecheck.
-fn dash_impl<T: Iterator<Item = PathEl>>(
-    inner: T,
-    dash_offset: f64,
-    dashes: &[f64],
-) -> DashIterator<'_, T> {
     // ensure that offset is positive and minimal by normalization using period
     let period = dashes.iter().sum();
     let dash_offset = dash_offset.rem_euclid(period);
@@ -725,12 +715,6 @@ fn dash_impl<T: Iterator<Item = PathEl>>(
 }
 
 impl<'a, T: Iterator<Item = PathEl>> DashIterator<'a, T> {
-    #[doc(hidden)]
-    #[deprecated(since = "0.10.4", note = "use dash() instead")]
-    pub fn new(inner: T, dash_offset: f64, dashes: &'a [f64]) -> Self {
-        dash_impl(inner, dash_offset, dashes)
-    }
-
     fn get_input(&mut self) {
         loop {
             if self.closepath_pending {


### PR DESCRIPTION
As of https://github.com/linebender/kurbo/pull/319, using this type directly has been deprecated