### PR TITLE
Experiment: `bazo` crate for vocabulary types (`Point`, `Size`, `Rect`, etc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bazo"
+version = "0.12.0"
+dependencies = [
+ "euclid",
+ "getrandom",
+ "libm",
+ "mint",
+ "rand",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["kurbo"]
+members = ["bazo", "kurbo"]
 
 [workspace.package]
 # Kurbo version, also used by other packages which want to mimic Kurbo's version.

--- a/bazo/Cargo.toml
+++ b/bazo/Cargo.toml
@@ -1,0 +1,66 @@
+[package]
+name = "bazo"
+authors = ["The bazo developers"]
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "A simple 2D shapes library"
+keywords = ["graphics", "geometry"]
+categories = ["graphics"]
+repository.workspace = true
+rust-version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+# There are no platform specific docs.
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
+
+[lints]
+workspace = true
+
+[features]
+default = ["std"]
+# Get floating point functions from the standard library (likely using your target's libc)
+std = ["euclid?/std"]
+# Use floating point implementations from libm
+libm = ["dep:libm", "euclid?/libm"]
+# Enable `From`/`Into` conversion of Kurbo and [mint] types, enabling interoperability
+# with other graphics libraries
+mint = ["dep:mint"]
+# Enable `From`/`Into` conversion of Kurbo and euclid types
+euclid = ["dep:euclid"]
+# Implement `serde::Deserialize` and `serde::Serialize` on various types
+serde = ["dep:serde"]
+# Add best-effort support for using Kurbo types in JSON schemas using schemars
+schemars = ["schemars/smallvec", "dep:schemars"]
+
+[dependencies]
+euclid = { version = "0.22", optional = true, default-features = false }
+
+[dependencies.libm]
+version = "0.2.15"
+optional = true
+
+[dependencies.mint]
+version = "0.5.9"
+optional = true
+
+[dependencies.schemars]
+version = "0.8.22"
+optional = true
+
+[dependencies.serde]
+version = "1.0.219"
+optional = true
+default-features = false
+features = ["alloc", "derive"]
+
+[dev-dependencies]
+# This is used for research but not really needed; maybe refactor.
+rand = "0.9.2"
+
+[target.wasm32-unknown-unknown.dev-dependencies]
+# We have a transitive dependency on getrandom and it does not automatically
+# support wasm32-unknown-unknown. We need to enable the wasm_js feature.
+getrandom = { version = "0.3.3", features = ["wasm_js"] }

--- a/bazo/LICENSE-APACHE
+++ b/bazo/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/bazo/LICENSE-MIT
+++ b/bazo/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018 Raph Levien
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/bazo/README.md
+++ b/bazo/README.md
@@ -1,0 +1,94 @@
+<div align="center">
+
+# Kurbo
+
+**A Rust 2D curves library**
+
+[![Linebender Zulip, #bazo channel](https://img.shields.io/badge/Linebender-%23bazo-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/260979-bazo)
+[![dependency status](https://deps.rs/repo/github/linebender/bazo/status.svg)](https://deps.rs/repo/github/linebender/bazo)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+[![Build status](https://github.com/linebender/bazo/workflows/CI/badge.svg)](https://github.com/linebender/bazo/actions)
+[![Crates.io](https://img.shields.io/crates/v/bazo.svg)](https://crates.io/crates/bazo)
+[![Docs](https://docs.rs/bazo/badge.svg)](https://docs.rs/bazo)
+
+</div>
+
+The Kurbo library contains data structures and algorithms for curves and vector paths.
+It is probably most appropriate for creative tools, but is general enough it might be useful for other applications.
+
+The name "bazo" is Esperanto for "curve".
+
+There is a focus on accuracy and good performance in high-accuracy conditions.
+Thus, the library might be useful in engineering and science contexts as well, as opposed to visual arts where rough approximations are often sufficient.
+Many approximate functions come with an accuracy parameter, and analytical solutions are used where they are practical.
+An example is area calculation, which is done using Green's theorem.
+
+The library is still in fairly early development stages.
+There are traits intended to be useful for general curves (not just Béziers), but these will probably be reorganized.
+
+## Minimum supported Rust Version (MSRV)
+
+This version of Kurbo has been verified to compile with **Rust 1.82** and later.
+
+Future versions of Kurbo might increase the Rust version requirement.
+It will not be treated as a breaking change and as such can even happen with small patch releases.
+
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some of Kurbo's dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+
+</details>
+
+## Similar crates
+
+Here we mention a few other curves libraries and touch on some of the decisions made differently here.
+
+* [lyon_geom] has a lot of very good vector algorithms. It's most focused on rendering.
+
+* [flo_curves] has good Bézier primitives, and seems tuned for animation. It's generic on the coordinate type, while we use `f64` for everything.
+
+* [vek] has both 2D and 3D Béziers among other things, and is tuned for game engines.
+
+Some code has been copied from lyon_geom with adaptation, thus the author of lyon_geom, Nicolas Silva, is credited in the [AUTHORS] file.
+
+## More info
+
+To learn more about Bézier curves, [A Primer on Bézier Curves] by Pomax is indispensable.
+
+## Community
+
+[![Linebender Zulip](https://img.shields.io/badge/Linebender-%23bazo-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/260979-bazo)
+
+Discussion of Kurbo development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#bazo channel](https://xi.zulipchat.com/#narrow/channel/260979-bazo).
+All public content can be read without logging in.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
+Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be licensed as above, without any additional terms or conditions.
+
+[Rust Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[lyon_geom]: https://crates.io/crates/lyon_geom
+[flo_curves]: https://crates.io/crates/flo_curves
+[vek]: https://crates.io/crates/vek
+[A Primer on Bézier Curves]: https://pomax.github.io/bezierinfo/
+[AUTHORS]: ./AUTHORS
+[CHANGELOG.md]: ./CHANGELOG.md

--- a/bazo/src/affine.rs
+++ b/bazo/src/affine.rs
@@ -1,0 +1,723 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Affine transforms.
+
+use core::ops::{Mul, MulAssign};
+
+use crate::{Point, Rect, Vec2};
+
+#[cfg(not(feature = "std"))]
+use crate::common::FloatFuncs;
+
+/// A 2D affine transform.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Affine([f64; 6]);
+
+impl Affine {
+    /// The identity transform.
+    pub const IDENTITY: Affine = Affine::scale(1.0);
+
+    /// A transform that is flipped on the y-axis. Useful for converting between
+    /// y-up and y-down spaces.
+    pub const FLIP_Y: Affine = Affine::new([1.0, 0., 0., -1.0, 0., 0.]);
+
+    /// A transform that is flipped on the x-axis.
+    pub const FLIP_X: Affine = Affine::new([-1.0, 0., 0., 1.0, 0., 0.]);
+
+    /// Construct an affine transform from coefficients.
+    ///
+    /// If the coefficients are `(a, b, c, d, e, f)`, then the resulting
+    /// transformation represents this augmented matrix:
+    ///
+    /// ```text
+    /// | a c e |
+    /// | b d f |
+    /// | 0 0 1 |
+    /// ```
+    ///
+    /// Note that this convention is transposed from PostScript and
+    /// Direct2D, but is consistent with the
+    /// [Wikipedia](https://en.wikipedia.org/wiki/Affine_transformation)
+    /// formulation of affine transformation as augmented matrix. The
+    /// idea is that `(A * B) * v == A * (B * v)`, where `*` is the
+    /// [`Mul`] trait.
+    #[inline(always)]
+    pub const fn new(c: [f64; 6]) -> Affine {
+        Affine(c)
+    }
+
+    /// An affine transform representing uniform scaling.
+    #[inline(always)]
+    pub const fn scale(s: f64) -> Affine {
+        Affine([s, 0.0, 0.0, s, 0.0, 0.0])
+    }
+
+    /// An affine transform representing non-uniform scaling
+    /// with different scale values for x and y
+    #[inline(always)]
+    pub const fn scale_non_uniform(s_x: f64, s_y: f64) -> Affine {
+        Affine([s_x, 0.0, 0.0, s_y, 0.0, 0.0])
+    }
+
+    /// An affine transform representing a scale of `scale` about `center`.
+    ///
+    /// Useful for a view transform that zooms at a specific point,
+    /// while keeping that point fixed in the result space.
+    ///
+    /// See [`Affine::scale()`] for more info.
+    #[inline]
+    pub fn scale_about(s: f64, center: impl Into<Point>) -> Affine {
+        let center = center.into().to_vec2();
+        Self::translate(-center)
+            .then_scale(s)
+            .then_translate(center)
+    }
+
+    /// An affine transform representing rotation.
+    ///
+    /// The convention for rotation is that a positive angle rotates a
+    /// positive X direction into positive Y. Thus, in a Y-down coordinate
+    /// system (as is common for graphics), it is a clockwise rotation, and
+    /// in Y-up (traditional for math), it is anti-clockwise.
+    ///
+    /// The angle, `th`, is expressed in radians.
+    #[inline]
+    pub fn rotate(th: f64) -> Affine {
+        let (s, c) = th.sin_cos();
+        Affine([c, s, -s, c, 0.0, 0.0])
+    }
+
+    /// An affine transform representing a rotation of `th` radians about `center`.
+    ///
+    /// See [`Affine::rotate()`] for more info.
+    #[inline]
+    pub fn rotate_about(th: f64, center: impl Into<Point>) -> Affine {
+        let center = center.into().to_vec2();
+        Self::translate(-center)
+            .then_rotate(th)
+            .then_translate(center)
+    }
+
+    /// An affine transform representing translation.
+    #[inline(always)]
+    pub fn translate<V: Into<Vec2>>(p: V) -> Affine {
+        let p = p.into();
+        Affine([1.0, 0.0, 0.0, 1.0, p.x, p.y])
+    }
+
+    /// An affine transformation representing a skew.
+    ///
+    /// The `skew_x` and `skew_y` parameters represent skew factors for the
+    /// horizontal and vertical directions, respectively.
+    ///
+    /// This is commonly used to generate a faux oblique transform for
+    /// font rendering. In this case, you can slant the glyph 20 degrees
+    /// clockwise in the horizontal direction (assuming a Y-up coordinate
+    /// system):
+    ///
+    /// ```
+    /// let oblique_transform = bazo::Affine::skew(20f64.to_radians().tan(), 0.0);
+    /// ```
+    #[inline(always)]
+    pub fn skew(skew_x: f64, skew_y: f64) -> Affine {
+        Affine([1.0, skew_y, skew_x, 1.0, 0.0, 0.0])
+    }
+
+    /// Create an affine transform that represents reflection about the line `point + direction * t, t in (-infty, infty)`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bazo::{Point, Vec2, Affine};
+    /// # fn assert_near(p0: Point, p1: Point) {
+    /// #     assert!((p1 - p0).hypot() < 1e-9, "{p0:?} != {p1:?}");
+    /// # }
+    /// let point = Point::new(1., 0.);
+    /// let vec = Vec2::new(1., 1.);
+    /// let map = Affine::reflect(point, vec);
+    /// assert_near(map * Point::new(1., 0.), Point::new(1., 0.));
+    /// assert_near(map * Point::new(2., 1.), Point::new(2., 1.));
+    /// assert_near(map * Point::new(2., 2.), Point::new(3., 1.));
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn reflect(point: impl Into<Point>, direction: impl Into<Vec2>) -> Self {
+        let point = point.into();
+        let direction = direction.into();
+
+        let n = Vec2 {
+            x: direction.y,
+            y: -direction.x,
+        }
+        .normalize();
+
+        // Compute Householder reflection matrix
+        let x2 = n.x * n.x;
+        let xy = n.x * n.y;
+        let y2 = n.y * n.y;
+        // Here we also add in the post translation, because it doesn't require any further calc.
+        let aff = Affine::new([
+            1. - 2. * x2,
+            -2. * xy,
+            -2. * xy,
+            1. - 2. * y2,
+            point.x,
+            point.y,
+        ]);
+        aff.pre_translate(-point.to_vec2())
+    }
+
+    /// A [rotation] by `th` followed by `self`.
+    ///
+    /// Equivalent to `self * Affine::rotate(th)`
+    ///
+    /// [rotation]: Affine::rotate
+    #[inline]
+    #[must_use]
+    pub fn pre_rotate(self, th: f64) -> Self {
+        self * Affine::rotate(th)
+    }
+
+    /// A [rotation] by `th` about `center` followed by `self`.
+    ///
+    /// Equivalent to `self * Affine::rotate_about(th, center)`
+    ///
+    /// [rotation]: Affine::rotate_about
+    #[inline]
+    #[must_use]
+    pub fn pre_rotate_about(self, th: f64, center: impl Into<Point>) -> Self {
+        Affine::rotate_about(th, center) * self
+    }
+
+    /// A [scale] by `scale` followed by `self`.
+    ///
+    /// Equivalent to `self * Affine::scale(scale)`
+    ///
+    /// [scale]: Affine::scale
+    #[inline]
+    #[must_use]
+    pub fn pre_scale(self, scale: f64) -> Self {
+        self * Affine::scale(scale)
+    }
+
+    /// A [scale] by `(scale_x, scale_y)` followed by `self`.
+    ///
+    /// Equivalent to `self * Affine::scale_non_uniform(scale_x, scale_y)`
+    ///
+    /// [scale]: Affine::scale_non_uniform
+    #[inline]
+    #[must_use]
+    pub fn pre_scale_non_uniform(self, scale_x: f64, scale_y: f64) -> Self {
+        self * Affine::scale_non_uniform(scale_x, scale_y)
+    }
+
+    /// A [translation] of `trans` followed by `self`.
+    ///
+    /// Equivalent to `self * Affine::translate(trans)`
+    ///
+    /// [translation]: Affine::translate
+    #[inline]
+    #[must_use]
+    pub fn pre_translate(self, trans: Vec2) -> Self {
+        self * Affine::translate(trans)
+    }
+
+    /// `self` followed by a [rotation] of `th`.
+    ///
+    /// Equivalent to `Affine::rotate(th) * self`
+    ///
+    /// [rotation]: Affine::rotate
+    #[inline]
+    #[must_use]
+    pub fn then_rotate(self, th: f64) -> Self {
+        Affine::rotate(th) * self
+    }
+
+    /// `self` followed by a [rotation] of `th` about `center`.
+    ///
+    /// Equivalent to `Affine::rotate_about(th, center) * self`
+    ///
+    /// [rotation]: Affine::rotate_about
+    #[inline]
+    #[must_use]
+    pub fn then_rotate_about(self, th: f64, center: impl Into<Point>) -> Self {
+        Affine::rotate_about(th, center) * self
+    }
+
+    /// `self` followed by a [scale] of `scale`.
+    ///
+    /// Equivalent to `Affine::scale(scale) * self`
+    ///
+    /// [scale]: Affine::scale
+    #[inline]
+    #[must_use]
+    pub fn then_scale(self, scale: f64) -> Self {
+        Affine::scale(scale) * self
+    }
+
+    /// `self` followed by a [scale] of `(scale_x, scale_y)`.
+    ///
+    /// Equivalent to `Affine::scale_non_uniform(scale_x, scale_y) * self`
+    ///
+    /// [scale]: Affine::scale_non_uniform
+    #[inline]
+    #[must_use]
+    pub fn then_scale_non_uniform(self, scale_x: f64, scale_y: f64) -> Self {
+        Affine::scale_non_uniform(scale_x, scale_y) * self
+    }
+
+    /// `self` followed by a [scale] of `scale` about `center`.
+    ///
+    /// Equivalent to `Affine::scale_about(scale) * self`
+    ///
+    /// [scale]: Affine::scale_about
+    #[inline]
+    #[must_use]
+    pub fn then_scale_about(self, scale: f64, center: impl Into<Point>) -> Self {
+        Affine::scale_about(scale, center) * self
+    }
+
+    /// `self` followed by a translation of `trans`.
+    ///
+    /// Equivalent to `Affine::translate(trans) * self`
+    ///
+    /// [translation]: Affine::translate
+    #[inline]
+    #[must_use]
+    pub fn then_translate(mut self, trans: Vec2) -> Self {
+        self.0[4] += trans.x;
+        self.0[5] += trans.y;
+        self
+    }
+
+    /// Creates an affine transformation that takes the unit square to the given rectangle.
+    ///
+    /// Useful when you want to draw into the unit square but have your output fill any rectangle.
+    /// In this case push the `Affine` onto the transform stack.
+    pub fn map_unit_square(rect: Rect) -> Affine {
+        Affine([rect.width(), 0., 0., rect.height(), rect.x0, rect.y0])
+    }
+
+    /// Get the coefficients of the transform.
+    #[inline(always)]
+    pub fn as_coeffs(self) -> [f64; 6] {
+        self.0
+    }
+
+    /// Compute the determinant of this transform.
+    pub fn determinant(self) -> f64 {
+        self.0[0] * self.0[3] - self.0[1] * self.0[2]
+    }
+
+    /// Compute the inverse transform.
+    ///
+    /// Produces NaN values when the determinant is zero.
+    pub fn inverse(self) -> Affine {
+        let inv_det = self.determinant().recip();
+        Affine([
+            inv_det * self.0[3],
+            -inv_det * self.0[1],
+            -inv_det * self.0[2],
+            inv_det * self.0[0],
+            inv_det * (self.0[2] * self.0[5] - self.0[3] * self.0[4]),
+            inv_det * (self.0[1] * self.0[4] - self.0[0] * self.0[5]),
+        ])
+    }
+
+    /// Compute the bounding box of a transformed rectangle.
+    ///
+    /// Returns the minimal `Rect` that encloses the given `Rect` after affine transformation.
+    /// If the transform is axis-aligned, then this bounding box is "tight", in other words the
+    /// returned `Rect` is the transformed rectangle.
+    ///
+    /// The returned rectangle always has non-negative width and height.
+    pub fn transform_rect_bbox(self, rect: Rect) -> Rect {
+        let p00 = self * Point::new(rect.x0, rect.y0);
+        let p01 = self * Point::new(rect.x0, rect.y1);
+        let p10 = self * Point::new(rect.x1, rect.y0);
+        let p11 = self * Point::new(rect.x1, rect.y1);
+        Rect::from_points(p00, p01).union(Rect::from_points(p10, p11))
+    }
+
+    /// Is this map [finite]?
+    ///
+    /// [finite]: f64::is_finite
+    #[inline]
+    pub fn is_finite(&self) -> bool {
+        self.0[0].is_finite()
+            && self.0[1].is_finite()
+            && self.0[2].is_finite()
+            && self.0[3].is_finite()
+            && self.0[4].is_finite()
+            && self.0[5].is_finite()
+    }
+
+    /// Is this map [NaN]?
+    ///
+    /// [NaN]: f64::is_nan
+    #[inline]
+    pub fn is_nan(&self) -> bool {
+        self.0[0].is_nan()
+            || self.0[1].is_nan()
+            || self.0[2].is_nan()
+            || self.0[3].is_nan()
+            || self.0[4].is_nan()
+            || self.0[5].is_nan()
+    }
+
+    /// Compute the singular value decomposition of the linear transformation (ignoring the
+    /// translation).
+    ///
+    /// All non-degenerate linear transformations can be represented as
+    ///
+    ///  1. a rotation about the origin.
+    ///  2. a scaling along the x and y axes
+    ///  3. another rotation about the origin
+    ///
+    /// composed together. Decomposing a 2x2 matrix in this way is called a "singular value
+    /// decomposition" and is written `U Σ V^T`, where U and V^T are orthogonal (rotations) and Σ
+    /// is a diagonal matrix (a scaling).
+    ///
+    /// Since currently this function is used to calculate ellipse radii and rotation from an
+    /// affine map on the unit circle, we don't calculate V^T, since a rotation of the unit (or
+    /// any) circle about its center always results in the same circle. This is the reason that an
+    /// ellipse mapped using an affine map is always an ellipse.
+    ///
+    /// Will return NaNs if the matrix (or equivalently the linear map) is non-finite.
+    ///
+    /// The first part of the returned tuple is the scaling, the second part is the angle of
+    /// rotation (in radians). The scaling along the x-axis is guaranteed to be greater than or
+    /// equal to the scaling along the y-axis.
+    //
+    // Note: though this does quite some computation, we are often interested only in specific
+    // components of the result. Hence this is marked `#[inline(always)]`, to give the compiler a
+    // good chance at eliminating dead code.
+    #[inline(always)]
+    pub(crate) fn svd(self) -> (Vec2, f64) {
+        let [a, b, c, d, _, _] = self.0;
+        let a2 = a * a;
+        let b2 = b * b;
+        let c2 = c * c;
+        let d2 = d * d;
+        let ab = a * b;
+        let cd = c * d;
+        let angle = 0.5 * (2.0 * (ab + cd)).atan2(a2 - b2 + c2 - d2);
+
+        // Given matrix A = [ a c ]
+        //                  [ b d ]
+        //
+        // The two singular values σ1, σ2 of A are the square roots of the two eigen values λ1, λ2
+        // of M = A^T A. The common formula for 2x2 eigenvalues requires evaluating a square root,
+        // but we'd like to compute the singular values of the matrix without nested square roots.
+        //
+        // M = A^T A = [ aa+cc   ab+cd ]
+        //             [ ab+cd   bb+dd ]
+        //
+        // We have
+        // λ = 1/2 (tr(M) ± sqrt(tr(M)^2 - 4 det(M))).
+        //
+        // Note det(M) = det(A^T A) = det(A)^2.
+        // => 2λ = tr(M) ± sqrt(tr(M)^2 - 4 det(A)^2)
+        // => 2λ = tr(M) ± sqrt[(a^2+b^2+c^2+d^2)^2 - 4 (ad-bc)^2]
+        // By factorizing the inner term,
+        // => 2λ = tr(M) ± sqrt[((a+d)^2 + (b-c)^2) ((a-d)^2 + (b+c)^2)]
+        // => 2λ = tr(M) ± sqrt[(a+d)^2 + (b-c)^2] sqrt[(a-d)^2 + (b+c)^2]
+        //
+        // Define S1 = sqrt[(a+d)^2 + (b-c)^2]
+        //        S2 = sqrt[(a-d)^2 + (b+c)^2].
+        //
+        // => 2λ = tr(M) ± S1 S2
+        // => 2λ = 1/2 (S1^2 + S2^2) ± S1 S2
+        // => λ = 1/4 (S1^2 + S2^2 ± 2 S1 S2)
+        // => λ = 1/4 (S1 ± S2)^2
+        //
+        // Note we're interested in
+        // σ = sqrt(λ).
+        //
+        // => σ1 = 1/2 (S1 + S2)
+        // and similarly σ2 = 1/2 |S1 - S2|
+        let s1 = ((a + d).powi(2) + (b - c).powi(2)).sqrt();
+        let s2 = ((a - d).powi(2) + (b + c).powi(2)).sqrt();
+        (
+            Vec2 {
+                x: 0.5 * (s1 + s2),
+                y: 0.5 * (s1 - s2).abs(),
+            },
+            angle,
+        )
+    }
+
+    /// Returns the translation part of this affine map (`(self.0[4], self.0[5])`).
+    #[inline(always)]
+    pub fn translation(self) -> Vec2 {
+        Vec2 {
+            x: self.0[4],
+            y: self.0[5],
+        }
+    }
+
+    /// Replaces the translation portion of this affine map
+    ///
+    /// The translation can be seen as being applied after the linear part of the map.
+    #[must_use]
+    #[inline(always)]
+    pub fn with_translation(mut self, trans: Vec2) -> Affine {
+        self.0[4] = trans.x;
+        self.0[5] = trans.y;
+        self
+    }
+}
+
+impl Default for Affine {
+    #[inline(always)]
+    fn default() -> Affine {
+        Affine::IDENTITY
+    }
+}
+
+impl Mul<Point> for Affine {
+    type Output = Point;
+
+    #[inline]
+    fn mul(self, other: Point) -> Point {
+        Point::new(
+            self.0[0] * other.x + self.0[2] * other.y + self.0[4],
+            self.0[1] * other.x + self.0[3] * other.y + self.0[5],
+        )
+    }
+}
+
+impl Mul for Affine {
+    type Output = Affine;
+
+    #[inline]
+    fn mul(self, other: Affine) -> Affine {
+        Affine([
+            self.0[0] * other.0[0] + self.0[2] * other.0[1],
+            self.0[1] * other.0[0] + self.0[3] * other.0[1],
+            self.0[0] * other.0[2] + self.0[2] * other.0[3],
+            self.0[1] * other.0[2] + self.0[3] * other.0[3],
+            self.0[0] * other.0[4] + self.0[2] * other.0[5] + self.0[4],
+            self.0[1] * other.0[4] + self.0[3] * other.0[5] + self.0[5],
+        ])
+    }
+}
+
+impl MulAssign for Affine {
+    #[inline]
+    fn mul_assign(&mut self, other: Affine) {
+        *self = self.mul(other);
+    }
+}
+
+impl Mul<Affine> for f64 {
+    type Output = Affine;
+
+    #[inline]
+    fn mul(self, other: Affine) -> Affine {
+        Affine([
+            self * other.0[0],
+            self * other.0[1],
+            self * other.0[2],
+            self * other.0[3],
+            self * other.0[4],
+            self * other.0[5],
+        ])
+    }
+}
+
+// Conversions to and from mint
+#[cfg(feature = "mint")]
+impl From<Affine> for mint::ColumnMatrix2x3<f64> {
+    #[inline(always)]
+    fn from(a: Affine) -> mint::ColumnMatrix2x3<f64> {
+        mint::ColumnMatrix2x3 {
+            x: mint::Vector2 {
+                x: a.0[0],
+                y: a.0[1],
+            },
+            y: mint::Vector2 {
+                x: a.0[2],
+                y: a.0[3],
+            },
+            z: mint::Vector2 {
+                x: a.0[4],
+                y: a.0[5],
+            },
+        }
+    }
+}
+
+#[cfg(feature = "mint")]
+impl From<mint::ColumnMatrix2x3<f64>> for Affine {
+    #[inline(always)]
+    fn from(m: mint::ColumnMatrix2x3<f64>) -> Affine {
+        Affine([m.x.x, m.x.y, m.y.x, m.y.y, m.z.x, m.z.y])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Affine, Point, Vec2};
+    use std::f64::consts::PI;
+
+    fn assert_near(p0: Point, p1: Point) {
+        assert!((p1 - p0).hypot() < 1e-9, "{p0:?} != {p1:?}");
+    }
+
+    fn affine_assert_near(a0: Affine, a1: Affine) {
+        for i in 0..6 {
+            assert!((a0.0[i] - a1.0[i]).abs() < 1e-9, "{a0:?} != {a1:?}");
+        }
+    }
+
+    #[test]
+    fn affine_basic() {
+        let p = Point::new(3.0, 4.0);
+
+        assert_near(Affine::default() * p, p);
+        assert_near(Affine::scale(2.0) * p, Point::new(6.0, 8.0));
+        assert_near(Affine::rotate(0.0) * p, p);
+        assert_near(Affine::rotate(PI / 2.0) * p, Point::new(-4.0, 3.0));
+        assert_near(Affine::translate((5.0, 6.0)) * p, Point::new(8.0, 10.0));
+        assert_near(Affine::skew(0.0, 0.0) * p, p);
+        assert_near(Affine::skew(2.0, 4.0) * p, Point::new(11.0, 16.0));
+    }
+
+    #[test]
+    fn affine_mul() {
+        let a1 = Affine::new([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let a2 = Affine::new([0.1, 1.2, 2.3, 3.4, 4.5, 5.6]);
+
+        let px = Point::new(1.0, 0.0);
+        let py = Point::new(0.0, 1.0);
+        let pxy = Point::new(1.0, 1.0);
+        assert_near(a1 * (a2 * px), (a1 * a2) * px);
+        assert_near(a1 * (a2 * py), (a1 * a2) * py);
+        assert_near(a1 * (a2 * pxy), (a1 * a2) * pxy);
+    }
+
+    #[test]
+    fn affine_inv() {
+        let a = Affine::new([0.1, 1.2, 2.3, 3.4, 4.5, 5.6]);
+        let a_inv = a.inverse();
+
+        let px = Point::new(1.0, 0.0);
+        let py = Point::new(0.0, 1.0);
+        let pxy = Point::new(1.0, 1.0);
+        assert_near(a * (a_inv * px), px);
+        assert_near(a * (a_inv * py), py);
+        assert_near(a * (a_inv * pxy), pxy);
+        assert_near(a_inv * (a * px), px);
+        assert_near(a_inv * (a * py), py);
+        assert_near(a_inv * (a * pxy), pxy);
+    }
+
+    #[test]
+    fn reflection() {
+        affine_assert_near(
+            Affine::reflect(Point::ZERO, (1., 0.)),
+            Affine::new([1., 0., 0., -1., 0., 0.]),
+        );
+        affine_assert_near(
+            Affine::reflect(Point::ZERO, (0., 1.)),
+            Affine::new([-1., 0., 0., 1., 0., 0.]),
+        );
+        // y = x
+        affine_assert_near(
+            Affine::reflect(Point::ZERO, (1., 1.)),
+            Affine::new([0., 1., 1., 0., 0., 0.]),
+        );
+
+        // no translate
+        let point = Point::new(0., 0.);
+        let vec = Vec2::new(1., 1.);
+        let map = Affine::reflect(point, vec);
+        assert_near(map * Point::new(0., 0.), Point::new(0., 0.));
+        assert_near(map * Point::new(1., 1.), Point::new(1., 1.));
+        assert_near(map * Point::new(1., 2.), Point::new(2., 1.));
+
+        // with translate
+        let point = Point::new(1., 0.);
+        let vec = Vec2::new(1., 1.);
+        let map = Affine::reflect(point, vec);
+        assert_near(map * Point::new(1., 0.), Point::new(1., 0.));
+        assert_near(map * Point::new(2., 1.), Point::new(2., 1.));
+        assert_near(map * Point::new(2., 2.), Point::new(3., 1.));
+    }
+
+    #[test]
+    fn svd() {
+        let a = Affine::new([1., 2., 3., 4., 5., 6.]);
+        let a_no_translate = a.with_translation(Vec2::ZERO);
+
+        // translation should have no effect
+        let (scale, rotation) = a.svd();
+        let (scale_no_translate, rotation_no_translate) = a_no_translate.svd();
+        assert_near(scale.to_point(), scale_no_translate.to_point());
+        assert!((rotation - rotation_no_translate).abs() <= 1e-9);
+
+        assert_near(
+            scale.to_point(),
+            Point::new(5.4649857042190427, 0.36596619062625782),
+        );
+        assert!((rotation - 0.95691013360780001).abs() <= 1e-9);
+
+        // singular affine
+        let a = Affine::new([0., 0., 0., 0., 5., 6.]);
+        assert_eq!(a.determinant(), 0.);
+        let (scale, rotation) = a.svd();
+        assert_eq!(scale, Vec2::new(0., 0.));
+        assert_eq!(rotation, 0.);
+    }
+
+    #[test]
+    fn svd_singular_values() {
+        // Test a few known singular values.
+        let mat = |a, b, c, d| Affine::new([a, b, c, d, 0., 0.]);
+
+        let s = mat(1., 0., 0., 1.).svd().0;
+        assert_near(s.to_point(), Point::new(1., 1.));
+
+        let s = mat(1., 0., 0., -1.).svd().0;
+        assert_near(s.to_point(), Point::new(1., 1.));
+
+        let s = mat(1., 1., 1., 1.).svd().0;
+        assert_near(s.to_point(), Point::new(2., 0.));
+
+        let s = mat(1., 1., 1., 1.).svd().0;
+        assert_near(s.to_point(), Point::new(2., 0.));
+
+        let s = mat(0., 0., 1., 0.).svd().0;
+        assert_near(s.to_point(), Point::new(1., 0.));
+
+        // The singular values are the scaling of the affine map. So let's test that.
+        let s = Affine::scale_non_uniform(4., 8.)
+            .then_rotate_about(42_f64.to_radians(), (-2., 50.))
+            .svd()
+            .0;
+        assert_near(s.to_point(), Point::new(8., 4.));
+
+        // Correctly handles negative scaling (singular values are necessarily non-negative).
+        let s = Affine::scale_non_uniform(-20., 3.).svd().0;
+        assert_near(s.to_point(), Point::new(20., 3.));
+        let s = Affine::scale_non_uniform(-20., -3.).svd().0;
+        assert_near(s.to_point(), Point::new(20., 3.));
+        let s = Affine::scale_non_uniform(20., -3.).svd().0;
+        assert_near(s.to_point(), Point::new(20., 3.));
+
+        // One more property: given a full-rank transform, the product of its singular values
+        // should be equal to its absolute determinant.
+        let m = mat(10., 9., -2.5, 3.3333);
+        let s = m.svd().0;
+        let prod = s.x * s.y;
+        let det = m.determinant().abs();
+        assert!(
+            (prod - det) < 1e-9,
+            "The product of the singular values {s:?} ({prod}) should be equal to the absolute determinant {det}.",
+        );
+    }
+}

--- a/bazo/src/arc.rs
+++ b/bazo/src/arc.rs
@@ -1,0 +1,103 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! An ellipse arc.
+
+use crate::{Affine, Ellipse, Point, Vec2};
+use core::ops::Mul;
+
+#[cfg(not(feature = "std"))]
+use crate::common::FloatFuncs;
+
+/// A single elliptical arc segment.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Arc {
+    /// The arc's centre point.
+    pub center: Point,
+    /// The arc's radii, where the vector's x-component is the radius in the
+    /// positive x direction after applying `x_rotation`.
+    pub radii: Vec2,
+    /// The start angle in radians.
+    pub start_angle: f64,
+    /// The angle between the start and end of the arc, in radians.
+    pub sweep_angle: f64,
+    /// How much the arc is rotated, in radians.
+    pub x_rotation: f64,
+}
+
+impl Arc {
+    /// Create a new `Arc`.
+    #[inline(always)]
+    pub fn new(
+        center: impl Into<Point>,
+        radii: impl Into<Vec2>,
+        start_angle: f64,
+        sweep_angle: f64,
+        x_rotation: f64,
+    ) -> Self {
+        Self {
+            center: center.into(),
+            radii: radii.into(),
+            start_angle,
+            sweep_angle,
+            x_rotation,
+        }
+    }
+
+    /// Returns a copy of this `Arc` in the opposite direction.
+    ///
+    /// The new `Arc` will sweep towards the original `Arc`s
+    /// start angle.
+    #[must_use]
+    #[inline]
+    pub fn reversed(&self) -> Arc {
+        Self {
+            center: self.center,
+            radii: self.radii,
+            start_angle: self.start_angle + self.sweep_angle,
+            sweep_angle: -self.sweep_angle,
+            x_rotation: self.x_rotation,
+        }
+    }
+}
+
+impl Mul<Arc> for Affine {
+    type Output = Arc;
+
+    fn mul(self, arc: Arc) -> Self::Output {
+        let ellipse = self * Ellipse::new(arc.center, arc.radii, arc.x_rotation);
+        let center = ellipse.center();
+        let (radii, rotation) = ellipse.radii_and_rotation();
+        Arc {
+            center,
+            radii,
+            x_rotation: rotation,
+            start_angle: arc.start_angle,
+            sweep_angle: arc.sweep_angle,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::f64::consts::PI;
+    #[test]
+    fn reversed_arc() {
+        let a = Arc::new((0., 0.), (1., 0.), 0., PI, 0.);
+        let f = a.reversed();
+
+        // Most fields should be unchanged:
+        assert_eq!(a.center, f.center);
+        assert_eq!(a.radii, f.radii);
+        assert_eq!(a.x_rotation, f.x_rotation);
+
+        // Sweep angle should be in reverse
+        assert_eq!(a.sweep_angle, -f.sweep_angle);
+
+        // Reversing it again should result in the original arc
+        assert_eq!(a, f.reversed());
+    }
+}

--- a/bazo/src/axis.rs
+++ b/bazo/src/axis.rs
@@ -1,0 +1,63 @@
+// Copyright 2025 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::{Point, Size, Vec2};
+
+/// An axis in the plane.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Axis {
+    /// The x axis.
+    Horizontal,
+    /// The y axis.
+    Vertical,
+}
+
+impl Axis {
+    /// Get the axis perpendicular to this one.
+    #[inline]
+    pub fn cross(self) -> Self {
+        match self {
+            Self::Horizontal => Self::Vertical,
+            Self::Vertical => Self::Horizontal,
+        }
+    }
+
+    /// Create a new [`Point`] by arranging the given magnitudes.
+    ///
+    /// The axis value is the one matching the axis (e.g. `y` for [`Self::Vertical`]).
+    /// The cross value is the other one.
+    #[inline]
+    pub fn pack_point(self, axis_value: f64, cross_value: f64) -> Point {
+        self.pack_xy(axis_value, cross_value).into()
+    }
+
+    /// Create a new [`Size`] by arranging the given magnitudes.
+    ///
+    /// The axis value is the one matching the axis (e.g. `height` for [`Self::Vertical`]).
+    /// The cross value is the other one.
+    #[inline]
+    pub fn pack_size(self, axis_value: f64, cross_value: f64) -> Size {
+        self.pack_xy(axis_value, cross_value).into()
+    }
+
+    /// Create a new [`Vec2`] by arranging the given magnitudes.
+    ///
+    /// The axis value is the one matching the axis (e.g. `y` for [`Self::Vertical`]).
+    /// The cross value is the other one.
+    #[inline]
+    pub fn pack_vec2(self, axis_value: f64, cross_value: f64) -> Vec2 {
+        self.pack_xy(axis_value, cross_value).into()
+    }
+
+    /// Create a new `(x, y)` pair by arranging the given magnitudes.
+    ///
+    /// The axis value is the one matching the axis (e.g. `y` for [`Self::Vertical`]).
+    /// The cross value is the other one.
+    #[inline]
+    pub fn pack_xy(self, axis_value: f64, cross_value: f64) -> (f64, f64) {
+        match self {
+            Self::Horizontal => (axis_value, cross_value),
+            Self::Vertical => (cross_value, axis_value),
+        }
+    }
+}

--- a/bazo/src/circle.rs
+++ b/bazo/src/circle.rs
@@ -1,0 +1,211 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Implementation of circle shape.
+
+use core::ops::{Add, Mul, Sub};
+
+use crate::{Affine, Arc, Ellipse, Point, Vec2};
+
+#[cfg(not(feature = "std"))]
+use crate::common::FloatFuncs;
+
+/// A circle.
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Circle {
+    /// The center.
+    pub center: Point,
+    /// The radius.
+    pub radius: f64,
+}
+
+impl Circle {
+    /// A new circle from center and radius.
+    #[inline(always)]
+    pub fn new(center: impl Into<Point>, radius: f64) -> Circle {
+        Circle {
+            center: center.into(),
+            radius,
+        }
+    }
+
+    /// Create a [`CircleSegment`] by cutting out parts of this circle.
+    #[inline(always)]
+    pub fn segment(self, inner_radius: f64, start_angle: f64, sweep_angle: f64) -> CircleSegment {
+        CircleSegment {
+            center: self.center,
+            outer_radius: self.radius,
+            inner_radius,
+            start_angle,
+            sweep_angle,
+        }
+    }
+
+    /// Is this circle [finite]?
+    ///
+    /// [finite]: f64::is_finite
+    #[inline]
+    pub fn is_finite(&self) -> bool {
+        self.center.is_finite() && self.radius.is_finite()
+    }
+
+    /// Is this circle [NaN]?
+    ///
+    /// [NaN]: f64::is_nan
+    #[inline]
+    pub fn is_nan(&self) -> bool {
+        self.center.is_nan() || self.radius.is_nan()
+    }
+}
+
+impl Add<Vec2> for Circle {
+    type Output = Circle;
+
+    #[inline]
+    fn add(self, v: Vec2) -> Circle {
+        Circle {
+            center: self.center + v,
+            radius: self.radius,
+        }
+    }
+}
+
+impl Sub<Vec2> for Circle {
+    type Output = Circle;
+
+    #[inline]
+    fn sub(self, v: Vec2) -> Circle {
+        Circle {
+            center: self.center - v,
+            radius: self.radius,
+        }
+    }
+}
+
+impl Mul<Circle> for Affine {
+    type Output = Ellipse;
+    fn mul(self, other: Circle) -> Self::Output {
+        self * Ellipse::from(other)
+    }
+}
+
+/// A segment of a circle.
+///
+/// If `inner_radius > 0`, then the shape will be a doughnut segment.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CircleSegment {
+    /// The center.
+    pub center: Point,
+    /// The outer radius.
+    pub outer_radius: f64,
+    /// The inner radius.
+    pub inner_radius: f64,
+    /// The angle to start drawing the segment (in radians).
+    pub start_angle: f64,
+    /// The arc length of the segment (in radians).
+    pub sweep_angle: f64,
+}
+
+impl CircleSegment {
+    /// Create a `CircleSegment` out of its constituent parts.
+    #[inline(always)]
+    pub fn new(
+        center: impl Into<Point>,
+        outer_radius: f64,
+        inner_radius: f64,
+        start_angle: f64,
+        sweep_angle: f64,
+    ) -> Self {
+        CircleSegment {
+            center: center.into(),
+            outer_radius,
+            inner_radius,
+            start_angle,
+            sweep_angle,
+        }
+    }
+
+    /// Return an arc representing the outer radius.
+    #[must_use]
+    #[inline(always)]
+    pub fn outer_arc(&self) -> Arc {
+        Arc {
+            center: self.center,
+            radii: Vec2::new(self.outer_radius, self.outer_radius),
+            start_angle: self.start_angle,
+            sweep_angle: self.sweep_angle,
+            x_rotation: 0.0,
+        }
+    }
+
+    /// Return an arc representing the inner radius.
+    ///
+    /// This is [reversed] from the outer arc, so that it is in the
+    /// same direction as the arc that would be drawn (as the path
+    /// elements for this circle segment produce a closed path).
+    ///
+    /// [reversed]: Arc::reversed
+    #[must_use]
+    #[inline]
+    pub fn inner_arc(&self) -> Arc {
+        Arc {
+            center: self.center,
+            radii: Vec2::new(self.inner_radius, self.inner_radius),
+            start_angle: self.start_angle + self.sweep_angle,
+            sweep_angle: -self.sweep_angle,
+            x_rotation: 0.0,
+        }
+    }
+
+    /// Is this circle segment [finite]?
+    ///
+    /// [finite]: f64::is_finite
+    #[inline]
+    pub fn is_finite(&self) -> bool {
+        self.center.is_finite()
+            && self.outer_radius.is_finite()
+            && self.inner_radius.is_finite()
+            && self.start_angle.is_finite()
+            && self.sweep_angle.is_finite()
+    }
+
+    /// Is this circle segment [NaN]?
+    ///
+    /// [NaN]: f64::is_nan
+    #[inline]
+    pub fn is_nan(&self) -> bool {
+        self.center.is_nan()
+            || self.outer_radius.is_nan()
+            || self.inner_radius.is_nan()
+            || self.start_angle.is_nan()
+            || self.sweep_angle.is_nan()
+    }
+}
+
+impl Add<Vec2> for CircleSegment {
+    type Output = CircleSegment;
+
+    #[inline]
+    fn add(self, v: Vec2) -> Self {
+        Self {
+            center: self.center + v,
+            ..self
+        }
+    }
+}
+
+impl Sub<Vec2> for CircleSegment {
+    type Output = CircleSegment;
+
+    #[inline]
+    fn sub(self, v: Vec2) -> Self {
+        Self {
+            center: self.center - v,
+            ..self
+        }
+    }
+}

--- a/bazo/src/common.rs
+++ b/bazo/src/common.rs
@@ -1,0 +1,175 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Common mathematical operations
+
+#![allow(missing_docs)]
+
+#[cfg(not(feature = "std"))]
+mod sealed {
+    /// A [sealed trait](https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/)
+    /// which stops [`super::FloatFuncs`] from being implemented outside bazo. This could
+    /// be relaxed in the future if there is are good reasons to allow external impls.
+    /// The benefit from being sealed is that we can add methods without breaking downstream
+    /// implementations.
+    pub trait FloatFuncsSealed {}
+}
+
+/// Defines a trait that chooses between libstd or libm implementations of float methods.
+///
+/// Some methods will eventually became available in core by
+/// [`core_float_math`](https://github.com/rust-lang/rust/issues/137578)
+macro_rules! define_float_funcs {
+    ($(
+        fn $name:ident(self $(,$arg:ident: $arg_ty:ty)*) -> $ret:ty
+        => $lname:ident/$lfname:ident;
+    )+) => {
+
+        /// Since core doesn't depend upon libm, this provides libm implementations
+        /// of float functions which are typically provided by the std library, when
+        /// the `std` feature is not enabled.
+        ///
+        /// For documentation see the respective functions in the std library.
+        #[cfg(not(feature = "std"))]
+        pub trait FloatFuncs : Sized + sealed::FloatFuncsSealed {
+            /// For documentation see <https://doc.rust-lang.org/std/primitive.f64.html#method.signum>
+            ///
+            /// Special implementation, because libm doesn't have it.
+            fn signum(self) -> Self;
+
+            /// For documentation see <https://doc.rust-lang.org/std/primitive.f64.html#method.rem_euclid>
+            ///
+            /// Special implementation, because libm doesn't have it.
+            fn rem_euclid(self, rhs: Self) -> Self;
+
+            $(fn $name(self $(,$arg: $arg_ty)*) -> $ret;)+
+        }
+
+        #[cfg(not(feature = "std"))]
+        impl sealed::FloatFuncsSealed for f32 {}
+
+        #[cfg(not(feature = "std"))]
+        impl FloatFuncs for f32 {
+            #[inline]
+            fn signum(self) -> f32 {
+                if self.is_nan() {
+                    f32::NAN
+                } else {
+                    1.0_f32.copysign(self)
+                }
+            }
+
+            #[inline]
+            fn rem_euclid(self, rhs: Self) -> Self {
+                let r = self % rhs;
+                if r < 0.0 {
+                    r + rhs.abs()
+                } else {
+                    r
+                }
+            }
+
+            $(fn $name(self $(,$arg: $arg_ty)*) -> $ret {
+                #[cfg(feature = "libm")]
+                return libm::$lfname(self $(,$arg as _)*);
+
+                #[cfg(not(feature = "libm"))]
+                compile_error!("bazo requires either the `std` or `libm` feature")
+            })+
+        }
+
+        #[cfg(not(feature = "std"))]
+        impl sealed::FloatFuncsSealed for f64 {}
+        #[cfg(not(feature = "std"))]
+        impl FloatFuncs for f64 {
+            #[inline]
+            fn signum(self) -> f64 {
+                if self.is_nan() {
+                    f64::NAN
+                } else {
+                    1.0_f64.copysign(self)
+                }
+            }
+
+            #[inline]
+            fn rem_euclid(self, rhs: Self) -> Self {
+                let r = self % rhs;
+                if r < 0.0 {
+                    r + rhs.abs()
+                } else {
+                    r
+                }
+            }
+
+            $(fn $name(self $(,$arg: $arg_ty)*) -> $ret {
+                #[cfg(feature = "libm")]
+                return libm::$lname(self $(,$arg as _)*);
+
+                #[cfg(not(feature = "libm"))]
+                compile_error!("bazo requires either the `std` or `libm` feature")
+            })+
+        }
+    }
+}
+
+define_float_funcs! {
+    fn abs(self) -> Self => fabs/fabsf;
+    fn acos(self) -> Self => acos/acosf;
+    fn atan2(self, other: Self) -> Self => atan2/atan2f;
+    fn cbrt(self) -> Self => cbrt/cbrtf;
+    fn ceil(self) -> Self => ceil/ceilf;
+    fn cos(self) -> Self => cos/cosf;
+    fn copysign(self, sign: Self) -> Self => copysign/copysignf;
+    fn floor(self) -> Self => floor/floorf;
+    fn hypot(self, other: Self) -> Self => hypot/hypotf;
+    fn ln(self) -> Self => log/logf;
+    fn log2(self) -> Self => log2/log2f;
+    fn mul_add(self, a: Self, b: Self) -> Self => fma/fmaf;
+    fn powi(self, n: i32) -> Self => pow/powf;
+    fn powf(self, n: Self) -> Self => pow/powf;
+    fn round(self) -> Self => round/roundf;
+    fn sin(self) -> Self => sin/sinf;
+    fn sin_cos(self) -> (Self, Self) => sincos/sincosf;
+    fn sqrt(self) -> Self => sqrt/sqrtf;
+    fn tan(self) -> Self => tan/tanf;
+    fn trunc(self) -> Self => trunc/truncf;
+}
+
+/// Adds convenience methods to `f32` and `f64`.
+pub trait FloatExt<T> {
+    /// Rounds to the nearest integer away from zero,
+    /// unless the provided value is already an integer.
+    ///
+    /// It is to `ceil` what `trunc` is to `floor`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::common::FloatExt;
+    ///
+    /// let f = 3.7_f64;
+    /// let g = 3.0_f64;
+    /// let h = -3.7_f64;
+    /// let i = -5.1_f32;
+    ///
+    /// assert_eq!(f.expand(), 4.0);
+    /// assert_eq!(g.expand(), 3.0);
+    /// assert_eq!(h.expand(), -4.0);
+    /// assert_eq!(i.expand(), -6.0);
+    /// ```
+    fn expand(&self) -> T;
+}
+
+impl FloatExt<f64> for f64 {
+    #[inline]
+    fn expand(&self) -> f64 {
+        self.abs().ceil().copysign(*self)
+    }
+}
+
+impl FloatExt<f32> for f32 {
+    #[inline]
+    fn expand(&self) -> f32 {
+        self.abs().ceil().copysign(*self)
+    }
+}

--- a/bazo/src/ellipse.rs
+++ b/bazo/src/ellipse.rs
@@ -1,0 +1,217 @@
+// Copyright 2020 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Implementation of ellipse shape.
+
+use core::ops::{Add, Mul, Sub};
+
+use crate::{Affine, Circle, Point, Rect, Size, Vec2};
+
+#[cfg(not(feature = "std"))]
+use crate::common::FloatFuncs;
+
+/// An ellipse.
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Ellipse {
+    /// All ellipses can be represented as an affine map of the unit circle,
+    /// centred at (0, 0). Therefore we can store the ellipse as an affine map,
+    /// with the implication that it be applied to the unit circle to recover the
+    /// actual shape.
+    inner: Affine,
+}
+
+impl Ellipse {
+    /// Create A new ellipse with a given center, radii, and rotation.
+    ///
+    /// The returned ellipse will be the result of taking a circle, stretching
+    /// it by the `radii` along the x and y axes, then rotating it from the
+    /// x axis by `rotation` radians, before finally translating the center
+    /// to `center`.
+    ///
+    /// Rotation is clockwise in a y-down coordinate system. For more on
+    /// rotation, see [`Affine::rotate`].
+    #[inline]
+    pub fn new(center: impl Into<Point>, radii: impl Into<Vec2>, x_rotation: f64) -> Ellipse {
+        let Point { x: cx, y: cy } = center.into();
+        let Vec2 { x: rx, y: ry } = radii.into();
+        Ellipse::private_new(Vec2 { x: cx, y: cy }, rx, ry, x_rotation)
+    }
+
+    /// Returns the largest ellipse that can be bounded by this [`Rect`].
+    ///
+    /// This uses the absolute width and height of the rectangle.
+    ///
+    /// This ellipse is always axis-aligned; to apply rotation you can call
+    /// [`with_rotation`] with the result.
+    ///
+    /// [`with_rotation`]: Ellipse::with_rotation
+    #[inline]
+    pub fn from_rect(rect: Rect) -> Self {
+        let center = rect.center().to_vec2();
+        let Size { width, height } = rect.size() / 2.0;
+        Ellipse::private_new(center, width, height, 0.0)
+    }
+
+    /// Create an ellipse from an affine transformation of the unit circle.
+    #[inline(always)]
+    pub fn from_affine(affine: Affine) -> Self {
+        Ellipse { inner: affine }
+    }
+
+    /// Create a new `Ellipse` centered on the provided point.
+    #[inline]
+    #[must_use]
+    pub fn with_center(self, new_center: impl Into<Point>) -> Ellipse {
+        let Point { x: cx, y: cy } = new_center.into();
+        Ellipse {
+            inner: self.inner.with_translation(Vec2 { x: cx, y: cy }),
+        }
+    }
+
+    /// Create a new `Ellipse` with the provided radii.
+    #[inline]
+    #[must_use]
+    pub fn with_radii(self, new_radii: Vec2) -> Ellipse {
+        let rotation = self.inner.svd().1;
+        let translation = self.inner.translation();
+        Ellipse::private_new(translation, new_radii.x, new_radii.y, rotation)
+    }
+
+    /// Create a new `Ellipse`, with the rotation replaced by `rotation`
+    /// radians.
+    ///
+    /// The rotation is clockwise, for a y-down coordinate system. For more
+    /// on rotation, See [`Affine::rotate`].
+    #[inline]
+    #[must_use]
+    pub fn with_rotation(self, rotation: f64) -> Ellipse {
+        let scale = self.inner.svd().0;
+        let translation = self.inner.translation();
+        Ellipse::private_new(translation, scale.x, scale.y, rotation)
+    }
+
+    /// This gives us an internal method without any type conversions.
+    #[inline]
+    fn private_new(center: Vec2, scale_x: f64, scale_y: f64, x_rotation: f64) -> Ellipse {
+        // Since the circle is symmetric about the x and y axes, using absolute values for the
+        // radii results in the same ellipse. For simplicity we make this change here.
+        Ellipse {
+            inner: Affine::translate(center)
+                * Affine::rotate(x_rotation)
+                * Affine::scale_non_uniform(scale_x.abs(), scale_y.abs()),
+        }
+    }
+
+    // Getters and setters.
+
+    /// Returns the center of this ellipse.
+    #[inline(always)]
+    pub fn center(&self) -> Point {
+        self.inner.translation().to_point()
+    }
+
+    /// Returns the two radii of this ellipse.
+    ///
+    /// The first number is the horizontal radius and the second is the vertical
+    /// radius, before rotation.
+    ///
+    /// If you are only interested in the value of the greatest or smallest radius of this ellipse,
+    /// consider using [`Ellipse::major_radius`] or [`Ellipse::minor_radius`] instead.
+    #[inline]
+    pub fn radii(&self) -> Vec2 {
+        self.inner.svd().0
+    }
+
+    /// Returns the major radius of this ellipse.
+    ///
+    /// This metric is also known as the semi-major axis.
+    #[inline]
+    pub fn major_radius(&self) -> f64 {
+        self.inner.svd().0.x
+    }
+
+    /// Returns the minor radius of this ellipse.
+    ///
+    /// This metric is also known as the semi-minor axis.
+    #[inline]
+    pub fn minor_radius(&self) -> f64 {
+        self.inner.svd().0.y
+    }
+
+    /// The ellipse's rotation, in radians.
+    ///
+    /// This allows all possible ellipses to be drawn by always starting with
+    /// an ellipse with the two radii on the x and y axes.
+    #[inline]
+    pub fn rotation(&self) -> f64 {
+        self.inner.svd().1
+    }
+
+    /// Returns the radii and the rotation of this ellipse.
+    ///
+    /// Equivalent to `(self.radii(), self.rotation())` but more efficient.
+    #[inline]
+    pub fn radii_and_rotation(&self) -> (Vec2, f64) {
+        self.inner.svd()
+    }
+
+    /// Is this ellipse [finite]?
+    ///
+    /// [finite]: f64::is_finite
+    #[inline]
+    pub fn is_finite(&self) -> bool {
+        self.inner.is_finite()
+    }
+
+    /// Is this ellipse [NaN]?
+    ///
+    /// [NaN]: f64::is_nan
+    #[inline]
+    pub fn is_nan(&self) -> bool {
+        self.inner.is_nan()
+    }
+}
+
+impl Add<Vec2> for Ellipse {
+    type Output = Ellipse;
+
+    /// In this context adding a `Vec2` applies the corresponding translation to the ellipse.
+    #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn add(self, v: Vec2) -> Ellipse {
+        Ellipse {
+            inner: Affine::translate(v) * self.inner,
+        }
+    }
+}
+
+impl Sub<Vec2> for Ellipse {
+    type Output = Ellipse;
+
+    /// In this context subtracting a `Vec2` applies the corresponding translation to the ellipse.
+    #[inline]
+    fn sub(self, v: Vec2) -> Ellipse {
+        Ellipse {
+            inner: Affine::translate(-v) * self.inner,
+        }
+    }
+}
+
+impl Mul<Ellipse> for Affine {
+    type Output = Ellipse;
+    #[inline]
+    fn mul(self, other: Ellipse) -> Self::Output {
+        Ellipse {
+            inner: self * other.inner,
+        }
+    }
+}
+
+impl From<Circle> for Ellipse {
+    #[inline]
+    fn from(circle: Circle) -> Self {
+        Ellipse::new(circle.center, Vec2::splat(circle.radius), 0.0)
+    }
+}

--- a/bazo/src/insets.rs
+++ b/bazo/src/insets.rs
@@ -1,0 +1,336 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! A description of the distances between the edges of two rectangles.
+
+use core::ops::{Add, Div, Mul, Neg, Sub};
+
+use crate::{Rect, Size};
+
+/// Insets from the edges of a rectangle.
+///
+///
+/// The inset value for each edge can be thought of as a delta computed from
+/// the center of the rect to that edge. For instance, with an inset of `2.0` on
+/// the x-axis, a rectangle with the origin `(0.0, 0.0)` with that inset added
+/// will have the new origin at `(-2.0, 0.0)`.
+///
+/// Put alternatively, a positive inset represents increased distance from center,
+/// and a negative inset represents decreased distance from center.
+///
+/// # Examples
+///
+/// Positive insets added to a [`Rect`] produce a larger [`Rect`]:
+/// ```
+/// # use bazo::{Insets, Rect};
+/// let rect = Rect::from_origin_size((0., 0.,), (10., 10.,));
+/// let insets = Insets::uniform_xy(3., 0.,);
+///
+/// let inset_rect = rect + insets;
+/// assert_eq!(inset_rect.width(), 16.0, "10.0 + 3.0 × 2");
+/// assert_eq!(inset_rect.x0, -3.0);
+/// ```
+///
+/// Negative insets added to a [`Rect`] produce a smaller [`Rect`]:
+///
+/// ```
+/// # use bazo::{Insets, Rect};
+/// let rect = Rect::from_origin_size((0., 0.,), (10., 10.,));
+/// let insets = Insets::uniform_xy(-3., 0.,);
+///
+/// let inset_rect = rect + insets;
+/// assert_eq!(inset_rect.width(), 4.0, "10.0 - 3.0 × 2");
+/// assert_eq!(inset_rect.x0, 3.0);
+/// ```
+///
+/// [`Insets`] operate on the absolute rectangle [`Rect::abs`], and so ignore
+/// existing negative widths and heights.
+///
+/// ```
+/// # use bazo::{Insets, Rect};
+/// let rect = Rect::new(7., 11., 0., 0.,);
+/// let insets = Insets::uniform_xy(0., 1.,);
+///
+/// assert_eq!(rect.width(), -7.0);
+///
+/// let inset_rect = rect + insets;
+/// assert_eq!(inset_rect.width(), 7.0);
+/// assert_eq!(inset_rect.x0, 0.0);
+/// assert_eq!(inset_rect.height(), 13.0);
+/// ```
+///
+/// The width and height of an inset operation can still be negative if the
+/// [`Insets`]' dimensions are greater than the dimensions of the original [`Rect`].
+///
+/// ```
+/// # use bazo::{Insets, Rect};
+/// let rect = Rect::new(0., 0., 3., 5.);
+/// let insets = Insets::uniform_xy(0., 7.,);
+///
+/// let inset_rect = rect - insets;
+/// assert_eq!(inset_rect.height(), -9., "5 - 7 × 2")
+/// ```
+///
+/// `Rect - Rect = Insets`:
+///
+///
+/// ```
+/// # use bazo::{Insets, Rect};
+/// let rect = Rect::new(0., 0., 5., 11.);
+/// let insets = Insets::uniform_xy(1., 7.,);
+///
+/// let inset_rect = rect + insets;
+/// let insets2 = inset_rect - rect;
+///
+/// assert_eq!(insets2.x0, insets.x0);
+/// assert_eq!(insets2.y1, insets.y1);
+/// assert_eq!(insets2.x_value(), insets.x_value());
+/// assert_eq!(insets2.y_value(), insets.y_value());
+/// ```
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Insets {
+    /// The minimum x coordinate (left edge).
+    pub x0: f64,
+    /// The minimum y coordinate (top edge in y-down spaces).
+    pub y0: f64,
+    /// The maximum x coordinate (right edge).
+    pub x1: f64,
+    /// The maximum y coordinate (bottom edge in y-down spaces).
+    pub y1: f64,
+}
+
+impl Insets {
+    /// Zeroed insets.
+    pub const ZERO: Insets = Insets::uniform(0.);
+
+    /// New uniform insets.
+    #[inline(always)]
+    pub const fn uniform(d: f64) -> Insets {
+        Insets {
+            x0: d,
+            y0: d,
+            x1: d,
+            y1: d,
+        }
+    }
+
+    /// New insets with uniform values along each axis.
+    #[inline(always)]
+    pub const fn uniform_xy(x: f64, y: f64) -> Insets {
+        Insets {
+            x0: x,
+            y0: y,
+            x1: x,
+            y1: y,
+        }
+    }
+
+    /// New insets. The ordering of the arguments is "left, top, right, bottom",
+    /// assuming a y-down coordinate space.
+    #[inline(always)]
+    pub const fn new(x0: f64, y0: f64, x1: f64, y1: f64) -> Insets {
+        Insets { x0, y0, x1, y1 }
+    }
+
+    /// The total delta on the x-axis represented by these insets.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Insets;
+    ///
+    /// let insets = Insets::uniform_xy(3., 8.);
+    /// assert_eq!(insets.x_value(), 6.);
+    ///
+    /// let insets = Insets::new(5., 0., -12., 0.,);
+    /// assert_eq!(insets.x_value(), -7.);
+    /// ```
+    #[inline]
+    pub fn x_value(self) -> f64 {
+        self.x0 + self.x1
+    }
+
+    /// The total delta on the y-axis represented by these insets.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Insets;
+    ///
+    /// let insets = Insets::uniform_xy(3., 7.);
+    /// assert_eq!(insets.y_value(), 14.);
+    ///
+    /// let insets = Insets::new(5., 10., -12., 4.,);
+    /// assert_eq!(insets.y_value(), 14.);
+    /// ```
+    #[inline]
+    pub fn y_value(self) -> f64 {
+        self.y0 + self.y1
+    }
+
+    /// Returns the total delta represented by these insets as a [`Size`].
+    ///
+    /// This is equivalent to creating a [`Size`] from the values returned by
+    /// [`x_value`] and [`y_value`].
+    ///
+    /// This function may return a size with negative values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::{Insets, Size};
+    ///
+    /// let insets = Insets::new(11.1, -43.3, 3.333, -0.0);
+    /// assert_eq!(insets.size(), Size::new(insets.x_value(), insets.y_value()));
+    /// ```
+    ///
+    /// [`x_value`]: Insets::x_value
+    /// [`y_value`]: Insets::y_value
+    pub fn size(self) -> Size {
+        Size::new(self.x_value(), self.y_value())
+    }
+
+    /// Return `true` iff all values are nonnegative.
+    pub fn are_nonnegative(self) -> bool {
+        let Insets { x0, y0, x1, y1 } = self;
+        x0 >= 0.0 && y0 >= 0.0 && x1 >= 0.0 && y1 >= 0.0
+    }
+
+    /// Return new `Insets` with all negative values replaced with `0.0`.
+    ///
+    /// This is provided as a convenience for applications where negative insets
+    /// are not meaningful.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Insets;
+    ///
+    /// let insets = Insets::new(-10., 3., -0.2, 4.);
+    /// let nonnegative = insets.nonnegative();
+    /// assert_eq!(nonnegative.x_value(), 0.0);
+    /// assert_eq!(nonnegative.y_value(), 7.0);
+    /// ```
+    pub fn nonnegative(self) -> Insets {
+        let Insets { x0, y0, x1, y1 } = self;
+        Insets {
+            x0: x0.max(0.0),
+            y0: y0.max(0.0),
+            x1: x1.max(0.0),
+            y1: y1.max(0.0),
+        }
+    }
+
+    /// Are these insets finite?
+    #[inline]
+    pub fn is_finite(&self) -> bool {
+        self.x0.is_finite() && self.y0.is_finite() && self.x1.is_finite() && self.y1.is_finite()
+    }
+
+    /// Are these insets NaN?
+    #[inline]
+    pub fn is_nan(&self) -> bool {
+        self.x0.is_nan() || self.y0.is_nan() || self.x1.is_nan() || self.y1.is_nan()
+    }
+}
+
+impl Neg for Insets {
+    type Output = Insets;
+
+    #[inline]
+    fn neg(self) -> Insets {
+        Insets::new(-self.x0, -self.y0, -self.x1, -self.y1)
+    }
+}
+
+impl Add<Rect> for Insets {
+    type Output = Rect;
+
+    #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn add(self, other: Rect) -> Rect {
+        let other = other.abs();
+        Rect::new(
+            other.x0 - self.x0,
+            other.y0 - self.y0,
+            other.x1 + self.x1,
+            other.y1 + self.y1,
+        )
+    }
+}
+
+impl Add<Insets> for Rect {
+    type Output = Rect;
+
+    #[inline]
+    fn add(self, other: Insets) -> Rect {
+        other + self
+    }
+}
+
+impl Sub<Rect> for Insets {
+    type Output = Rect;
+
+    #[inline]
+    fn sub(self, other: Rect) -> Rect {
+        other + -self
+    }
+}
+
+impl Mul<f64> for Insets {
+    type Output = Insets;
+
+    fn mul(self, rhs: f64) -> Self::Output {
+        Self {
+            x0: self.x0 * rhs,
+            y0: self.y0 * rhs,
+            x1: self.x1 * rhs,
+            y1: self.y1 * rhs,
+        }
+    }
+}
+
+impl Div<f64> for Insets {
+    type Output = Insets;
+
+    fn div(self, rhs: f64) -> Self::Output {
+        Self {
+            x0: self.x0 / rhs,
+            y0: self.y0 / rhs,
+            x1: self.x1 / rhs,
+            y1: self.y1 / rhs,
+        }
+    }
+}
+
+impl Sub<Insets> for Rect {
+    type Output = Rect;
+
+    #[inline]
+    fn sub(self, other: Insets) -> Rect {
+        other - self
+    }
+}
+
+impl From<f64> for Insets {
+    #[inline(always)]
+    fn from(src: f64) -> Insets {
+        Insets::uniform(src)
+    }
+}
+
+impl From<(f64, f64)> for Insets {
+    #[inline(always)]
+    fn from(src: (f64, f64)) -> Insets {
+        Insets::uniform_xy(src.0, src.1)
+    }
+}
+
+impl From<(f64, f64, f64, f64)> for Insets {
+    #[inline(always)]
+    fn from(src: (f64, f64, f64, f64)) -> Insets {
+        Insets::new(src.0, src.1, src.2, src.3)
+    }
+}

--- a/bazo/src/interop_euclid.rs
+++ b/bazo/src/interop_euclid.rs
@@ -1,0 +1,91 @@
+// Copyright 2025 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use euclid::UnknownUnit;
+
+impl From<euclid::Vector2D<f64, UnknownUnit>> for crate::Vec2 {
+    #[inline(always)]
+    fn from(value: euclid::Vector2D<f64, UnknownUnit>) -> Self {
+        Self::new(value.x, value.y)
+    }
+}
+
+impl From<crate::Vec2> for euclid::Vector2D<f64, UnknownUnit> {
+    #[inline(always)]
+    fn from(value: crate::Vec2) -> Self {
+        Self::new(value.x, value.y)
+    }
+}
+
+impl From<euclid::Point2D<f64, UnknownUnit>> for crate::Point {
+    #[inline(always)]
+    fn from(value: euclid::Point2D<f64, UnknownUnit>) -> Self {
+        Self::new(value.x, value.y)
+    }
+}
+
+impl From<crate::Point> for euclid::Point2D<f64, UnknownUnit> {
+    #[inline(always)]
+    fn from(value: crate::Point) -> Self {
+        Self::new(value.x, value.y)
+    }
+}
+
+impl From<euclid::Size2D<f64, UnknownUnit>> for crate::Size {
+    #[inline(always)]
+    fn from(value: euclid::Size2D<f64, UnknownUnit>) -> Self {
+        Self::new(value.width, value.height)
+    }
+}
+
+impl From<crate::Size> for euclid::Size2D<f64, UnknownUnit> {
+    #[inline(always)]
+    fn from(value: crate::Size) -> Self {
+        Self::new(value.width, value.height)
+    }
+}
+
+impl From<euclid::Rect<f64, UnknownUnit>> for crate::Rect {
+    #[inline]
+    fn from(value: euclid::Rect<f64, UnknownUnit>) -> Self {
+        Self::from_origin_size(value.origin, value.size)
+    }
+}
+
+impl From<crate::Rect> for euclid::Rect<f64, UnknownUnit> {
+    #[inline]
+    fn from(value: crate::Rect) -> Self {
+        Self::new(value.origin().into(), value.size().into())
+    }
+}
+
+impl From<euclid::Box2D<f64, UnknownUnit>> for crate::Rect {
+    #[inline]
+    fn from(value: euclid::Box2D<f64, UnknownUnit>) -> Self {
+        Self::from_points(value.min, value.max)
+    }
+}
+
+impl From<crate::Rect> for euclid::Box2D<f64, UnknownUnit> {
+    #[inline]
+    fn from(value: crate::Rect) -> Self {
+        Self::new(
+            euclid::Point2D::new(value.min_x(), value.min_y()),
+            euclid::Point2D::new(value.max_x(), value.max_y()),
+        )
+    }
+}
+
+impl From<euclid::Transform2D<f64, UnknownUnit, UnknownUnit>> for crate::Affine {
+    #[inline(always)]
+    fn from(t: euclid::Transform2D<f64, UnknownUnit, UnknownUnit>) -> Self {
+        Self::new(t.to_array())
+    }
+}
+
+impl From<crate::Affine> for euclid::Transform2D<f64, UnknownUnit, UnknownUnit> {
+    #[inline(always)]
+    fn from(a: crate::Affine) -> Self {
+        Self::from_array(a.as_coeffs())
+    }
+}

--- a/bazo/src/lib.rs
+++ b/bazo/src/lib.rs
@@ -1,0 +1,138 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! 2D geometry, with a focus on curves.
+//!
+//! The bazo library contains data structures and algorithms for curves and
+//! vector paths. It was designed to serve the needs of 2D graphics applications,
+//! but it is intended to be general enough to be useful for other applications.
+//! It can be used as "vocabulary types" for representing curves and paths, and
+//! also contains a number of computational geometry methods.
+//!
+//! # Examples
+//!
+//! Basic UI-style geometry:
+//! ```
+//! use bazo::{Insets, Point, Rect, Size, Vec2};
+//!
+//! let pt = Point::new(10.0, 10.0);
+//! let vector = Vec2::new(5.0, -5.0);
+//! let pt2 = pt + vector;
+//! assert_eq!(pt2, Point::new(15.0, 5.0));
+//!
+//! let rect = Rect::from_points(pt, pt2);
+//! assert_eq!(rect, Rect::from_origin_size((10.0, 5.0), (5.0, 5.0)));
+//!
+//! let insets = Insets::uniform(1.0);
+//! let inset_rect = rect - insets;
+//! assert_eq!(inset_rect.size(), Size::new(3.0, 3.0));
+//! ```
+//!
+//!
+//! # Feature Flags
+//!
+//! The following crate [feature flags](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features) are available:
+//!
+//! - `std` (enabled by default): Get floating point functions from the standard library
+//!   (likely using your target's libc).
+//! - `libm`: Use floating point implementations from [libm][].
+//!   This is useful for `no_std` environments.
+//!   However, note that the `libm` crate is not as efficient as the standard library.
+//! - `mint`: Enable `From`/`Into` conversion of Kurbo and [mint][] types, enabling interoperability
+//!   with other graphics libraries.
+//! - `euclid`: Enable `From`/`Into` conversion of Kurbo and [euclid][] types.
+//!   Note that if you're using both Kurbo and euclid at the same time, you *must*
+//!   also enable one of euclid's `std` or `libm` features.
+//! - `serde`: Implement `serde::Deserialize` and `serde::Serialize` on various types.
+//! - `schemars`: Add best-effort support for using Kurbo types in JSON schemas using [schemars][].
+//!
+//! At least one of `std` and `libm` is required; `std` overrides `libm`.
+//! Note that Kurbo does require that an allocator is available (i.e. it uses [alloc]).
+
+// LINEBENDER LINT SET - lib.rs - v1
+// See https://linebender.org/wiki/canonical-lints/
+// These lints aren't included in Cargo.toml because they
+// shouldn't apply to examples and tests
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(clippy::print_stdout, clippy::print_stderr)]
+// END LINEBENDER LINT SET
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![allow(
+    clippy::unreadable_literal,
+    clippy::many_single_char_names,
+    clippy::excessive_precision,
+    clippy::bool_to_int_with_if
+)]
+// The following lints are part of the Linebender standard set,
+// but resolving them has been deferred for now.
+// Feel free to send a PR that solves one or more of these.
+#![allow(
+    missing_debug_implementations,
+    elided_lifetimes_in_paths,
+    single_use_lifetimes,
+    trivial_numeric_casts,
+    unnameable_types,
+    clippy::use_self,
+    clippy::return_self_not_must_use,
+    clippy::cast_possible_truncation,
+    clippy::wildcard_imports,
+    clippy::shadow_unrelated,
+    clippy::missing_assert_message,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::exhaustive_enums,
+    clippy::match_same_arms,
+    clippy::partial_pub_fields,
+    clippy::unseparated_literal_suffix,
+    clippy::duplicated_attributes,
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason
+)]
+
+#[cfg(not(any(feature = "std", feature = "libm")))]
+compile_error!("bazo requires either the `std` or `libm` feature");
+
+// Suppress the unused_crate_dependencies lint when both std and libm are specified.
+#[cfg(all(feature = "std", feature = "libm"))]
+use libm as _;
+
+extern crate alloc;
+
+mod affine;
+mod arc;
+mod axis;
+mod circle;
+pub mod common;
+mod ellipse;
+mod insets;
+mod line;
+mod point;
+mod rect;
+mod rounded_rect;
+mod rounded_rect_radii;
+mod size;
+mod svg;
+mod translate_scale;
+mod triangle;
+mod vec2;
+
+#[cfg(feature = "euclid")]
+mod interop_euclid;
+
+pub use crate::affine::Affine;
+pub use crate::arc::Arc;
+pub use crate::axis::Axis;
+pub use crate::circle::{Circle, CircleSegment};
+pub use crate::ellipse::Ellipse;
+pub use crate::insets::Insets;
+pub use crate::line::{ConstPoint, Line};
+pub use crate::point::Point;
+pub use crate::rect::Rect;
+pub use crate::rounded_rect::RoundedRect;
+pub use crate::rounded_rect_radii::RoundedRectRadii;
+pub use crate::size::Size;
+pub use crate::svg::SvgArc;
+pub use crate::translate_scale::TranslateScale;
+pub use crate::triangle::Triangle;
+pub use crate::vec2::Vec2;

--- a/bazo/src/line.rs
+++ b/bazo/src/line.rs
@@ -1,0 +1,203 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Lines.
+
+use core::ops::{Add, Mul, Sub};
+
+use crate::{Affine, Point, Vec2};
+
+/// A single line.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Line {
+    /// The line's start point.
+    pub p0: Point,
+    /// The line's end point.
+    pub p1: Point,
+}
+
+impl Line {
+    /// Create a new line.
+    #[inline(always)]
+    pub fn new(p0: impl Into<Point>, p1: impl Into<Point>) -> Line {
+        Line {
+            p0: p0.into(),
+            p1: p1.into(),
+        }
+    }
+
+    /// Returns a copy of this `Line` with the end points swapped so that it
+    /// points in the opposite direction.
+    #[must_use]
+    #[inline(always)]
+    pub fn reversed(&self) -> Line {
+        Self {
+            p0: self.p1,
+            p1: self.p0,
+        }
+    }
+
+    /// The length of the line.
+    #[inline]
+    pub fn length(self) -> f64 {
+        (self.p1 - self.p0).hypot()
+    }
+
+    /// The midpoint of the line.
+    ///
+    /// This is the same as calling [`Point::midpoint`] with
+    /// the endpoints of this line.
+    #[must_use]
+    #[inline]
+    pub fn midpoint(&self) -> Point {
+        self.p0.midpoint(self.p1)
+    }
+
+    /// Computes the point where two lines, if extended to infinity, would cross.
+    pub fn crossing_point(self, other: Line) -> Option<Point> {
+        let ab = self.p1 - self.p0;
+        let cd = other.p1 - other.p0;
+        let pcd = ab.cross(cd);
+        if pcd == 0.0 {
+            return None;
+        }
+        let h = ab.cross(self.p0 - other.p0) / pcd;
+        Some(other.p0 + cd * h)
+    }
+
+    /// Is this line `finite`?
+    ///
+    /// [finite]: f64::is_finite
+    #[inline]
+    pub fn is_finite(self) -> bool {
+        self.p0.is_finite() && self.p1.is_finite()
+    }
+
+    /// Is this line `NaN`?
+    ///
+    /// [NaN]: f64::is_nan
+    #[inline]
+    pub fn is_nan(self) -> bool {
+        self.p0.is_nan() || self.p1.is_nan()
+    }
+}
+
+impl From<(Point, Point)> for Line {
+    #[inline(always)]
+    fn from((from, to): (Point, Point)) -> Self {
+        Line::new(from, to)
+    }
+}
+
+impl From<(Point, Vec2)> for Line {
+    #[inline(always)]
+    fn from((origin, displacement): (Point, Vec2)) -> Self {
+        Line::new(origin, origin + displacement)
+    }
+}
+
+/// A trivial "curve" that is just a constant.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ConstPoint(Point);
+
+impl ConstPoint {
+    /// Is this point [finite]?
+    ///
+    /// [finite]: f64::is_finite
+    #[inline]
+    pub fn is_finite(self) -> bool {
+        self.0.is_finite()
+    }
+
+    /// Is this point [NaN]?
+    ///
+    /// [NaN]: f64::is_nan
+    #[inline]
+    pub fn is_nan(self) -> bool {
+        self.0.is_nan()
+    }
+}
+
+impl Mul<Line> for Affine {
+    type Output = Line;
+
+    #[inline]
+    fn mul(self, other: Line) -> Line {
+        Line {
+            p0: self * other.p0,
+            p1: self * other.p1,
+        }
+    }
+}
+
+impl Add<Vec2> for Line {
+    type Output = Line;
+
+    #[inline]
+    fn add(self, v: Vec2) -> Line {
+        Line::new(self.p0 + v, self.p1 + v)
+    }
+}
+
+impl Sub<Vec2> for Line {
+    type Output = Line;
+
+    #[inline]
+    fn sub(self, v: Vec2) -> Line {
+        Line::new(self.p0 - v, self.p1 - v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Line, Point};
+
+    #[test]
+    fn line_reversed() {
+        let l = Line::new((0.0, 0.0), (1.0, 1.0));
+        let f = l.reversed();
+
+        assert_eq!(l.p0, f.p1);
+        assert_eq!(l.p1, f.p0);
+
+        // Reversing it again should result in the original line
+        assert_eq!(l, f.reversed());
+    }
+
+    #[test]
+    fn line_midpoint() {
+        let l = Line::new((0.0, 0.0), (2.0, 4.0));
+        assert_eq!(l.midpoint(), Point::new(1.0, 2.0));
+    }
+
+    #[test]
+    fn line_is_finite() {
+        assert!((Line {
+            p0: Point { x: 0., y: 0. },
+            p1: Point { x: 1., y: 1. }
+        })
+        .is_finite());
+
+        assert!(!(Line {
+            p0: Point { x: 0., y: 0. },
+            p1: Point {
+                x: f64::INFINITY,
+                y: 1.
+            }
+        })
+        .is_finite());
+
+        assert!(!(Line {
+            p0: Point { x: 0., y: 0. },
+            p1: Point {
+                x: 0.,
+                y: f64::INFINITY
+            }
+        })
+        .is_finite());
+    }
+}

--- a/bazo/src/point.rs
+++ b/bazo/src/point.rs
@@ -1,0 +1,398 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! A 2D point.
+
+use core::fmt;
+use core::ops::{Add, AddAssign, Sub, SubAssign};
+
+use crate::common::FloatExt;
+use crate::{Axis, Vec2};
+
+#[cfg(not(feature = "std"))]
+use crate::common::FloatFuncs;
+
+/// A 2D point.
+///
+/// This type represents a point in 2D space. It has the same layout as [`Vec2`], but
+/// its meaning is different: `Vec2` represents a change in location (for example velocity).
+///
+/// In general, `bazo` overloads math operators where it makes sense, for example implementing
+/// `Affine * Point` as the point under the affine transformation. However `Point + Point` and
+/// `f64 * Point` are not implemented, because the operations do not make geometric sense. If you
+/// need to apply these operations, then 1) check what you're doing makes geometric sense, then 2)
+/// use [`Point::to_vec2`] to convert the point to a `Vec2`.
+#[derive(Clone, Copy, Default, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Point {
+    /// The x coordinate.
+    pub x: f64,
+    /// The y coordinate.
+    pub y: f64,
+}
+
+impl Point {
+    /// The point (0, 0).
+    pub const ZERO: Point = Point::new(0., 0.);
+
+    /// The point at the origin; (0, 0).
+    pub const ORIGIN: Point = Point::new(0., 0.);
+
+    /// Create a new `Point` with the provided `x` and `y` coordinates.
+    #[inline(always)]
+    pub const fn new(x: f64, y: f64) -> Self {
+        Point { x, y }
+    }
+
+    /// Convert this point into a `Vec2`.
+    #[inline(always)]
+    pub const fn to_vec2(self) -> Vec2 {
+        Vec2::new(self.x, self.y)
+    }
+
+    /// Linearly interpolate between two points.
+    #[inline]
+    pub fn lerp(self, other: Point, t: f64) -> Point {
+        self.to_vec2().lerp(other.to_vec2(), t).to_point()
+    }
+
+    /// Determine the midpoint of two points.
+    #[inline]
+    pub const fn midpoint(self, other: Point) -> Point {
+        Point::new(0.5 * (self.x + other.x), 0.5 * (self.y + other.y))
+    }
+
+    /// Euclidean distance.
+    ///
+    /// See [`Vec2::hypot`] for the same operation on [`Vec2`].
+    #[inline]
+    pub fn distance(self, other: Point) -> f64 {
+        (self - other).hypot()
+    }
+
+    /// Squared Euclidean distance.
+    ///
+    /// See [`Vec2::hypot2`] for the same operation on [`Vec2`].
+    #[inline]
+    pub fn distance_squared(self, other: Point) -> f64 {
+        (self - other).hypot2()
+    }
+
+    /// Returns a new `Point`, with `x` and `y` [rounded] to the nearest integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Point;
+    /// let a = Point::new(3.3, 3.6).round();
+    /// let b = Point::new(3.0, -3.1).round();
+    /// assert_eq!(a.x, 3.0);
+    /// assert_eq!(a.y, 4.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -3.0);
+    /// ```
+    ///
+    /// [rounded]: f64::round
+    #[inline]
+    pub fn round(self) -> Point {
+        Point::new(self.x.round(), self.y.round())
+    }
+
+    /// Returns a new `Point`,
+    /// with `x` and `y` [rounded up] to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Point;
+    /// let a = Point::new(3.3, 3.6).ceil();
+    /// let b = Point::new(3.0, -3.1).ceil();
+    /// assert_eq!(a.x, 4.0);
+    /// assert_eq!(a.y, 4.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -3.0);
+    /// ```
+    ///
+    /// [rounded up]: f64::ceil
+    #[inline]
+    pub fn ceil(self) -> Point {
+        Point::new(self.x.ceil(), self.y.ceil())
+    }
+
+    /// Returns a new `Point`,
+    /// with `x` and `y` [rounded down] to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Point;
+    /// let a = Point::new(3.3, 3.6).floor();
+    /// let b = Point::new(3.0, -3.1).floor();
+    /// assert_eq!(a.x, 3.0);
+    /// assert_eq!(a.y, 3.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -4.0);
+    /// ```
+    ///
+    /// [rounded down]: f64::floor
+    #[inline]
+    pub fn floor(self) -> Point {
+        Point::new(self.x.floor(), self.y.floor())
+    }
+
+    /// Returns a new `Point`,
+    /// with `x` and `y` [rounded away] from zero to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Point;
+    /// let a = Point::new(3.3, 3.6).expand();
+    /// let b = Point::new(3.0, -3.1).expand();
+    /// assert_eq!(a.x, 4.0);
+    /// assert_eq!(a.y, 4.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -4.0);
+    /// ```
+    ///
+    /// [rounded away]: FloatExt::expand
+    #[inline]
+    pub fn expand(self) -> Point {
+        Point::new(self.x.expand(), self.y.expand())
+    }
+
+    /// Returns a new `Point`,
+    /// with `x` and `y` [rounded towards] zero to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Point;
+    /// let a = Point::new(3.3, 3.6).trunc();
+    /// let b = Point::new(3.0, -3.1).trunc();
+    /// assert_eq!(a.x, 3.0);
+    /// assert_eq!(a.y, 3.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -3.0);
+    /// ```
+    ///
+    /// [rounded towards]: f64::trunc
+    #[inline]
+    pub fn trunc(self) -> Point {
+        Point::new(self.x.trunc(), self.y.trunc())
+    }
+
+    /// Is this point [finite]?
+    ///
+    /// [finite]: f64::is_finite
+    #[inline]
+    pub fn is_finite(self) -> bool {
+        self.x.is_finite() && self.y.is_finite()
+    }
+
+    /// Is this point [`NaN`]?
+    ///
+    /// [`NaN`]: f64::is_nan
+    #[inline]
+    pub fn is_nan(self) -> bool {
+        self.x.is_nan() || self.y.is_nan()
+    }
+
+    /// Get the member matching the given axis.
+    #[inline]
+    pub fn get_coord(self, axis: Axis) -> f64 {
+        match axis {
+            Axis::Horizontal => self.x,
+            Axis::Vertical => self.y,
+        }
+    }
+
+    /// Get a mutable reference to the member matching the given axis.
+    #[inline]
+    pub fn get_coord_mut(&mut self, axis: Axis) -> &mut f64 {
+        match axis {
+            Axis::Horizontal => &mut self.x,
+            Axis::Vertical => &mut self.y,
+        }
+    }
+
+    /// Set the member matching the given axis to the given value.
+    #[inline]
+    pub fn set_coord(&mut self, axis: Axis, value: f64) {
+        match axis {
+            Axis::Horizontal => self.x = value,
+            Axis::Vertical => self.y = value,
+        }
+    }
+}
+
+impl From<(f32, f32)> for Point {
+    #[inline(always)]
+    fn from(v: (f32, f32)) -> Point {
+        Point {
+            x: v.0 as f64,
+            y: v.1 as f64,
+        }
+    }
+}
+
+impl From<(f64, f64)> for Point {
+    #[inline(always)]
+    fn from(v: (f64, f64)) -> Point {
+        Point { x: v.0, y: v.1 }
+    }
+}
+
+impl From<Point> for (f64, f64) {
+    #[inline(always)]
+    fn from(v: Point) -> (f64, f64) {
+        (v.x, v.y)
+    }
+}
+
+impl Add<Vec2> for Point {
+    type Output = Point;
+
+    #[inline]
+    fn add(self, other: Vec2) -> Self {
+        Point::new(self.x + other.x, self.y + other.y)
+    }
+}
+
+impl AddAssign<Vec2> for Point {
+    #[inline]
+    fn add_assign(&mut self, other: Vec2) {
+        *self = Point::new(self.x + other.x, self.y + other.y);
+    }
+}
+
+impl Sub<Vec2> for Point {
+    type Output = Point;
+
+    #[inline]
+    fn sub(self, other: Vec2) -> Self {
+        Point::new(self.x - other.x, self.y - other.y)
+    }
+}
+
+impl SubAssign<Vec2> for Point {
+    #[inline]
+    fn sub_assign(&mut self, other: Vec2) {
+        *self = Point::new(self.x - other.x, self.y - other.y);
+    }
+}
+
+impl Add<(f64, f64)> for Point {
+    type Output = Point;
+
+    #[inline]
+    fn add(self, (x, y): (f64, f64)) -> Self {
+        Point::new(self.x + x, self.y + y)
+    }
+}
+
+impl AddAssign<(f64, f64)> for Point {
+    #[inline]
+    fn add_assign(&mut self, (x, y): (f64, f64)) {
+        *self = Point::new(self.x + x, self.y + y);
+    }
+}
+
+impl Sub<(f64, f64)> for Point {
+    type Output = Point;
+
+    #[inline]
+    fn sub(self, (x, y): (f64, f64)) -> Self {
+        Point::new(self.x - x, self.y - y)
+    }
+}
+
+impl SubAssign<(f64, f64)> for Point {
+    #[inline]
+    fn sub_assign(&mut self, (x, y): (f64, f64)) {
+        *self = Point::new(self.x - x, self.y - y);
+    }
+}
+
+impl Sub<Point> for Point {
+    type Output = Vec2;
+
+    #[inline]
+    fn sub(self, other: Point) -> Vec2 {
+        Vec2::new(self.x - other.x, self.y - other.y)
+    }
+}
+
+impl fmt::Debug for Point {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({:?}, {:?})", self.x, self.y)
+    }
+}
+
+impl fmt::Display for Point {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "(")?;
+        fmt::Display::fmt(&self.x, formatter)?;
+        write!(formatter, ", ")?;
+        fmt::Display::fmt(&self.y, formatter)?;
+        write!(formatter, ")")
+    }
+}
+
+#[cfg(feature = "mint")]
+impl From<Point> for mint::Point2<f64> {
+    #[inline(always)]
+    fn from(p: Point) -> mint::Point2<f64> {
+        mint::Point2 { x: p.x, y: p.y }
+    }
+}
+
+#[cfg(feature = "mint")]
+impl From<mint::Point2<f64>> for Point {
+    #[inline(always)]
+    fn from(p: mint::Point2<f64>) -> Point {
+        Point { x: p.x, y: p.y }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn point_arithmetic() {
+        assert_eq!(
+            Point::new(0., 0.) - Vec2::new(10., 0.),
+            Point::new(-10., 0.)
+        );
+        assert_eq!(
+            Point::new(0., 0.) - Point::new(-5., 101.),
+            Vec2::new(5., -101.)
+        );
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn distance() {
+        let p1 = Point::new(0., 10.);
+        let p2 = Point::new(0., 5.);
+        assert_eq!(p1.distance(p2), 5.);
+
+        let p1 = Point::new(-11., 1.);
+        let p2 = Point::new(-7., -2.);
+        assert_eq!(p1.distance(p2), 5.);
+    }
+
+    #[test]
+    fn display() {
+        let p = Point::new(0.12345, 9.87654);
+        assert_eq!(format!("{p}"), "(0.12345, 9.87654)");
+
+        let p = Point::new(0.12345, 9.87654);
+        assert_eq!(format!("{p:.2}"), "(0.12, 9.88)");
+    }
+}

--- a/bazo/src/rounded_rect.rs
+++ b/bazo/src/rounded_rect.rs
@@ -1,0 +1,164 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! A rectangle with rounded corners.
+
+use core::ops::{Add, Sub};
+
+use crate::{Point, Rect, RoundedRectRadii, Size, Vec2};
+
+#[allow(unused_imports)] // This is unused in later versions of Rust because of additions to core::f32
+#[cfg(not(feature = "std"))]
+use crate::common::FloatFuncs;
+
+/// A rectangle with rounded corners.
+///
+/// By construction the rounded rectangle will have
+/// non-negative dimensions and radii clamped to half size of the rect.
+/// The rounded rectangle can have different radii for each corner.
+///
+/// The easiest way to create a `RoundedRect` is often to create a [`Rect`],
+/// and then call [`to_rounded_rect`].
+///
+/// ```
+/// use bazo::{RoundedRect, RoundedRectRadii};
+///
+/// // Create a rounded rectangle with a single radius for all corners:
+/// RoundedRect::new(0.0, 0.0, 10.0, 10.0, 5.0);
+///
+/// // Or, specify different radii for each corner, clockwise from the top-left:
+/// RoundedRect::new(0.0, 0.0, 10.0, 10.0, (1.0, 2.0, 3.0, 4.0));
+/// ```
+///
+/// [`to_rounded_rect`]: Rect::to_rounded_rect
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RoundedRect {
+    /// Coordinates of the rectangle.
+    rect: Rect,
+    /// Radius of all four corners.
+    radii: RoundedRectRadii,
+}
+
+impl RoundedRect {
+    /// A new rectangle from minimum and maximum coordinates.
+    ///
+    /// The result will have non-negative width, height and radii.
+    #[inline]
+    pub fn new(
+        x0: f64,
+        y0: f64,
+        x1: f64,
+        y1: f64,
+        radii: impl Into<RoundedRectRadii>,
+    ) -> RoundedRect {
+        RoundedRect::from_rect(Rect::new(x0, y0, x1, y1), radii)
+    }
+
+    /// A new rounded rectangle from a rectangle and corner radii.
+    ///
+    /// The result will have non-negative width, height and radii.
+    ///
+    /// See also [`Rect::to_rounded_rect`], which offers the same utility.
+    #[inline]
+    pub fn from_rect(rect: Rect, radii: impl Into<RoundedRectRadii>) -> RoundedRect {
+        let rect = rect.abs();
+        let shortest_side_length = (rect.width()).min(rect.height());
+        let radii = radii.into().abs().clamp(shortest_side_length / 2.0);
+
+        RoundedRect { rect, radii }
+    }
+
+    /// A new rectangle from two [`Point`]s.
+    ///
+    /// The result will have non-negative width, height and radius.
+    #[inline]
+    pub fn from_points(
+        p0: impl Into<Point>,
+        p1: impl Into<Point>,
+        radii: impl Into<RoundedRectRadii>,
+    ) -> RoundedRect {
+        Rect::from_points(p0, p1).to_rounded_rect(radii)
+    }
+
+    /// A new rectangle from origin and size.
+    ///
+    /// The result will have non-negative width, height and radius.
+    #[inline]
+    pub fn from_origin_size(
+        origin: impl Into<Point>,
+        size: impl Into<Size>,
+        radii: impl Into<RoundedRectRadii>,
+    ) -> RoundedRect {
+        Rect::from_origin_size(origin, size).to_rounded_rect(radii)
+    }
+
+    /// The width of the rectangle.
+    #[inline]
+    pub fn width(&self) -> f64 {
+        self.rect.width()
+    }
+
+    /// The height of the rectangle.
+    #[inline]
+    pub fn height(&self) -> f64 {
+        self.rect.height()
+    }
+
+    /// Radii of the rounded corners.
+    #[inline(always)]
+    pub fn radii(&self) -> RoundedRectRadii {
+        self.radii
+    }
+
+    /// The (non-rounded) rectangle.
+    #[inline(always)]
+    pub fn rect(&self) -> Rect {
+        self.rect
+    }
+
+    /// The origin of the rectangle.
+    ///
+    /// This is the top left corner in a y-down space.
+    #[inline(always)]
+    pub fn origin(&self) -> Point {
+        self.rect.origin()
+    }
+
+    /// The center point of the rectangle.
+    #[inline]
+    pub fn center(&self) -> Point {
+        self.rect.center()
+    }
+
+    /// Is this rounded rectangle finite?
+    #[inline]
+    pub fn is_finite(&self) -> bool {
+        self.rect.is_finite() && self.radii.is_finite()
+    }
+
+    /// Is this rounded rectangle NaN?
+    #[inline]
+    pub fn is_nan(&self) -> bool {
+        self.rect.is_nan() || self.radii.is_nan()
+    }
+}
+
+impl Add<Vec2> for RoundedRect {
+    type Output = RoundedRect;
+
+    #[inline]
+    fn add(self, v: Vec2) -> RoundedRect {
+        RoundedRect::from_rect(self.rect + v, self.radii)
+    }
+}
+
+impl Sub<Vec2> for RoundedRect {
+    type Output = RoundedRect;
+
+    #[inline]
+    fn sub(self, v: Vec2) -> RoundedRect {
+        RoundedRect::from_rect(self.rect - v, self.radii)
+    }
+}

--- a/bazo/src/rounded_rect_radii.rs
+++ b/bazo/src/rounded_rect_radii.rs
@@ -1,0 +1,124 @@
+// Copyright 2021 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! A description of the radii for each corner of a rounded rectangle.
+
+use core::convert::From;
+
+#[allow(unused_imports)] // This is unused in later versions of Rust because of additions to core::f32
+#[cfg(not(feature = "std"))]
+use crate::common::FloatFuncs;
+
+/// Radii for each corner of a rounded rectangle.
+///
+/// The use of `top` as in `top_left` assumes a y-down coordinate space. Piet
+/// (and Druid by extension) uses a y-down coordinate space, but Kurbo also
+/// supports a y-up coordinate space, in which case `top_left` would actually
+/// refer to the bottom-left corner, and vice versa. Top may not always
+/// actually be the top, but `top` corners will always have a smaller y-value
+/// than `bottom` corners.
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RoundedRectRadii {
+    /// The radius of the top-left corner.
+    pub top_left: f64,
+    /// The radius of the top-right corner.
+    pub top_right: f64,
+    /// The radius of the bottom-right corner.
+    pub bottom_right: f64,
+    /// The radius of the bottom-left corner.
+    pub bottom_left: f64,
+}
+
+impl RoundedRectRadii {
+    /// Create a new `RoundedRectRadii`. This function takes radius values for
+    /// the four corners. The argument order is `top_left`, `top_right`,
+    /// `bottom_right`, `bottom_left`, or clockwise starting from `top_left`.
+    #[inline(always)]
+    pub const fn new(top_left: f64, top_right: f64, bottom_right: f64, bottom_left: f64) -> Self {
+        RoundedRectRadii {
+            top_left,
+            top_right,
+            bottom_right,
+            bottom_left,
+        }
+    }
+
+    /// Create a new `RoundedRectRadii` from a single radius. The `radius`
+    /// argument will be set as the radius for all four corners.
+    #[inline(always)]
+    pub const fn from_single_radius(radius: f64) -> Self {
+        RoundedRectRadii {
+            top_left: radius,
+            top_right: radius,
+            bottom_right: radius,
+            bottom_left: radius,
+        }
+    }
+
+    /// Takes the absolute value of all corner radii.
+    pub fn abs(&self) -> Self {
+        RoundedRectRadii::new(
+            self.top_left.abs(),
+            self.top_right.abs(),
+            self.bottom_right.abs(),
+            self.bottom_left.abs(),
+        )
+    }
+
+    /// For each corner, takes the min of that corner's radius and `max`.
+    pub fn clamp(&self, max: f64) -> Self {
+        RoundedRectRadii::new(
+            self.top_left.min(max),
+            self.top_right.min(max),
+            self.bottom_right.min(max),
+            self.bottom_left.min(max),
+        )
+    }
+
+    /// Returns `true` if all radius values are finite.
+    pub fn is_finite(&self) -> bool {
+        self.top_left.is_finite()
+            && self.top_right.is_finite()
+            && self.bottom_right.is_finite()
+            && self.bottom_left.is_finite()
+    }
+
+    /// Returns `true` if any corner radius value is NaN.
+    pub fn is_nan(&self) -> bool {
+        self.top_left.is_nan()
+            || self.top_right.is_nan()
+            || self.bottom_right.is_nan()
+            || self.bottom_left.is_nan()
+    }
+
+    /// If all radii are equal, returns the value of the radii. Otherwise,
+    /// returns `None`.
+    pub fn as_single_radius(&self) -> Option<f64> {
+        let epsilon = 1e-9;
+
+        if (self.top_left - self.top_right).abs() < epsilon
+            && (self.top_right - self.bottom_right).abs() < epsilon
+            && (self.bottom_right - self.bottom_left).abs() < epsilon
+        {
+            Some(self.top_left)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<f64> for RoundedRectRadii {
+    #[inline(always)]
+    fn from(radius: f64) -> Self {
+        RoundedRectRadii::from_single_radius(radius)
+    }
+}
+
+impl From<(f64, f64, f64, f64)> for RoundedRectRadii {
+    #[inline(always)]
+    fn from(radii: (f64, f64, f64, f64)) -> Self {
+        RoundedRectRadii::new(radii.0, radii.1, radii.2, radii.3)
+    }
+}

--- a/bazo/src/size.rs
+++ b/bazo/src/size.rs
@@ -1,0 +1,492 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! A 2D size.
+
+use core::fmt;
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+
+use crate::common::FloatExt;
+use crate::{Axis, Rect, RoundedRect, RoundedRectRadii, Vec2};
+
+#[cfg(not(feature = "std"))]
+use crate::common::FloatFuncs;
+
+/// A 2D size.
+#[derive(Clone, Copy, Default, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Size {
+    /// The width.
+    pub width: f64,
+    /// The height.
+    pub height: f64,
+}
+
+impl Size {
+    /// A size with zero width or height.
+    pub const ZERO: Size = Size::new(0., 0.);
+
+    /// A size with width and height set to `f64::INFINITY`.
+    pub const INFINITY: Size = Size::new(f64::INFINITY, f64::INFINITY);
+
+    /// Create a new `Size` with the provided `width` and `height`.
+    #[inline(always)]
+    pub const fn new(width: f64, height: f64) -> Self {
+        Size { width, height }
+    }
+
+    /// Returns the max of `width` and `height`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Size;
+    /// let size = Size::new(-10.5, 42.0);
+    /// assert_eq!(size.max_side(), 42.0);
+    /// ```
+    pub fn max_side(self) -> f64 {
+        self.width.max(self.height)
+    }
+
+    /// Returns the min of `width` and `height`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Size;
+    /// let size = Size::new(-10.5, 42.0);
+    /// assert_eq!(size.min_side(), -10.5);
+    /// ```
+    pub fn min_side(self) -> f64 {
+        self.width.min(self.height)
+    }
+
+    /// The area covered by this size.
+    #[inline]
+    pub fn area(self) -> f64 {
+        self.width * self.height
+    }
+
+    /// Whether this size has zero area.
+    #[doc(alias = "is_empty")]
+    #[inline]
+    pub fn is_zero_area(self) -> bool {
+        self.area() == 0.0
+    }
+
+    /// Returns the component-wise minimum of `self` and `other`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Size;
+    ///
+    /// let this = Size::new(0., 100.);
+    /// let other = Size::new(10., 10.);
+    ///
+    /// assert_eq!(this.min(other), Size::new(0., 10.));
+    /// ```
+    pub fn min(self, other: Size) -> Self {
+        Size {
+            width: self.width.min(other.width),
+            height: self.height.min(other.height),
+        }
+    }
+
+    /// Returns the component-wise maximum of `self` and `other`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Size;
+    ///
+    /// let this = Size::new(0., 100.);
+    /// let other = Size::new(10., 10.);
+    ///
+    /// assert_eq!(this.max(other), Size::new(10., 100.));
+    /// ```
+    pub fn max(self, other: Size) -> Self {
+        Size {
+            width: self.width.max(other.width),
+            height: self.height.max(other.height),
+        }
+    }
+
+    /// Returns a new size bounded by `min` and `max.`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Size;
+    ///
+    /// let this = Size::new(0., 100.);
+    /// let min = Size::new(10., 10.,);
+    /// let max = Size::new(50., 50.);
+    /// assert_eq!(this.clamp(min, max), Size::new(10., 50.))
+    /// ```
+    pub fn clamp(self, min: Size, max: Size) -> Self {
+        self.max(min).min(max)
+    }
+
+    /// Convert this size into a [`Vec2`], with `width` mapped to `x` and `height`
+    /// mapped to `y`.
+    #[inline(always)]
+    pub const fn to_vec2(self) -> Vec2 {
+        Vec2::new(self.width, self.height)
+    }
+
+    /// Returns a new `Size`,
+    /// with `width` and `height` [rounded] to the nearest integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Size;
+    /// let size_pos = Size::new(3.3, 3.6).round();
+    /// assert_eq!(size_pos.width, 3.0);
+    /// assert_eq!(size_pos.height, 4.0);
+    /// let size_neg = Size::new(-3.3, -3.6).round();
+    /// assert_eq!(size_neg.width, -3.0);
+    /// assert_eq!(size_neg.height, -4.0);
+    /// ```
+    ///
+    /// [rounded]: f64::round
+    #[inline]
+    pub fn round(self) -> Size {
+        Size::new(self.width.round(), self.height.round())
+    }
+
+    /// Returns a new `Size`,
+    /// with `width` and `height` [rounded up] to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Size;
+    /// let size_pos = Size::new(3.3, 3.6).ceil();
+    /// assert_eq!(size_pos.width, 4.0);
+    /// assert_eq!(size_pos.height, 4.0);
+    /// let size_neg = Size::new(-3.3, -3.6).ceil();
+    /// assert_eq!(size_neg.width, -3.0);
+    /// assert_eq!(size_neg.height, -3.0);
+    /// ```
+    ///
+    /// [rounded up]: f64::ceil
+    #[inline]
+    pub fn ceil(self) -> Size {
+        Size::new(self.width.ceil(), self.height.ceil())
+    }
+
+    /// Returns a new `Size`,
+    /// with `width` and `height` [rounded down] to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Size;
+    /// let size_pos = Size::new(3.3, 3.6).floor();
+    /// assert_eq!(size_pos.width, 3.0);
+    /// assert_eq!(size_pos.height, 3.0);
+    /// let size_neg = Size::new(-3.3, -3.6).floor();
+    /// assert_eq!(size_neg.width, -4.0);
+    /// assert_eq!(size_neg.height, -4.0);
+    /// ```
+    ///
+    /// [rounded down]: f64::floor
+    #[inline]
+    pub fn floor(self) -> Size {
+        Size::new(self.width.floor(), self.height.floor())
+    }
+
+    /// Returns a new `Size`,
+    /// with `width` and `height` [rounded away] from zero to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Size;
+    /// let size_pos = Size::new(3.3, 3.6).expand();
+    /// assert_eq!(size_pos.width, 4.0);
+    /// assert_eq!(size_pos.height, 4.0);
+    /// let size_neg = Size::new(-3.3, -3.6).expand();
+    /// assert_eq!(size_neg.width, -4.0);
+    /// assert_eq!(size_neg.height, -4.0);
+    /// ```
+    ///
+    /// [rounded away]: FloatExt::expand
+    #[inline]
+    pub fn expand(self) -> Size {
+        Size::new(self.width.expand(), self.height.expand())
+    }
+
+    /// Returns a new `Size`,
+    /// with `width` and `height` [rounded towards] zero to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Size;
+    /// let size_pos = Size::new(3.3, 3.6).trunc();
+    /// assert_eq!(size_pos.width, 3.0);
+    /// assert_eq!(size_pos.height, 3.0);
+    /// let size_neg = Size::new(-3.3, -3.6).trunc();
+    /// assert_eq!(size_neg.width, -3.0);
+    /// assert_eq!(size_neg.height, -3.0);
+    /// ```
+    ///
+    /// [rounded towards]: f64::trunc
+    #[inline]
+    pub fn trunc(self) -> Size {
+        Size::new(self.width.trunc(), self.height.trunc())
+    }
+
+    /// Returns the aspect ratio of a rectangle with this size.
+    ///
+    /// The aspect ratio is the ratio of the width to the height.
+    ///
+    /// If the height is `0`, the output will be `sign(self.width) * infinity`. If the width and
+    /// height are both `0`, then the output will be `NaN`.
+    #[inline]
+    pub fn aspect_ratio_width(self) -> f64 {
+        // ratio is determined by width / height
+        // https://en.wikipedia.org/wiki/Aspect_ratio_(image)
+        // https://en.wikipedia.org/wiki/Ratio
+        self.width / self.height
+    }
+
+    /// Returns **the inverse** of the aspect ratio of a rectangle with this size.
+    ///
+    /// Aspect ratios are usually defined as the ratio of the width to the height, but
+    /// this method incorrectly returns the ratio of height to width.
+    /// You should generally prefer [`aspect_ratio_width`](Self::aspect_ratio_width).
+    ///
+    /// If the width is `0`, the output will be `sign(self.height) * infinity`. If the width and
+    /// height are both `0`, then the output will be `NaN`.
+    #[deprecated(
+        note = "You should use `aspect_ratio_width` instead, as this method returns a potentially unexpected value.",
+        since = "0.12.0"
+    )]
+    #[inline]
+    // TODO: When we remove this, we should also work out what to do with aspect_ratio_width
+    // The tentatitive plan is to rename `aspect_ratio_width` back to this name
+    pub fn aspect_ratio(self) -> f64 {
+        self.height / self.width
+    }
+
+    /// Convert this `Size` into a [`Rect`] with origin `(0.0, 0.0)`.
+    #[inline(always)]
+    pub const fn to_rect(self) -> Rect {
+        Rect::new(0., 0., self.width, self.height)
+    }
+
+    /// Convert this `Size` into a [`RoundedRect`] with origin `(0.0, 0.0)` and
+    /// the provided corner radius.
+    #[inline]
+    pub fn to_rounded_rect(self, radii: impl Into<RoundedRectRadii>) -> RoundedRect {
+        self.to_rect().to_rounded_rect(radii)
+    }
+
+    /// Is this size [finite]?
+    ///
+    /// [finite]: f64::is_finite
+    #[inline]
+    pub fn is_finite(self) -> bool {
+        self.width.is_finite() && self.height.is_finite()
+    }
+
+    /// Is this size [NaN]?
+    ///
+    /// [NaN]: f64::is_nan
+    #[inline]
+    pub fn is_nan(self) -> bool {
+        self.width.is_nan() || self.height.is_nan()
+    }
+
+    /// Get the member matching the given axis.
+    #[inline]
+    pub fn get_coord(self, axis: Axis) -> f64 {
+        match axis {
+            Axis::Horizontal => self.width,
+            Axis::Vertical => self.height,
+        }
+    }
+
+    /// Get a mutable reference to the member matching the given axis.
+    #[inline]
+    pub fn get_coord_mut(&mut self, axis: Axis) -> &mut f64 {
+        match axis {
+            Axis::Horizontal => &mut self.width,
+            Axis::Vertical => &mut self.height,
+        }
+    }
+
+    /// Set the member matching the given axis to the given value.
+    #[inline]
+    pub fn set_coord(&mut self, axis: Axis, value: f64) {
+        match axis {
+            Axis::Horizontal => self.width = value,
+            Axis::Vertical => self.height = value,
+        }
+    }
+}
+
+impl fmt::Debug for Size {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}W×{:?}H", self.width, self.height)
+    }
+}
+
+impl fmt::Display for Size {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "(")?;
+        fmt::Display::fmt(&self.width, formatter)?;
+        write!(formatter, "×")?;
+        fmt::Display::fmt(&self.height, formatter)?;
+        write!(formatter, ")")
+    }
+}
+
+impl MulAssign<f64> for Size {
+    #[inline]
+    fn mul_assign(&mut self, other: f64) {
+        *self = Size {
+            width: self.width * other,
+            height: self.height * other,
+        };
+    }
+}
+
+impl Mul<Size> for f64 {
+    type Output = Size;
+
+    #[inline]
+    fn mul(self, other: Size) -> Size {
+        other * self
+    }
+}
+
+impl Mul<f64> for Size {
+    type Output = Size;
+
+    #[inline]
+    fn mul(self, other: f64) -> Size {
+        Size {
+            width: self.width * other,
+            height: self.height * other,
+        }
+    }
+}
+
+impl DivAssign<f64> for Size {
+    #[inline]
+    fn div_assign(&mut self, other: f64) {
+        *self = Size {
+            width: self.width / other,
+            height: self.height / other,
+        };
+    }
+}
+
+impl Div<f64> for Size {
+    type Output = Size;
+
+    #[inline]
+    fn div(self, other: f64) -> Size {
+        Size {
+            width: self.width / other,
+            height: self.height / other,
+        }
+    }
+}
+
+impl Add<Size> for Size {
+    type Output = Size;
+    #[inline]
+    fn add(self, other: Size) -> Size {
+        Size {
+            width: self.width + other.width,
+            height: self.height + other.height,
+        }
+    }
+}
+
+impl AddAssign<Size> for Size {
+    #[inline]
+    fn add_assign(&mut self, other: Size) {
+        *self = *self + other;
+    }
+}
+
+impl Sub<Size> for Size {
+    type Output = Size;
+    #[inline]
+    fn sub(self, other: Size) -> Size {
+        Size {
+            width: self.width - other.width,
+            height: self.height - other.height,
+        }
+    }
+}
+
+impl SubAssign<Size> for Size {
+    #[inline]
+    fn sub_assign(&mut self, other: Size) {
+        *self = *self - other;
+    }
+}
+
+impl From<(f64, f64)> for Size {
+    #[inline(always)]
+    fn from(v: (f64, f64)) -> Size {
+        Size {
+            width: v.0,
+            height: v.1,
+        }
+    }
+}
+
+impl From<Size> for (f64, f64) {
+    #[inline(always)]
+    fn from(v: Size) -> (f64, f64) {
+        (v.width, v.height)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display() {
+        let s = Size::new(-0.12345, 9.87654);
+        assert_eq!(format!("{s}"), "(-0.12345×9.87654)");
+
+        let s = Size::new(-0.12345, 9.87654);
+        assert_eq!(format!("{s:+6.2}"), "( -0.12× +9.88)");
+    }
+
+    #[test]
+    #[expect(deprecated, reason = "Testing deprecated function.")]
+    fn aspect_ratio() {
+        let s = Size::new(1.0, 1.0);
+        assert!((s.aspect_ratio() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn aspect_ratio_width() {
+        let s = Size::new(1.0, 1.0);
+        assert!((s.aspect_ratio_width() - 1.0).abs() < 1e-6);
+
+        // 3:2 film (mm)
+        let s = Size::new(36.0, 24.0);
+        assert!((s.aspect_ratio_width() - 1.5).abs() < 1e-6);
+        // 4k screen
+        let s = Size::new(3840.0, 2160.0);
+        assert!((s.aspect_ratio_width() - (16. / 9.)).abs() < 1e-6);
+    }
+}

--- a/bazo/src/svg.rs
+++ b/bazo/src/svg.rs
@@ -1,0 +1,127 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! SVG path representation.
+
+use core::f64::consts::PI;
+
+use crate::{Arc, Point, Vec2};
+
+#[cfg(not(feature = "std"))]
+use crate::common::FloatFuncs;
+
+// Note: the SVG arc logic is heavily adapted from https://github.com/nical/lyon
+
+/// A single SVG arc segment.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SvgArc {
+    /// The arc's start point.
+    pub from: Point,
+    /// The arc's end point.
+    pub to: Point,
+    /// The arc's radii, where the vector's x-component is the radius in the
+    /// positive x direction after applying `x_rotation`.
+    pub radii: Vec2,
+    /// How much the arc is rotated, in radians.
+    pub x_rotation: f64,
+    /// Does this arc sweep through more than π radians?
+    pub large_arc: bool,
+    /// Determines if the arc should begin moving at positive angles.
+    pub sweep: bool,
+}
+
+impl SvgArc {
+    /// Checks that arc is actually a straight line.
+    ///
+    /// In this case, it can be replaced with a `LineTo`.
+    pub fn is_straight_line(&self) -> bool {
+        self.radii.x.abs() <= 1e-5 || self.radii.y.abs() <= 1e-5 || self.from == self.to
+    }
+}
+
+impl Arc {
+    /// Creates an `Arc` from a `SvgArc`.
+    ///
+    /// Returns `None` if `arc` is actually a straight line.
+    pub fn from_svg_arc(arc: &SvgArc) -> Option<Arc> {
+        // Have to check this first, otherwise `sum_of_sq` will be 0.
+        if arc.is_straight_line() {
+            return None;
+        }
+
+        let mut rx = arc.radii.x.abs();
+        let mut ry = arc.radii.y.abs();
+
+        let xr = arc.x_rotation % (2.0 * PI);
+        let (sin_phi, cos_phi) = xr.sin_cos();
+        let hd_x = (arc.from.x - arc.to.x) * 0.5;
+        let hd_y = (arc.from.y - arc.to.y) * 0.5;
+        let hs_x = (arc.from.x + arc.to.x) * 0.5;
+        let hs_y = (arc.from.y + arc.to.y) * 0.5;
+
+        // F6.5.1
+        let p = Vec2::new(
+            cos_phi * hd_x + sin_phi * hd_y,
+            -sin_phi * hd_x + cos_phi * hd_y,
+        );
+
+        // Sanitize the radii.
+        // If rf > 1 it means the radii are too small for the arc to
+        // possibly connect the end points. In this situation we scale
+        // them up according to the formula provided by the SVG spec.
+
+        // F6.6.2
+        let rf = p.x * p.x / (rx * rx) + p.y * p.y / (ry * ry);
+        if rf > 1.0 {
+            let scale = rf.sqrt();
+            rx *= scale;
+            ry *= scale;
+        }
+
+        let rxry = rx * ry;
+        let rxpy = rx * p.y;
+        let rypx = ry * p.x;
+        let sum_of_sq = rxpy * rxpy + rypx * rypx;
+
+        debug_assert!(sum_of_sq != 0.0);
+
+        // F6.5.2
+        let sign_coe = if arc.large_arc == arc.sweep {
+            -1.0
+        } else {
+            1.0
+        };
+        let coe = sign_coe * ((rxry * rxry - sum_of_sq) / sum_of_sq).abs().sqrt();
+        let transformed_cx = coe * rxpy / ry;
+        let transformed_cy = -coe * rypx / rx;
+
+        // F6.5.3
+        let center = Point::new(
+            cos_phi * transformed_cx - sin_phi * transformed_cy + hs_x,
+            sin_phi * transformed_cx + cos_phi * transformed_cy + hs_y,
+        );
+
+        let start_v = Vec2::new((p.x - transformed_cx) / rx, (p.y - transformed_cy) / ry);
+        let end_v = Vec2::new((-p.x - transformed_cx) / rx, (-p.y - transformed_cy) / ry);
+
+        let start_angle = start_v.atan2();
+
+        let mut sweep_angle = (end_v.atan2() - start_angle) % (2.0 * PI);
+
+        if arc.sweep && sweep_angle < 0.0 {
+            sweep_angle += 2.0 * PI;
+        } else if !arc.sweep && sweep_angle > 0.0 {
+            sweep_angle -= 2.0 * PI;
+        }
+
+        Some(Arc {
+            center,
+            radii: Vec2::new(rx, ry),
+            start_angle,
+            sweep_angle,
+            x_rotation: arc.x_rotation,
+        })
+    }
+}

--- a/bazo/src/translate_scale.rs
+++ b/bazo/src/translate_scale.rs
@@ -1,0 +1,320 @@
+// Copyright 2019 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! A transformation that includes both scale and translation.
+
+use core::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
+
+use crate::{Affine, Circle, Line, Point, Rect, RoundedRect, RoundedRectRadii, Vec2};
+
+/// A transformation consisting of a uniform scaling followed by a translation.
+///
+/// If the translation is `(x, y)` and the scale is `s`, then this
+/// transformation represents this augmented matrix:
+///
+/// ```text
+/// | s 0 x |
+/// | 0 s y |
+/// | 0 0 1 |
+/// ```
+///
+/// See [`Affine`] for more details about the
+/// equivalence with augmented matrices.
+///
+/// Various multiplication ops are defined, and these are all defined
+/// to be consistent with matrix multiplication. Therefore,
+/// `TranslateScale * Point` is defined but not the other way around.
+///
+/// Also note that multiplication is not commutative. Thus,
+/// `TranslateScale::scale(2.0) * TranslateScale::translate(Vec2::new(1.0, 0.0))`
+/// has a translation of (2, 0), while
+/// `TranslateScale::translate(Vec2::new(1.0, 0.0)) * TranslateScale::scale(2.0)`
+/// has a translation of (1, 0). (Both have a scale of 2; also note that
+/// the first case can be written
+/// `2.0 * TranslateScale::translate(Vec2::new(1.0, 0.0))` as this case
+/// has an implicit conversion).
+///
+/// This transformation is less powerful than [`Affine`], but can be applied
+/// to more primitives, especially including [`Rect`].
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TranslateScale {
+    /// The translation component of this transformation
+    pub translation: Vec2,
+    /// The scale component of this transformation
+    pub scale: f64,
+}
+
+impl TranslateScale {
+    /// Create a new transformation from translation and scale.
+    #[inline(always)]
+    pub const fn new(translation: Vec2, scale: f64) -> TranslateScale {
+        TranslateScale { translation, scale }
+    }
+
+    /// Create a new transformation with scale only.
+    #[inline(always)]
+    pub const fn scale(s: f64) -> TranslateScale {
+        TranslateScale::new(Vec2::ZERO, s)
+    }
+
+    /// Create a new transformation with translation only.
+    #[inline(always)]
+    pub fn translate(translation: impl Into<Vec2>) -> TranslateScale {
+        TranslateScale::new(translation.into(), 1.0)
+    }
+
+    /// Create a transform that scales about a point other than the origin.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bazo::{Point, TranslateScale};
+    /// # fn assert_near(p0: Point, p1: Point) {
+    /// #   assert!((p1 - p0).hypot() < 1e-9, "{p0:?} != {p1:?}");
+    /// # }
+    /// let center = Point::new(1., 1.);
+    /// let ts = TranslateScale::from_scale_about(2., center);
+    /// // Should keep the point (1., 1.) stationary
+    /// assert_near(ts * center, center);
+    /// // (2., 2.) -> (3., 3.)
+    /// assert_near(ts * Point::new(2., 2.), Point::new(3., 3.));
+    /// ```
+    #[inline]
+    pub fn from_scale_about(scale: f64, focus: impl Into<Point>) -> Self {
+        // We need to create a transform that is equivalent to translating `focus`
+        // to the origin, followed by a normal scale, followed by reversing the translation.
+        // We need to find the (translation ∘ scale) that matches this.
+        let focus = focus.into().to_vec2();
+        let translation = focus - focus * scale;
+        Self::new(translation, scale)
+    }
+
+    /// Compute the inverse transform.
+    ///
+    /// Multiplying a transform with its inverse (either on the
+    /// left or right) results in the identity transform
+    /// (modulo floating point rounding errors).
+    ///
+    /// Produces NaN values when scale is zero.
+    #[inline]
+    pub fn inverse(self) -> TranslateScale {
+        let scale_recip = self.scale.recip();
+        TranslateScale {
+            translation: self.translation * -scale_recip,
+            scale: scale_recip,
+        }
+    }
+
+    /// Is this translate/scale [finite]?
+    ///
+    /// [finite]: f64::is_finite
+    #[inline]
+    pub fn is_finite(&self) -> bool {
+        self.translation.is_finite() && self.scale.is_finite()
+    }
+
+    /// Is this translate/scale [NaN]?
+    ///
+    /// [NaN]: f64::is_nan
+    #[inline]
+    pub fn is_nan(&self) -> bool {
+        self.translation.is_nan() || self.scale.is_nan()
+    }
+}
+
+impl Default for TranslateScale {
+    #[inline(always)]
+    fn default() -> TranslateScale {
+        TranslateScale::new(Vec2::ZERO, 1.0)
+    }
+}
+
+impl From<TranslateScale> for Affine {
+    #[inline(always)]
+    fn from(ts: TranslateScale) -> Affine {
+        let TranslateScale { translation, scale } = ts;
+        Affine::new([scale, 0.0, 0.0, scale, translation.x, translation.y])
+    }
+}
+
+impl Mul<Point> for TranslateScale {
+    type Output = Point;
+
+    #[inline]
+    fn mul(self, other: Point) -> Point {
+        (self.scale * other.to_vec2()).to_point() + self.translation
+    }
+}
+
+impl Mul for TranslateScale {
+    type Output = TranslateScale;
+
+    #[inline]
+    fn mul(self, other: TranslateScale) -> TranslateScale {
+        TranslateScale {
+            translation: self.translation + self.scale * other.translation,
+            scale: self.scale * other.scale,
+        }
+    }
+}
+
+impl MulAssign for TranslateScale {
+    #[inline]
+    fn mul_assign(&mut self, other: TranslateScale) {
+        *self = self.mul(other);
+    }
+}
+
+impl Mul<TranslateScale> for f64 {
+    type Output = TranslateScale;
+
+    #[inline]
+    fn mul(self, other: TranslateScale) -> TranslateScale {
+        TranslateScale {
+            translation: other.translation * self,
+            scale: other.scale * self,
+        }
+    }
+}
+
+impl Add<Vec2> for TranslateScale {
+    type Output = TranslateScale;
+
+    #[inline]
+    fn add(self, other: Vec2) -> TranslateScale {
+        TranslateScale {
+            translation: self.translation + other,
+            scale: self.scale,
+        }
+    }
+}
+
+impl Add<TranslateScale> for Vec2 {
+    type Output = TranslateScale;
+
+    #[inline]
+    fn add(self, other: TranslateScale) -> TranslateScale {
+        other + self
+    }
+}
+
+impl AddAssign<Vec2> for TranslateScale {
+    #[inline]
+    fn add_assign(&mut self, other: Vec2) {
+        *self = self.add(other);
+    }
+}
+
+impl Sub<Vec2> for TranslateScale {
+    type Output = TranslateScale;
+
+    #[inline]
+    fn sub(self, other: Vec2) -> TranslateScale {
+        TranslateScale {
+            translation: self.translation - other,
+            scale: self.scale,
+        }
+    }
+}
+
+impl SubAssign<Vec2> for TranslateScale {
+    #[inline]
+    fn sub_assign(&mut self, other: Vec2) {
+        *self = self.sub(other);
+    }
+}
+
+impl Mul<Circle> for TranslateScale {
+    type Output = Circle;
+
+    #[inline]
+    fn mul(self, other: Circle) -> Circle {
+        Circle::new(self * other.center, self.scale * other.radius)
+    }
+}
+
+impl Mul<Line> for TranslateScale {
+    type Output = Line;
+
+    #[inline]
+    fn mul(self, other: Line) -> Line {
+        Line::new(self * other.p0, self * other.p1)
+    }
+}
+
+impl Mul<Rect> for TranslateScale {
+    type Output = Rect;
+
+    #[inline]
+    fn mul(self, other: Rect) -> Rect {
+        let pt0 = self * Point::new(other.x0, other.y0);
+        let pt1 = self * Point::new(other.x1, other.y1);
+        (pt0, pt1).into()
+    }
+}
+
+impl Mul<RoundedRect> for TranslateScale {
+    type Output = RoundedRect;
+
+    #[inline]
+    fn mul(self, other: RoundedRect) -> RoundedRect {
+        RoundedRect::from_rect(self * other.rect(), self * other.radii())
+    }
+}
+
+impl Mul<RoundedRectRadii> for TranslateScale {
+    type Output = RoundedRectRadii;
+
+    #[inline]
+    fn mul(self, other: RoundedRectRadii) -> RoundedRectRadii {
+        RoundedRectRadii::new(
+            self.scale * other.top_left,
+            self.scale * other.top_right,
+            self.scale * other.bottom_right,
+            self.scale * other.bottom_left,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Affine, Point, TranslateScale, Vec2};
+
+    fn assert_near(p0: Point, p1: Point) {
+        assert!((p1 - p0).hypot() < 1e-9, "{p0:?} != {p1:?}");
+    }
+
+    #[test]
+    fn translate_scale() {
+        let p = Point::new(3.0, 4.0);
+        let ts = TranslateScale::new(Vec2::new(5.0, 6.0), 2.0);
+
+        assert_near(ts * p, Point::new(11.0, 14.0));
+    }
+
+    #[test]
+    fn conversions() {
+        let p = Point::new(3.0, 4.0);
+        let s = 2.0;
+        let t = Vec2::new(5.0, 6.0);
+        let ts = TranslateScale::new(t, s);
+
+        // Test that conversion to affine is consistent.
+        let a: Affine = ts.into();
+        assert_near(ts * p, a * p);
+
+        assert_near((s * p.to_vec2()).to_point(), TranslateScale::scale(s) * p);
+        assert_near(p + t, TranslateScale::translate(t) * p);
+    }
+
+    #[test]
+    fn inverse() {
+        let p = Point::new(3.0, 4.0);
+        let ts = TranslateScale::new(Vec2::new(5.0, 6.0), 2.0);
+
+        assert_near(p, (ts * ts.inverse()) * p);
+        assert_near(p, (ts.inverse() * ts) * p);
+    }
+}

--- a/bazo/src/triangle.rs
+++ b/bazo/src/triangle.rs
@@ -1,0 +1,310 @@
+// Copyright 2024 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Triangle shape
+use crate::{Circle, Point, Vec2};
+
+use core::cmp::*;
+use core::f64::consts::FRAC_PI_4;
+use core::ops::{Add, Sub};
+
+#[cfg(not(feature = "std"))]
+use crate::common::FloatFuncs;
+
+/// Triangle
+//     A
+//     *
+//    / \
+//   /   \
+//  *-----*
+//  B     C
+#[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Triangle {
+    /// vertex a.
+    pub a: Point,
+    /// vertex b.
+    pub b: Point,
+    /// vertex c.
+    pub c: Point,
+}
+
+impl Triangle {
+    /// The empty [`Triangle`] at the origin.
+    pub const ZERO: Self = Self::from_coords((0., 0.), (0., 0.), (0., 0.));
+
+    /// Equilateral [`Triangle`] with the x-axis unit vector as its base.
+    pub const EQUILATERAL: Self = Self::from_coords(
+        (
+            1.0 / 2.0,
+            1.732050807568877293527446341505872367_f64 / 2.0, /* (sqrt 3)/2 */
+        ),
+        (0.0, 0.0),
+        (1.0, 0.0),
+    );
+
+    /// A new [`Triangle`] from three vertices ([`Point`]s).
+    #[inline(always)]
+    pub fn new(a: impl Into<Point>, b: impl Into<Point>, c: impl Into<Point>) -> Self {
+        Self {
+            a: a.into(),
+            b: b.into(),
+            c: c.into(),
+        }
+    }
+
+    /// A new [`Triangle`] from three float vertex coordinates.
+    ///
+    /// Works as a constant [`Triangle::new`].
+    #[inline(always)]
+    pub const fn from_coords(a: (f64, f64), b: (f64, f64), c: (f64, f64)) -> Self {
+        Self {
+            a: Point::new(a.0, a.1),
+            b: Point::new(b.0, b.1),
+            c: Point::new(c.0, c.1),
+        }
+    }
+
+    /// The centroid of the [`Triangle`].
+    #[inline]
+    pub fn centroid(&self) -> Point {
+        (1.0 / 3.0 * (self.a.to_vec2() + self.b.to_vec2() + self.c.to_vec2())).to_point()
+    }
+
+    /// The offset of each vertex from the centroid.
+    #[inline]
+    pub fn offsets(&self) -> [Vec2; 3] {
+        let centroid = self.centroid().to_vec2();
+
+        [
+            (self.a.to_vec2() - centroid),
+            (self.b.to_vec2() - centroid),
+            (self.c.to_vec2() - centroid),
+        ]
+    }
+
+    /// The area of the [`Triangle`].
+    #[inline]
+    pub fn area(&self) -> f64 {
+        0.5 * (self.b - self.a).cross(self.c - self.a)
+    }
+
+    /// Whether this [`Triangle`] has zero area.
+    #[doc(alias = "is_empty")]
+    #[inline]
+    pub fn is_zero_area(&self) -> bool {
+        self.area() == 0.0
+    }
+
+    /// The inscribed circle of [`Triangle`].
+    ///
+    /// This is defined as the greatest [`Circle`] that lies within the [`Triangle`].
+    #[doc(alias = "incircle")]
+    #[inline]
+    pub fn inscribed_circle(&self) -> Circle {
+        let ab = self.a.distance(self.b);
+        let bc = self.b.distance(self.c);
+        let ac = self.a.distance(self.c);
+
+        // [`Vec2::div`] also multiplies by the reciprocal of the argument, but as this reciprocal
+        // is reused below to calculate the radius, there's explicitly only one division needed.
+        let perimeter_recip = 1. / (ab + bc + ac);
+        let incenter = (self.a.to_vec2() * bc + self.b.to_vec2() * ac + self.c.to_vec2() * ab)
+            * perimeter_recip;
+
+        Circle::new(incenter.to_point(), 2.0 * self.area() * perimeter_recip)
+    }
+
+    /// The circumscribed circle of [`Triangle`].
+    ///
+    /// This is defined as the smallest [`Circle`] which intercepts each vertex of the [`Triangle`].
+    #[doc(alias = "circumcircle")]
+    #[inline]
+    pub fn circumscribed_circle(&self) -> Circle {
+        let b = self.b - self.a;
+        let c = self.c - self.a;
+        let b_len2 = b.hypot2();
+        let c_len2 = c.hypot2();
+        let d_recip = 0.5 / b.cross(c);
+
+        let x = (c.y * b_len2 - b.y * c_len2) * d_recip;
+        let y = (b.x * c_len2 - c.x * b_len2) * d_recip;
+        let r = (b_len2 * c_len2).sqrt() * (c - b).hypot() * d_recip;
+
+        Circle::new(self.a + Vec2::new(x, y), r)
+    }
+
+    /// Expand the triangle by a constant amount (`scalar`) in all directions.
+    #[doc(alias = "offset")]
+    pub fn inflate(&self, scalar: f64) -> Self {
+        let centroid = self.centroid();
+
+        Self::new(
+            centroid + (0.0, scalar),
+            centroid + scalar * Vec2::from_angle(5.0 * FRAC_PI_4),
+            centroid + scalar * Vec2::from_angle(7.0 * FRAC_PI_4),
+        )
+    }
+
+    /// Is this [`Triangle`] [finite]?
+    ///
+    /// [finite]: f64::is_finite
+    #[inline]
+    pub fn is_finite(&self) -> bool {
+        self.a.is_finite() && self.b.is_finite() && self.c.is_finite()
+    }
+
+    /// Is this [`Triangle`] [NaN]?
+    ///
+    /// [NaN]: f64::is_nan
+    #[inline]
+    pub fn is_nan(&self) -> bool {
+        self.a.is_nan() || self.b.is_nan() || self.c.is_nan()
+    }
+}
+
+impl From<(Point, Point, Point)> for Triangle {
+    fn from(points: (Point, Point, Point)) -> Triangle {
+        Triangle::new(points.0, points.1, points.2)
+    }
+}
+
+impl Add<Vec2> for Triangle {
+    type Output = Triangle;
+
+    #[inline]
+    fn add(self, v: Vec2) -> Triangle {
+        Triangle::new(self.a + v, self.b + v, self.c + v)
+    }
+}
+
+impl Sub<Vec2> for Triangle {
+    type Output = Triangle;
+
+    #[inline]
+    fn sub(self, v: Vec2) -> Triangle {
+        Triangle::new(self.a - v, self.b - v, self.c - v)
+    }
+}
+
+// TODO: better and more tests
+#[cfg(test)]
+mod tests {
+    use crate::{Point, Triangle, Vec2};
+
+    fn assert_approx_eq(x: f64, y: f64, max_relative_error: f64) {
+        assert!(
+            (x - y).abs() <= f64::max(x.abs(), y.abs()) * max_relative_error,
+            "{x} != {y}"
+        );
+    }
+
+    fn assert_approx_eq_point(x: Point, y: Point, max_relative_error: f64) {
+        assert_approx_eq(x.x, y.x, max_relative_error);
+        assert_approx_eq(x.y, y.y, max_relative_error);
+    }
+
+    #[test]
+    fn centroid() {
+        let test = Triangle::from_coords((-90.02, 3.5), (7.2, -9.3), (8.0, 9.1)).centroid();
+        let expected = Point::new(-24.94, 1.1);
+
+        assert_approx_eq_point(test, expected, f64::EPSILON * 100.);
+    }
+
+    #[test]
+    fn offsets() {
+        let test = Triangle::from_coords((-20.0, 180.2), (1.2, 0.0), (290.0, 100.0)).offsets();
+        let expected = [
+            Vec2::new(-110.4, 86.8),
+            Vec2::new(-89.2, -93.4),
+            Vec2::new(199.6, 6.6),
+        ];
+
+        test.iter().zip(expected.iter()).for_each(|(t, e)| {
+            assert_approx_eq_point(t.to_point(), e.to_point(), f64::EPSILON * 100.);
+        });
+    }
+
+    #[test]
+    fn area() {
+        let test = Triangle::new(
+            (12123.423, 2382.7834),
+            (7892.729, 238.459),
+            (7820.2, 712.23),
+        );
+        let expected = 1079952.9157407999;
+
+        // initial
+        assert_approx_eq(test.area(), -expected, f64::EPSILON * 100.);
+        // permutate vertex
+        let test = Triangle::new(test.b, test.a, test.c);
+        assert_approx_eq(test.area(), expected, f64::EPSILON * 100.);
+    }
+
+    #[test]
+    fn circumcenter() {
+        let test = Triangle::EQUILATERAL.circumscribed_circle().center;
+        let expected = Point::new(0.5, 0.28867513459481288);
+
+        assert_approx_eq_point(test, expected, f64::EPSILON * 100.);
+    }
+
+    #[test]
+    fn inradius() {
+        let test = Triangle::EQUILATERAL.inscribed_circle().radius;
+        let expected = 0.28867513459481287;
+
+        assert_approx_eq(test, expected, f64::EPSILON * 100.);
+    }
+
+    #[test]
+    fn circumradius() {
+        let test = Triangle::EQUILATERAL;
+        let expected = 0.57735026918962576;
+
+        assert_approx_eq(
+            test.circumscribed_circle().radius,
+            expected,
+            f64::EPSILON * 100.,
+        );
+        // permute vertex
+        let test = Triangle::new(test.b, test.a, test.c);
+        assert_approx_eq(
+            test.circumscribed_circle().radius,
+            -expected,
+            f64::EPSILON * 100.,
+        );
+    }
+
+    #[test]
+    fn inscribed_circle() {
+        let test = Triangle::new((-4., 1.), (-4., -1.), (10., 3.));
+
+        let inscribed = test.inscribed_circle();
+        assert_approx_eq_point(
+            inscribed.center,
+            (-3.0880178529263671, 0.20904207741504303).into(),
+            f64::EPSILON * 100.,
+        );
+        assert_approx_eq(inscribed.radius, 0.91198214707363295, f64::EPSILON * 100.);
+    }
+
+    #[test]
+    fn circumscribed_circle() {
+        let test = Triangle::new((-4., 1.), (-4., -1.), (10., 3.));
+
+        let circumscribed = test.circumscribed_circle();
+        assert_approx_eq_point(
+            circumscribed.center,
+            (3.2857142857142857, 0.).into(),
+            f64::EPSILON * 100.,
+        );
+        assert_approx_eq(
+            circumscribed.radius,
+            7.3540215292764288,
+            f64::EPSILON * 100.,
+        );
+    }
+}

--- a/bazo/src/vec2.rs
+++ b/bazo/src/vec2.rs
@@ -1,0 +1,556 @@
+// Copyright 2018 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! A simple 2D vector.
+
+use core::fmt;
+use core::iter::Sum;
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use crate::common::FloatExt;
+use crate::{Axis, Point, Size};
+
+#[cfg(not(feature = "std"))]
+use crate::common::FloatFuncs;
+
+/// A 2D vector.
+///
+/// This is intended primarily for a vector in the mathematical sense,
+/// but it can be interpreted as a translation, and converted to and
+/// from a [`Point`] (vector relative to the origin) and [`Size`].
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Vec2 {
+    /// The x-coordinate.
+    pub x: f64,
+    /// The y-coordinate.
+    pub y: f64,
+}
+
+impl Vec2 {
+    /// The vector (0, 0).
+    pub const ZERO: Vec2 = Vec2::new(0., 0.);
+
+    /// Create a new vector.
+    #[inline(always)]
+    pub const fn new(x: f64, y: f64) -> Vec2 {
+        Vec2 { x, y }
+    }
+
+    /// Convert this vector into a [`Point`].
+    #[inline(always)]
+    pub const fn to_point(self) -> Point {
+        Point::new(self.x, self.y)
+    }
+
+    /// Convert this vector into a [`Size`].
+    #[inline(always)]
+    pub const fn to_size(self) -> Size {
+        Size::new(self.x, self.y)
+    }
+
+    /// Create a vector with the same value for `x` and `y`.
+    #[inline(always)]
+    pub const fn splat(v: f64) -> Self {
+        Vec2 { x: v, y: v }
+    }
+
+    /// Dot product of two vectors.
+    #[inline]
+    pub const fn dot(self, other: Vec2) -> f64 {
+        self.x * other.x + self.y * other.y
+    }
+
+    /// Cross product of two vectors.
+    ///
+    /// This is signed so that `(1, 0) × (0, 1) = 1`.
+    ///
+    /// The following relations hold:
+    ///
+    /// `u.cross(v) = -v.cross(u)`
+    ///
+    /// `v.cross(v) = 0.0`
+    #[inline]
+    pub const fn cross(self, other: Vec2) -> f64 {
+        self.x * other.y - self.y * other.x
+    }
+
+    /// Magnitude of vector.
+    ///
+    /// See [`Point::distance`] for the same operation on [`Point`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Vec2;
+    /// let v = Vec2::new(3.0, 4.0);
+    /// assert_eq!(v.hypot(), 5.0);
+    /// ```
+    #[inline]
+    pub fn hypot(self) -> f64 {
+        // Avoid f64::hypot as it calls a slow library function.
+        self.hypot2().sqrt()
+    }
+
+    /// Magnitude of vector.
+    ///
+    /// This is an alias for [`Vec2::hypot`].
+    #[inline]
+    pub fn length(self) -> f64 {
+        self.hypot()
+    }
+
+    /// Magnitude squared of vector.
+    ///
+    /// See [`Point::distance_squared`] for the same operation on [`Point`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Vec2;
+    /// let v = Vec2::new(3.0, 4.0);
+    /// assert_eq!(v.hypot2(), 25.0);
+    /// ```
+    #[inline]
+    pub const fn hypot2(self) -> f64 {
+        self.dot(self)
+    }
+
+    /// Magnitude squared of vector.
+    ///
+    /// This is an alias for [`Vec2::hypot2`].
+    #[inline]
+    pub const fn length_squared(self) -> f64 {
+        self.hypot2()
+    }
+
+    /// Find the angle in radians between this vector and the vector `Vec2 { x: 1.0, y: 0.0 }`
+    /// in the positive `y` direction.
+    ///
+    /// If the vector is interpreted as a complex number, this is the argument.
+    /// The angle is expressed in radians.
+    #[inline]
+    pub fn atan2(self) -> f64 {
+        self.y.atan2(self.x)
+    }
+
+    /// Find the angle in radians between this vector and the vector `Vec2 { x: 1.0, y: 0.0 }`
+    /// in the positive `y` direction.
+    ///
+    /// This is an alias for [`Vec2::atan2`].
+    #[inline]
+    pub fn angle(self) -> f64 {
+        self.atan2()
+    }
+
+    /// A unit vector of the given angle.
+    ///
+    /// With `th` at zero, the result is the positive X unit vector, and
+    /// at π/2, it is the positive Y unit vector. The angle is expressed
+    /// in radians.
+    ///
+    /// Thus, in a Y-down coordinate system (as is common for graphics),
+    /// it is a clockwise rotation, and in Y-up (traditional for math), it
+    /// is anti-clockwise. This convention is consistent with
+    /// [`Affine::rotate`].
+    ///
+    /// [`Affine::rotate`]: crate::Affine::rotate
+    #[inline]
+    pub fn from_angle(th: f64) -> Vec2 {
+        let (th_sin, th_cos) = th.sin_cos();
+        Vec2 {
+            x: th_cos,
+            y: th_sin,
+        }
+    }
+
+    /// Linearly interpolate between two vectors.
+    #[inline]
+    pub fn lerp(self, other: Vec2, t: f64) -> Vec2 {
+        self + t * (other - self)
+    }
+
+    /// Returns a vector of [magnitude] 1.0 with the same angle as `self`; i.e.
+    /// a unit/direction vector.
+    ///
+    /// This produces `NaN` values when the magnitude is `0`.
+    ///
+    /// [magnitude]: Self::hypot
+    #[inline]
+    pub fn normalize(self) -> Vec2 {
+        self / self.hypot()
+    }
+
+    /// Returns a new `Vec2`,
+    /// with `x` and `y` [rounded] to the nearest integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Vec2;
+    /// let a = Vec2::new(3.3, 3.6).round();
+    /// let b = Vec2::new(3.0, -3.1).round();
+    /// assert_eq!(a.x, 3.0);
+    /// assert_eq!(a.y, 4.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -3.0);
+    /// ```
+    ///
+    /// [rounded]: f64::round
+    #[inline]
+    pub fn round(self) -> Vec2 {
+        Vec2::new(self.x.round(), self.y.round())
+    }
+
+    /// Returns a new `Vec2`,
+    /// with `x` and `y` [rounded up] to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Vec2;
+    /// let a = Vec2::new(3.3, 3.6).ceil();
+    /// let b = Vec2::new(3.0, -3.1).ceil();
+    /// assert_eq!(a.x, 4.0);
+    /// assert_eq!(a.y, 4.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -3.0);
+    /// ```
+    ///
+    /// [rounded up]: f64::ceil
+    #[inline]
+    pub fn ceil(self) -> Vec2 {
+        Vec2::new(self.x.ceil(), self.y.ceil())
+    }
+
+    /// Returns a new `Vec2`,
+    /// with `x` and `y` [rounded down] to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Vec2;
+    /// let a = Vec2::new(3.3, 3.6).floor();
+    /// let b = Vec2::new(3.0, -3.1).floor();
+    /// assert_eq!(a.x, 3.0);
+    /// assert_eq!(a.y, 3.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -4.0);
+    /// ```
+    ///
+    /// [rounded down]: f64::floor
+    #[inline]
+    pub fn floor(self) -> Vec2 {
+        Vec2::new(self.x.floor(), self.y.floor())
+    }
+
+    /// Returns a new `Vec2`,
+    /// with `x` and `y` [rounded away] from zero to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Vec2;
+    /// let a = Vec2::new(3.3, 3.6).expand();
+    /// let b = Vec2::new(3.0, -3.1).expand();
+    /// assert_eq!(a.x, 4.0);
+    /// assert_eq!(a.y, 4.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -4.0);
+    /// ```
+    ///
+    /// [rounded away]: FloatExt::expand
+    #[inline]
+    pub fn expand(self) -> Vec2 {
+        Vec2::new(self.x.expand(), self.y.expand())
+    }
+
+    /// Returns a new `Vec2`,
+    /// with `x` and `y` [rounded towards] zero to the nearest integer,
+    /// unless they are already an integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bazo::Vec2;
+    /// let a = Vec2::new(3.3, 3.6).trunc();
+    /// let b = Vec2::new(3.0, -3.1).trunc();
+    /// assert_eq!(a.x, 3.0);
+    /// assert_eq!(a.y, 3.0);
+    /// assert_eq!(b.x, 3.0);
+    /// assert_eq!(b.y, -3.0);
+    /// ```
+    ///
+    /// [rounded towards]: f64::trunc
+    #[inline]
+    pub fn trunc(self) -> Vec2 {
+        Vec2::new(self.x.trunc(), self.y.trunc())
+    }
+
+    /// Is this `Vec2` [finite]?
+    ///
+    /// [finite]: f64::is_finite
+    #[inline]
+    pub fn is_finite(self) -> bool {
+        self.x.is_finite() && self.y.is_finite()
+    }
+
+    /// Is this `Vec2` [`NaN`]?
+    ///
+    /// [`NaN`]: f64::is_nan
+    #[inline]
+    pub fn is_nan(self) -> bool {
+        self.x.is_nan() || self.y.is_nan()
+    }
+
+    /// Turn by 90 degrees.
+    ///
+    /// The rotation is clockwise in a Y-down coordinate system. The following relations hold:
+    ///
+    /// `u.dot(v) = u.cross(v.turn_90())`
+    ///
+    /// `u.cross(v) = u.turn_90().dot(v)`
+    #[inline]
+    pub const fn turn_90(self) -> Vec2 {
+        Vec2::new(-self.y, self.x)
+    }
+
+    /// Combine two vectors interpreted as rotation and scaling.
+    ///
+    /// Interpret both vectors as a rotation and a scale, and combine
+    /// their effects.  by adding the angles and multiplying the magnitudes.
+    /// This operation is equivalent to multiplication when the vectors
+    /// are interpreted as complex numbers. It is commutative.
+    #[inline]
+    pub const fn rotate_scale(self, rhs: Vec2) -> Vec2 {
+        Vec2::new(
+            self.x * rhs.x - self.y * rhs.y,
+            self.x * rhs.y + self.y * rhs.x,
+        )
+    }
+
+    /// Get the member matching the given axis.
+    #[inline]
+    pub fn get_coord(self, axis: Axis) -> f64 {
+        match axis {
+            Axis::Horizontal => self.x,
+            Axis::Vertical => self.y,
+        }
+    }
+
+    /// Get a mutable reference to the member matching the given axis.
+    #[inline]
+    pub fn get_coord_mut(&mut self, axis: Axis) -> &mut f64 {
+        match axis {
+            Axis::Horizontal => &mut self.x,
+            Axis::Vertical => &mut self.y,
+        }
+    }
+
+    /// Set the member matching the given axis to the given value.
+    #[inline]
+    pub fn set_coord(&mut self, axis: Axis, value: f64) {
+        match axis {
+            Axis::Horizontal => self.x = value,
+            Axis::Vertical => self.y = value,
+        }
+    }
+}
+
+impl From<(f64, f64)> for Vec2 {
+    #[inline(always)]
+    fn from(v: (f64, f64)) -> Vec2 {
+        Vec2 { x: v.0, y: v.1 }
+    }
+}
+
+impl From<Vec2> for (f64, f64) {
+    #[inline(always)]
+    fn from(v: Vec2) -> (f64, f64) {
+        (v.x, v.y)
+    }
+}
+
+impl Add for Vec2 {
+    type Output = Vec2;
+
+    #[inline]
+    fn add(self, other: Vec2) -> Vec2 {
+        Vec2 {
+            x: self.x + other.x,
+            y: self.y + other.y,
+        }
+    }
+}
+
+impl AddAssign for Vec2 {
+    #[inline]
+    fn add_assign(&mut self, other: Vec2) {
+        *self = Vec2 {
+            x: self.x + other.x,
+            y: self.y + other.y,
+        }
+    }
+}
+
+impl Sum for Vec2 {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Vec2::ZERO, |sum, v| sum + v)
+    }
+}
+
+impl Sub for Vec2 {
+    type Output = Vec2;
+
+    #[inline]
+    fn sub(self, other: Vec2) -> Vec2 {
+        Vec2 {
+            x: self.x - other.x,
+            y: self.y - other.y,
+        }
+    }
+}
+
+impl SubAssign for Vec2 {
+    #[inline]
+    fn sub_assign(&mut self, other: Vec2) {
+        *self = Vec2 {
+            x: self.x - other.x,
+            y: self.y - other.y,
+        }
+    }
+}
+
+impl Mul<f64> for Vec2 {
+    type Output = Vec2;
+
+    #[inline]
+    fn mul(self, other: f64) -> Vec2 {
+        Vec2 {
+            x: self.x * other,
+            y: self.y * other,
+        }
+    }
+}
+
+impl MulAssign<f64> for Vec2 {
+    #[inline]
+    fn mul_assign(&mut self, other: f64) {
+        *self = Vec2 {
+            x: self.x * other,
+            y: self.y * other,
+        };
+    }
+}
+
+impl Mul<Vec2> for f64 {
+    type Output = Vec2;
+
+    #[inline]
+    fn mul(self, other: Vec2) -> Vec2 {
+        other * self
+    }
+}
+
+impl Div<f64> for Vec2 {
+    type Output = Vec2;
+
+    /// Note: division by a scalar is implemented by multiplying by the reciprocal.
+    ///
+    /// This is more efficient but has different roundoff behavior than division.
+    #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn div(self, other: f64) -> Vec2 {
+        self * other.recip()
+    }
+}
+
+impl DivAssign<f64> for Vec2 {
+    #[inline]
+    fn div_assign(&mut self, other: f64) {
+        self.mul_assign(other.recip());
+    }
+}
+
+impl Neg for Vec2 {
+    type Output = Vec2;
+
+    #[inline]
+    fn neg(self) -> Vec2 {
+        Vec2 {
+            x: -self.x,
+            y: -self.y,
+        }
+    }
+}
+
+impl fmt::Display for Vec2 {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "𝐯=(")?;
+        fmt::Display::fmt(&self.x, formatter)?;
+        write!(formatter, ", ")?;
+        fmt::Display::fmt(&self.y, formatter)?;
+        write!(formatter, ")")
+    }
+}
+
+// Conversions to and from mint
+#[cfg(feature = "mint")]
+impl From<Vec2> for mint::Vector2<f64> {
+    #[inline(always)]
+    fn from(p: Vec2) -> mint::Vector2<f64> {
+        mint::Vector2 { x: p.x, y: p.y }
+    }
+}
+
+#[cfg(feature = "mint")]
+impl From<mint::Vector2<f64>> for Vec2 {
+    #[inline(always)]
+    fn from(p: mint::Vector2<f64>) -> Vec2 {
+        Vec2 { x: p.x, y: p.y }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::f64::consts::FRAC_PI_2;
+
+    use super::*;
+    #[test]
+    fn display() {
+        let v = Vec2::new(1.2332421, 532.10721213123);
+        let s = format!("{v:.2}");
+        assert_eq!(s.as_str(), "𝐯=(1.23, 532.11)");
+    }
+
+    #[test]
+    fn cross_sign() {
+        let v = Vec2::new(1., 0.).cross(Vec2::new(0., 1.));
+        assert_eq!(v, 1.);
+    }
+
+    #[test]
+    fn turn_90() {
+        let u = Vec2::new(0.1, 0.2);
+        let turned = u.turn_90();
+        // This should be exactly equal by IEEE rules, might fail
+        // in fastmath conditions.
+        assert_eq!(u.length(), turned.length());
+        const EPSILON: f64 = 1e-12;
+        assert!((u.angle() + FRAC_PI_2 - turned.angle()).abs() < EPSILON);
+    }
+
+    #[test]
+    fn rotate_scale() {
+        let u = Vec2::new(0.1, 0.2);
+        let v = Vec2::new(0.3, -0.4);
+        let uv = u.rotate_scale(v);
+        const EPSILON: f64 = 1e-12;
+        assert!((u.length() * v.length() - uv.length()).abs() < EPSILON);
+        assert!((u.angle() + v.angle() - uv.angle()).abs() < EPSILON);
+    }
+}


### PR DESCRIPTION
An experiement in making a base vocabulary crate to sit under `kurbo` (could also be used in `parley`, `peniko`, `taffy`, etc. This crate is similar to `euclid`, except that it doesn't have a type parameter for the units making it much more ergonomic to use.

The idea is that this crate would be highly stable (rarely if ever making breaking changes).

## Tasks

- [x] Duplicate `kurbo` crate as `bazo`
- [x] Remove `kurbo`-specific code from `bazo`
- [ ] Make `bazo` types generic (rather than hardcoded to `f64`)
- [ ] Use `bazo` types in `kurbo` and ensure all impls still work

## Open questions

- Is this a good idea?
- Should `Stroke`, `Cap`, `Dash`, etc be included (in limited form)?
- Should `BezPath`, `CubicBez`, `QuadBez` (in limited form)?
- Where should the kurbo SVG path parsing code live (separate crate?)
- Should this depend on `num-traits` or have it's own number abstractions?
