### PR TITLE
Mark `{Point,Rect,Size,Vec2}`'s axis methods `const`

### DIFF
--- a/kurbo/src/point.rs
+++ b/kurbo/src/point.rs
@@ -205,7 +205,7 @@ impl Point {
 
     /// Get the member matching the given axis.
     #[inline]
-    pub fn get_coord(self, axis: Axis) -> f64 {
+    pub const fn get_coord(self, axis: Axis) -> f64 {
         match axis {
             Axis::Horizontal => self.x,
             Axis::Vertical => self.y,
@@ -214,7 +214,7 @@ impl Point {
 
     /// Get a mutable reference to the member matching the given axis.
     #[inline]
-    pub fn get_coord_mut(&mut self, axis: Axis) -> &mut f64 {
+    pub const fn get_coord_mut(&mut self, axis: Axis) -> &mut f64 {
         match axis {
             Axis::Horizontal => &mut self.x,
             Axis::Vertical => &mut self.y,
@@ -223,7 +223,7 @@ impl Point {
 
     /// Set the member matching the given axis to the given value.
     #[inline]
-    pub fn set_coord(&mut self, axis: Axis, value: f64) {
+    pub const fn set_coord(&mut self, axis: Axis, value: f64) {
         match axis {
             Axis::Horizontal => self.x = value,
             Axis::Vertical => self.y = value,

--- a/kurbo/src/rect.rs
+++ b/kurbo/src/rect.rs
@@ -643,7 +643,7 @@ impl Rect {
 
     /// Get the members matching the given axis.
     #[inline]
-    pub fn get_coords(self, axis: Axis) -> (f64, f64) {
+    pub const fn get_coords(self, axis: Axis) -> (f64, f64) {
         match axis {
             Axis::Horizontal => (self.x0, self.x1),
             Axis::Vertical => (self.y0, self.y1),
@@ -652,7 +652,7 @@ impl Rect {
 
     /// Get a mutable reference to the members matching the given axis.
     #[inline]
-    pub fn get_coords_mut(&mut self, axis: Axis) -> (&mut f64, &mut f64) {
+    pub const fn get_coords_mut(&mut self, axis: Axis) -> (&mut f64, &mut f64) {
         match axis {
             Axis::Horizontal => (&mut self.x0, &mut self.x1),
             Axis::Vertical => (&mut self.y0, &mut self.y1),
@@ -661,7 +661,7 @@ impl Rect {
 
     /// Set the members matching the given axis to the given values.
     #[inline]
-    pub fn set_coords(&mut self, axis: Axis, v0: f64, v1: f64) {
+    pub const fn set_coords(&mut self, axis: Axis, v0: f64, v1: f64) {
         match axis {
             Axis::Horizontal => (self.x0, self.x1) = (v0, v1),
             Axis::Vertical => (self.y0, self.y1) = (v0, v1),

--- a/kurbo/src/size.rs
+++ b/kurbo/src/size.rs
@@ -309,7 +309,7 @@ impl Size {
 
     /// Get the member matching the given axis.
     #[inline]
-    pub fn get_coord(self, axis: Axis) -> f64 {
+    pub const fn get_coord(self, axis: Axis) -> f64 {
         match axis {
             Axis::Horizontal => self.width,
             Axis::Vertical => self.height,
@@ -318,7 +318,7 @@ impl Size {
 
     /// Get a mutable reference to the member matching the given axis.
     #[inline]
-    pub fn get_coord_mut(&mut self, axis: Axis) -> &mut f64 {
+    pub const fn get_coord_mut(&mut self, axis: Axis) -> &mut f64 {
         match axis {
             Axis::Horizontal => &mut self.width,
             Axis::Vertical => &mut self.height,
@@ -327,7 +327,7 @@ impl Size {
 
     /// Set the member matching the given axis to the given value.
     #[inline]
-    pub fn set_coord(&mut self, axis: Axis, value: f64) {
+    pub const fn set_coord(&mut self, axis: Axis, value: f64) {
         match axis {
             Axis::Horizontal => self.width = value,
             Axis::Vertical => self.height = value,

--- a/kurbo/src/vec2.rs
+++ b/kurbo/src/vec2.rs
@@ -347,7 +347,7 @@ impl Vec2 {
 
     /// Get the member matching the given axis.
     #[inline]
-    pub fn get_coord(self, axis: Axis) -> f64 {
+    pub const fn get_coord(self, axis: Axis) -> f64 {
         match axis {
             Axis::Horizontal => self.x,
             Axis::Vertical => self.y,
@@ -356,7 +356,7 @@ impl Vec2 {
 
     /// Get a mutable reference to the member matching the given axis.
     #[inline]
-    pub fn get_coord_mut(&mut self, axis: Axis) -> &mut f64 {
+    pub const fn get_coord_mut(&mut self, axis: Axis) -> &mut f64 {
         match axis {
             Axis::Horizontal => &mut self.x,
             Axis::Vertical => &mut self.y,
@@ -365,7 +365,7 @@ impl Vec2 {
 
     /// Set the member matching the given axis to the given value.
     #[inline]
-    pub fn set_coord(&mut self, axis: Axis, value: f64) {
+    pub const fn set_coord(&mut self, axis: Axis, value: f64) {
         match axis {
             Axis::Horizontal => self.x = value,
             Axis::Vertical => self.y = value,


### PR DESCRIPTION
`const` mutable references were stabilized in Rust 1.83 (we now have MSRV 1.85).