### PR TITLE
Fixup changelog for 0.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ It was increased to support floating point math in const functions.
 
 - Breaking change: `DashIterator` has been removed. Replace `DashIterator::new` with `dash`. ([#488][] by [@DJMcNab][])
 - Breaking change: The previously deprecated `BezPath::flatten`, `Ellipse::[with_]x_rotation`, `{Rect, Size}::is_empty`, `Shape::[in]to_bez_path`,
-  and `TranslateScale::as_tuple` have been removed.([#487][] by [@DJMcNab][])
+  and `TranslateScale::as_tuple` have been removed. ([#487][] by [@DJMcNab][])
 
 ## [0.11.3][] (2025-07-21)
 


### PR DESCRIPTION
Line about bumping MSRV was in the wrong place in kurbo#500. (While we're at it, add a missing period.)