### PR TITLE
Make `Stroke::new` `const`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This release has an [MSRV][] of 1.85.
 ## Changed
 
 - Improve performance of `RoundedRect::winding` and `RoundedRect::contains`. ([#534][] by [@tomcur][])
-- `Axis`, `Insets`, `Line::reversed`, `Rect::min_x/max_x/min_y/max_y`, `RoundedRectRadii::abs/clamp/as_single_radius`, `RoundedRect::width/height/radii/rect/origin/center`, `Size::aspect_ratio`, `Stroke::with_join/with_miter_limit/with_start_cap/with_end_cap/with_caps` are all now `const`. ([#536][] by [@xStrom])
+- `Axis`, `Insets`, `Line::reversed`, `Rect::min_x/max_x/min_y/max_y`, `RoundedRectRadii::abs/clamp/as_single_radius`, `RoundedRect::width/height/radii/rect/origin/center`, `Size::aspect_ratio`, `Stroke::new/with_join/with_miter_limit/with_start_cap/with_end_cap/with_caps` are all now `const`. ([#536][] by [@xStrom], [#539][] by [@tomcur][])
 
 ## [0.13.0] (2025-11-27)
 
@@ -271,6 +271,7 @@ Note: A changelog was not kept for or before this release
 [#527]: https://github.com/linebender/kurbo/pull/527
 [#534]: https://github.com/linebender/kurbo/pull/534
 [#536]: https://github.com/linebender/kurbo/pull/536
+[#539]: https://github.com/linebender/kurbo/pull/539
 
 [Unreleased]: https://github.com/linebender/kurbo/compare/v0.13.0...HEAD
 [0.13.0]: https://github.com/linebender/kurbo/releases/tag/v0.13.0

--- a/kurbo/Cargo.toml
+++ b/kurbo/Cargo.toml
@@ -35,7 +35,7 @@ serde = ["smallvec/serde", "dep:serde"]
 schemars = ["schemars/smallvec", "dep:schemars"]
 
 [dependencies]
-smallvec = "1.15.1"
+smallvec = { version = "1.15.1", features = ["const_new"] }
 euclid = { version = "0.22", optional = true, default-features = false }
 polycool.workspace = true
 

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -92,24 +92,21 @@ impl Default for StrokeOpts {
 
 impl Default for Stroke {
     fn default() -> Self {
-        Self {
-            width: 1.0,
-            join: Join::Round,
-            miter_limit: 4.0,
-            start_cap: Cap::Round,
-            end_cap: Cap::Round,
-            dash_pattern: SmallVec::default(),
-            dash_offset: 0.0,
-        }
+        Self::new(1.0)
     }
 }
 
 impl Stroke {
     /// Creates a new stroke with the specified width.
-    pub fn new(width: f64) -> Self {
+    pub const fn new(width: f64) -> Self {
         Self {
             width,
-            ..Stroke::default()
+            join: Join::Round,
+            miter_limit: 4.0,
+            start_cap: Cap::Round,
+            end_cap: Cap::Round,
+            dash_pattern: SmallVec::new_const(),
+            dash_offset: 0.0,
         }
     }
 


### PR DESCRIPTION
This allows easily constructing a `const` stroke without having to set all the fields manually.

This does require `smallvec`'s `const_new` feature flag. [They mention it requiring Rust 1.51 or higher](https://github.com/servo/rust-smallvec/blob/d0f47a3ea99296498ee940b5d99f59b403c498a2/src/lib.rs#L51-L57), which should be non-breaking as Kurbo's MSRV is 1.85. The feature also enables `smallvec`'s `const_generics` feature, switching `smallvec` from implementing for a number of concrete array sizes to a blanket const-generic `impl` [here](https://github.com/servo/rust-smallvec/blob/d0f47a3ea99296498ee940b5d99f59b403c498a2/src/lib.rs#L2434-L2462), but I believe breakage by that is already prevented by the rust compiler ([E0119](https://doc.rust-lang.org/error_codes/E0119.html) with "upstream crates may add a new impl of trait `smallvec::Array` for type `[T; ...]` in future versions").