### PR TITLE
Add ability to add/subtract `Insets` from `Insets`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This release has an [MSRV][] of 1.85.
 
 - Add `Stroke::is_finite` and `Stroke::is_nan`. ([#545][] by [@waywardmonkeys][])
 - Component-wise `Insets::min/max` methods. ([#548][] by [@xStrom][])
+- Ability to add and subtract `Insets` from other `Insets`. ([#549][] by [@xStrom][])
 
 ## Changed
 
@@ -284,6 +285,7 @@ Note: A changelog was not kept for or before this release
 [#539]: https://github.com/linebender/kurbo/pull/539
 [#545]: https://github.com/linebender/kurbo/pull/545
 [#548]: https://github.com/linebender/kurbo/pull/548
+[#549]: https://github.com/linebender/kurbo/pull/549
 
 [Unreleased]: https://github.com/linebender/kurbo/compare/v0.13.0...HEAD
 [0.13.0]: https://github.com/linebender/kurbo/releases/tag/v0.13.0

--- a/kurbo/src/insets.rs
+++ b/kurbo/src/insets.rs
@@ -287,6 +287,32 @@ impl Neg for Insets {
     }
 }
 
+impl Add<Insets> for Insets {
+    type Output = Insets;
+
+    fn add(self, other: Insets) -> Self::Output {
+        Insets {
+            x0: self.x0 + other.x0,
+            x1: self.x1 + other.x1,
+            y0: self.y0 + other.y0,
+            y1: self.y1 + other.y1,
+        }
+    }
+}
+
+impl Sub<Insets> for Insets {
+    type Output = Insets;
+
+    fn sub(self, other: Insets) -> Self::Output {
+        Insets {
+            x0: self.x0 - other.x0,
+            x1: self.x1 - other.x1,
+            y0: self.y0 - other.y0,
+            y1: self.y1 - other.y1,
+        }
+    }
+}
+
 impl Add<Rect> for Insets {
     type Output = Rect;
 


### PR DESCRIPTION
This will improve ergonomics of already existing code in Masonry.