### PR TITLE
Inline the `next` method of the `Segments` iterator

### DIFF
--- a/kurbo/src/bezpath.rs
+++ b/kurbo/src/bezpath.rs
@@ -777,6 +777,7 @@ pub struct Segments<I: Iterator<Item = PathEl>> {
 impl<I: Iterator<Item = PathEl>> Iterator for Segments<I> {
     type Item = PathSeg;
 
+    #[inline]
     fn next(&mut self) -> Option<PathSeg> {
         for el in &mut self.elements {
             // We first need to check whether this is the first


### PR DESCRIPTION
Before:
<img width="1289" height="178" alt="image" src="https://github.com/user-attachments/assets/352fcbab-9ac5-4163-b3ab-be986ffb2010" />

After:
<img width="1296" height="188" alt="image" src="https://github.com/user-attachments/assets/8db23a0b-e59e-49fa-bc7a-da50a10ad917" />
