### PR TITLE
Make a bunch of methods `const`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This release has an [MSRV][] of 1.85.
 ## Changed
 
 - Improve performance of `RoundedRect::winding` and `RoundedRect::contains`. ([#534][] by [@tomcur][])
+- `Axis`, `Insets`, `Line::reversed`, `Rect::min_x/max_x/min_y/max_y`, `RoundedRectRadii::abs/clamp/as_single_radius`, `RoundedRect::width/height/radii/rect/origin/center`, `Size::aspect_ratio`, `Stroke::with_join/with_miter_limit/with_start_cap/with_end_cap/with_caps` are all now `const`. ([#536][] by [@xStrom])
 
 ## [0.13.0] (2025-11-27)
 
@@ -193,6 +194,7 @@ Note: A changelog was not kept for or before this release
 [@tomcur]: https://github.com/tomcur
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 [@xorgy]: https://github.com/xorgy
+[@xStrom]: https://github.com/xStrom
 
 [#288]: https://github.com/linebender/kurbo/pull/288
 [#334]: https://github.com/linebender/kurbo/pull/334
@@ -268,6 +270,7 @@ Note: A changelog was not kept for or before this release
 [#526]: https://github.com/linebender/kurbo/pull/526
 [#527]: https://github.com/linebender/kurbo/pull/527
 [#534]: https://github.com/linebender/kurbo/pull/534
+[#536]: https://github.com/linebender/kurbo/pull/536
 
 [Unreleased]: https://github.com/linebender/kurbo/compare/v0.13.0...HEAD
 [0.13.0]: https://github.com/linebender/kurbo/releases/tag/v0.13.0

--- a/kurbo/src/axis.rs
+++ b/kurbo/src/axis.rs
@@ -15,7 +15,7 @@ pub enum Axis {
 impl Axis {
     /// Get the axis perpendicular to this one.
     #[inline]
-    pub fn cross(self) -> Self {
+    pub const fn cross(self) -> Self {
         match self {
             Self::Horizontal => Self::Vertical,
             Self::Vertical => Self::Horizontal,
@@ -27,8 +27,11 @@ impl Axis {
     /// The axis value is the one matching the axis (e.g. `y` for [`Self::Vertical`]).
     /// The cross value is the other one.
     #[inline]
-    pub fn pack_point(self, axis_value: f64, cross_value: f64) -> Point {
-        self.pack_xy(axis_value, cross_value).into()
+    pub const fn pack_point(self, axis_value: f64, cross_value: f64) -> Point {
+        match self {
+            Self::Horizontal => Point::new(axis_value, cross_value),
+            Self::Vertical => Point::new(cross_value, axis_value),
+        }
     }
 
     /// Create a new [`Size`] by arranging the given magnitudes.
@@ -36,8 +39,11 @@ impl Axis {
     /// The axis value is the one matching the axis (e.g. `height` for [`Self::Vertical`]).
     /// The cross value is the other one.
     #[inline]
-    pub fn pack_size(self, axis_value: f64, cross_value: f64) -> Size {
-        self.pack_xy(axis_value, cross_value).into()
+    pub const fn pack_size(self, axis_value: f64, cross_value: f64) -> Size {
+        match self {
+            Self::Horizontal => Size::new(axis_value, cross_value),
+            Self::Vertical => Size::new(cross_value, axis_value),
+        }
     }
 
     /// Create a new [`Vec2`] by arranging the given magnitudes.
@@ -45,8 +51,11 @@ impl Axis {
     /// The axis value is the one matching the axis (e.g. `y` for [`Self::Vertical`]).
     /// The cross value is the other one.
     #[inline]
-    pub fn pack_vec2(self, axis_value: f64, cross_value: f64) -> Vec2 {
-        self.pack_xy(axis_value, cross_value).into()
+    pub const fn pack_vec2(self, axis_value: f64, cross_value: f64) -> Vec2 {
+        match self {
+            Self::Horizontal => Vec2::new(axis_value, cross_value),
+            Self::Vertical => Vec2::new(cross_value, axis_value),
+        }
     }
 
     /// Create a new `(x, y)` pair by arranging the given magnitudes.
@@ -54,7 +63,7 @@ impl Axis {
     /// The axis value is the one matching the axis (e.g. `y` for [`Self::Vertical`]).
     /// The cross value is the other one.
     #[inline]
-    pub fn pack_xy(self, axis_value: f64, cross_value: f64) -> (f64, f64) {
+    pub const fn pack_xy(self, axis_value: f64, cross_value: f64) -> (f64, f64) {
         match self {
             Self::Horizontal => (axis_value, cross_value),
             Self::Vertical => (cross_value, axis_value),

--- a/kurbo/src/insets.rs
+++ b/kurbo/src/insets.rs
@@ -148,7 +148,7 @@ impl Insets {
     /// assert_eq!(insets.x_value(), -7.);
     /// ```
     #[inline]
-    pub fn x_value(self) -> f64 {
+    pub const fn x_value(self) -> f64 {
         self.x0 + self.x1
     }
 
@@ -166,7 +166,7 @@ impl Insets {
     /// assert_eq!(insets.y_value(), 14.);
     /// ```
     #[inline]
-    pub fn y_value(self) -> f64 {
+    pub const fn y_value(self) -> f64 {
         self.y0 + self.y1
     }
 
@@ -188,12 +188,12 @@ impl Insets {
     ///
     /// [`x_value`]: Insets::x_value
     /// [`y_value`]: Insets::y_value
-    pub fn size(self) -> Size {
+    pub const fn size(self) -> Size {
         Size::new(self.x_value(), self.y_value())
     }
 
     /// Return `true` iff all values are nonnegative.
-    pub fn are_nonnegative(self) -> bool {
+    pub const fn are_nonnegative(self) -> bool {
         let Insets { x0, y0, x1, y1 } = self;
         x0 >= 0.0 && y0 >= 0.0 && x1 >= 0.0 && y1 >= 0.0
     }
@@ -213,7 +213,7 @@ impl Insets {
     /// assert_eq!(nonnegative.x_value(), 0.0);
     /// assert_eq!(nonnegative.y_value(), 7.0);
     /// ```
-    pub fn nonnegative(self) -> Insets {
+    pub const fn nonnegative(self) -> Insets {
         let Insets { x0, y0, x1, y1 } = self;
         Insets {
             x0: x0.max(0.0),

--- a/kurbo/src/line.rs
+++ b/kurbo/src/line.rs
@@ -38,7 +38,7 @@ impl Line {
     /// points in the opposite direction.
     #[must_use]
     #[inline(always)]
-    pub fn reversed(&self) -> Line {
+    pub const fn reversed(&self) -> Line {
         Self {
             p0: self.p1,
             p1: self.p0,

--- a/kurbo/src/rect.rs
+++ b/kurbo/src/rect.rs
@@ -118,25 +118,25 @@ impl Rect {
 
     /// Returns the minimum value for the x-coordinate of the rectangle.
     #[inline]
-    pub fn min_x(&self) -> f64 {
+    pub const fn min_x(&self) -> f64 {
         self.x0.min(self.x1)
     }
 
     /// Returns the maximum value for the x-coordinate of the rectangle.
     #[inline]
-    pub fn max_x(&self) -> f64 {
+    pub const fn max_x(&self) -> f64 {
         self.x0.max(self.x1)
     }
 
     /// Returns the minimum value for the y-coordinate of the rectangle.
     #[inline]
-    pub fn min_y(&self) -> f64 {
+    pub const fn min_y(&self) -> f64 {
         self.y0.min(self.y1)
     }
 
     /// Returns the maximum value for the y-coordinate of the rectangle.
     #[inline]
-    pub fn max_y(&self) -> f64 {
+    pub const fn max_y(&self) -> f64 {
         self.y0.max(self.y1)
     }
 

--- a/kurbo/src/rounded_rect.rs
+++ b/kurbo/src/rounded_rect.rs
@@ -97,25 +97,25 @@ impl RoundedRect {
 
     /// The width of the rectangle.
     #[inline]
-    pub fn width(&self) -> f64 {
+    pub const fn width(&self) -> f64 {
         self.rect.width()
     }
 
     /// The height of the rectangle.
     #[inline]
-    pub fn height(&self) -> f64 {
+    pub const fn height(&self) -> f64 {
         self.rect.height()
     }
 
     /// Radii of the rounded corners.
     #[inline(always)]
-    pub fn radii(&self) -> RoundedRectRadii {
+    pub const fn radii(&self) -> RoundedRectRadii {
         self.radii
     }
 
     /// The (non-rounded) rectangle.
     #[inline(always)]
-    pub fn rect(&self) -> Rect {
+    pub const fn rect(&self) -> Rect {
         self.rect
     }
 
@@ -123,13 +123,13 @@ impl RoundedRect {
     ///
     /// This is the top left corner in a y-down space.
     #[inline(always)]
-    pub fn origin(&self) -> Point {
+    pub const fn origin(&self) -> Point {
         self.rect.origin()
     }
 
     /// The center point of the rectangle.
     #[inline]
-    pub fn center(&self) -> Point {
+    pub const fn center(&self) -> Point {
         self.rect.center()
     }
 

--- a/kurbo/src/rounded_rect_radii.rs
+++ b/kurbo/src/rounded_rect_radii.rs
@@ -58,7 +58,7 @@ impl RoundedRectRadii {
     }
 
     /// Takes the absolute value of all corner radii.
-    pub fn abs(&self) -> Self {
+    pub const fn abs(&self) -> Self {
         RoundedRectRadii::new(
             self.top_left.abs(),
             self.top_right.abs(),
@@ -68,7 +68,7 @@ impl RoundedRectRadii {
     }
 
     /// For each corner, takes the min of that corner's radius and `max`.
-    pub fn clamp(&self, max: f64) -> Self {
+    pub const fn clamp(&self, max: f64) -> Self {
         RoundedRectRadii::new(
             self.top_left.min(max),
             self.top_right.min(max),
@@ -95,7 +95,7 @@ impl RoundedRectRadii {
 
     /// If all radii are equal, returns the value of the radii. Otherwise,
     /// returns `None`.
-    pub fn as_single_radius(&self) -> Option<f64> {
+    pub const fn as_single_radius(&self) -> Option<f64> {
         let epsilon = 1e-9;
 
         if (self.top_left - self.top_right).abs() < epsilon

--- a/kurbo/src/size.rs
+++ b/kurbo/src/size.rs
@@ -274,7 +274,7 @@ impl Size {
     #[inline]
     // TODO: When we remove this, we should also work out what to do with aspect_ratio_width
     // The tentatitive plan is to rename `aspect_ratio_width` back to this name
-    pub fn aspect_ratio(self) -> f64 {
+    pub const fn aspect_ratio(self) -> f64 {
         self.height / self.width
     }
 

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -114,31 +114,31 @@ impl Stroke {
     }
 
     /// Builder method for setting the join style.
-    pub fn with_join(mut self, join: Join) -> Self {
+    pub const fn with_join(mut self, join: Join) -> Self {
         self.join = join;
         self
     }
 
     /// Builder method for setting the limit for miter joins.
-    pub fn with_miter_limit(mut self, limit: f64) -> Self {
+    pub const fn with_miter_limit(mut self, limit: f64) -> Self {
         self.miter_limit = limit;
         self
     }
 
     /// Builder method for setting the cap style for the start of the stroke.
-    pub fn with_start_cap(mut self, cap: Cap) -> Self {
+    pub const fn with_start_cap(mut self, cap: Cap) -> Self {
         self.start_cap = cap;
         self
     }
 
     /// Builder method for setting the cap style for the end of the stroke.
-    pub fn with_end_cap(mut self, cap: Cap) -> Self {
+    pub const fn with_end_cap(mut self, cap: Cap) -> Self {
         self.end_cap = cap;
         self
     }
 
     /// Builder method for setting the cap style.
-    pub fn with_caps(mut self, cap: Cap) -> Self {
+    pub const fn with_caps(mut self, cap: Cap) -> Self {
         self.start_cap = cap;
         self.end_cap = cap;
         self


### PR DESCRIPTION
I wanted `Axis` methods to be `const` and figured I can make some others `const` too while I'm at it.

* `Axis`
* `Insets`
* `Line::reversed`
* `Rect::min_x/max_x/min_y/max_y`
* `RoundedRectRadii::abs/clamp/as_single_radius`
* `RoundedRect::width/height/radii/rect/origin/center`
* `Size::aspect_ratio`
* `Stroke::with_join/with_miter_limit/with_start_cap/with_end_cap/with_caps`