### PR TITLE
Mark `BezPath::into_elements` `#[inline(always)]`

### DIFF
--- a/kurbo/src/bezpath.rs
+++ b/kurbo/src/bezpath.rs
@@ -273,7 +273,7 @@ impl BezPath {
     }
 
     /// Consumes the `BezPath` and returns a vector of [`PathEl`]s.
-    #[inline]
+    #[inline(always)]
     pub fn into_elements(self) -> Vec<PathEl> {
         self.0
     }


### PR DESCRIPTION
Make the hint stronger, as it gets compiled down to a no-op, so ideally it always gets inlined.

(Though I'd be surprised if it didn't get inlined with `#[inline]` as it is now.)