### PR TITLE
Add `Ellipse::{major,minor}_radius` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ You can find its changes [documented below](#0113-2025-07-21).
 This release has an [MSRV][] of 1.82.
 It was increased to support floating point math in const functions.
 
+### Added
+
+- Add `Ellipse::major_radius` and `Ellipse::minor_radius` methods. ([#497][] by [@tomcur][])
+
 ### Changed
 
 - The implementation of stroking is much faster. ([#427][] by [@raphlinus][])
@@ -202,6 +206,7 @@ Note: A changelog was not kept for or before this release
 [#489]: https://github.com/linebender/kurbo/pull/489
 [#490]: https://github.com/linebender/kurbo/pull/490
 [#496]: https://github.com/linebender/kurbo/pull/496
+[#497]: https://github.com/linebender/kurbo/pull/497
 
 [Unreleased]: https://github.com/linebender/kurbo/compare/v0.11.3...HEAD
 [0.11.0]: https://github.com/linebender/kurbo/releases/tag/v0.11.0

--- a/kurbo/src/affine.rs
+++ b/kurbo/src/affine.rs
@@ -389,16 +389,18 @@ impl Affine {
     /// Will return NaNs if the matrix (or equivalently the linear map) is non-finite.
     ///
     /// The first part of the returned tuple is the scaling, the second part is the angle of
-    /// rotation (in radians).
-    #[inline]
+    /// rotation (in radians). The scaling along the x-axis is guaranteed to be greater than or
+    /// equal to the scaling along the y-axis.
+    //
+    // Note: though this does quite some computation, we are often interested only in specific
+    // components of the result. Hence this is marked `#[inline(always)]`, to give the compiler a
+    // good chance at eliminating dead code.
+    #[inline(always)]
     pub(crate) fn svd(self) -> (Vec2, f64) {
-        let a = self.0[0];
+        let [a, b, c, d, _, _] = self.0;
         let a2 = a * a;
-        let b = self.0[1];
         let b2 = b * b;
-        let c = self.0[2];
         let c2 = c * c;
-        let d = self.0[3];
         let d2 = d * d;
         let ab = a * b;
         let cd = c * d;

--- a/kurbo/src/ellipse.rs
+++ b/kurbo/src/ellipse.rs
@@ -120,9 +120,28 @@ impl Ellipse {
     ///
     /// The first number is the horizontal radius and the second is the vertical
     /// radius, before rotation.
+    ///
+    /// If you are only interested in the value of the greatest or smallest radius of this ellipse,
+    /// consider using [`Ellipse::major_radius`] or [`Ellipse::minor_radius`] instead.
     #[inline]
     pub fn radii(&self) -> Vec2 {
         self.inner.svd().0
+    }
+
+    /// Returns the major radius of this ellipse.
+    ///
+    /// This metric is also known as the semi-major axis.
+    #[inline]
+    pub fn major_radius(&self) -> f64 {
+        self.inner.svd().0.x
+    }
+
+    /// Returns the minor radius of this ellipse.
+    ///
+    /// This metric is also known as the semi-minor axis.
+    #[inline]
+    pub fn minor_radius(&self) -> f64 {
+        self.inner.svd().0.y
     }
 
     /// The ellipse's rotation, in radians.


### PR DESCRIPTION
This adds methods to `Ellipse` to get the major and minor radii.

This documents the (private) `Affine::svd` method to guarantee the part of its behavior we're using here for efficiency.

The `Ellipse::radii()` method effectively already allows for this, by taking the `x` component for the major radius and the `y` component for the minor radius; however, we do not currently guarantee that behavior, and may not want to, to keep the option of changing internal representations. Plus, within crate boundaries and the specified inlining, the compiler should be able to eliminate the dead singular value decomposition code.

Quickly looking over the assembly, there are just the two `sqrtsd` instructions as expected.

Like https://github.com/linebender/kurbo/pull/496, this is motivated by https://github.com/linebender/vello/pull/1180, to allow eliding more computations.

<details>
<summary>x86 assembly</summary>

```assembly
		// kurbo/src/ellipse.rs:132
		pub fn major_radius(&self) -> f64 {
	.cfi_startproc
	sub rsp, 104
	.cfi_def_cfa_offset 112
		// kurbo/src/ellipse.rs:133
		self.inner.svd().0.x
	movupd xmm0, xmmword ptr [rdi]
	movupd xmm4, xmmword ptr [rdi + 16]
		// kurbo/src/affine.rs:401
		let a2 = a * a;
	movapd xmm3, xmm0
	mulpd xmm3, xmm0
		// kurbo/src/affine.rs:405
		let ab = a * b;
	movapd xmm2, xmm0
	unpcklpd xmm2, xmm4
	unpckhpd xmm0, xmm4
		// kurbo/src/affine.rs:403
		let c2 = c * c;
	mulpd xmm4, xmm4
		// kurbo/src/affine.rs:405
		let ab = a * b;
	mulpd xmm0, xmm2
		// kurbo/src/affine.rs:407
		let angle = 0.5 * (2.0 * (ab + cd)).atan2(a2 - b2 + c2 - d2);
	movapd xmm1, xmm0
	unpckhpd xmm1, xmm0
	addsd xmm1, xmm0
	movapd xmmword ptr [rsp + 80], xmm1
	movapd xmm0, xmm1
	addsd xmm0, xmm1
	movapd xmmword ptr [rsp + 48], xmm3
		// kurbo/src/affine.rs:408
		let s1 = a2 + b2 + c2 + d2;
	movapd xmm2, xmm3
	unpckhpd xmm2, xmm3
	movapd xmmword ptr [rsp + 32], xmm2
		// kurbo/src/affine.rs:407
		let angle = 0.5 * (2.0 * (ab + cd)).atan2(a2 - b2 + c2 - d2);
	movapd xmm1, xmm3
	subsd xmm1, xmm2
	movapd xmmword ptr [rsp + 16], xmm4
	addsd xmm1, xmm4
		// kurbo/src/affine.rs:408
		let s1 = a2 + b2 + c2 + d2;
	unpckhpd xmm4, xmm4
	movapd xmmword ptr [rsp], xmm4
		// kurbo/src/affine.rs:407
		let angle = 0.5 * (2.0 * (ab + cd)).atan2(a2 - b2 + c2 - d2);
	subsd xmm1, xmm4
	movapd xmmword ptr [rsp + 64], xmm1
	call qword ptr [rip + atan2@GOTPCREL]
	movapd xmm0, xmmword ptr [rsp + 32]
		// kurbo/src/affine.rs:408
		let s1 = a2 + b2 + c2 + d2;
	addsd xmm0, qword ptr [rsp + 48]
	addsd xmm0, qword ptr [rsp + 16]
	addsd xmm0, qword ptr [rsp]
	movapd xmm1, xmm0
	movapd xmm0, xmmword ptr [rsp + 80]
	mulsd xmm0, xmm0
		// kurbo/src/affine.rs:409
		let s2 = ((a2 - b2 + c2 - d2).powi(2) + 4.0 * (ab + cd).powi(2)).sqrt();
	mulsd xmm0, qword ptr [rip + .LCPI116_0]
	movapd xmm2, xmmword ptr [rsp + 64]
	mulsd xmm2, xmm2
		// kurbo/src/affine.rs:409
		let s2 = ((a2 - b2 + c2 - d2).powi(2) + 4.0 * (ab + cd).powi(2)).sqrt();
	addsd xmm0, xmm2
	sqrtsd xmm0, xmm0
		// kurbo/src/affine.rs:412
		x: (0.5 * (s1 + s2)).sqrt(),
	addsd xmm0, xmm1
	mulsd xmm0, qword ptr [rip + .LCPI116_1]
	sqrtsd xmm0, xmm0
		// kurbo/src/ellipse.rs:134
		}
	add rsp, 104
	.cfi_def_cfa_offset 8
	ret
```

</details>