### PR TITLE
fixes: stroke() function with dashed stroke returns first piece last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This release has an [MSRV][] of 1.85.
 - `Arc` now implements `ParamCurve`. ([#378][] by [@waywardmonkeys][])
 - Add `Affine::{pre,then}_skew` and `Affine::{pre,then}_reflect` fluent composition helpers. ([#563][] by [@waywardmonkeys][])
 - Add three transform matrix norms: `Affine::{nuclear_norm_squared,frobenius_norm_squared,spectral_norm}`. ([#569][] by [@tomcur][])
+- Add `stable_dash_order` option to emit dashes in a closed path in the order they appear. ([#550][] by [@RobertBrewitz][])
 
 ## Changed
 
@@ -211,6 +212,7 @@ Note: A changelog was not kept for or before this release
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 [@xorgy]: https://github.com/xorgy
 [@xStrom]: https://github.com/xStrom
+[@RobertBrewitz]: https://github.com/RobertBrewitz
 
 [#288]: https://github.com/linebender/kurbo/pull/288
 [#334]: https://github.com/linebender/kurbo/pull/334
@@ -293,6 +295,7 @@ Note: A changelog was not kept for or before this release
 [#545]: https://github.com/linebender/kurbo/pull/545
 [#548]: https://github.com/linebender/kurbo/pull/548
 [#549]: https://github.com/linebender/kurbo/pull/549
+[#550]: https://github.com/linebender/kurbo/pull/550
 [#559]: https://github.com/linebender/kurbo/pull/559
 [#561]: https://github.com/linebender/kurbo/pull/561
 [#563]: https://github.com/linebender/kurbo/pull/563

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This release has an [MSRV][] of 1.85.
 - `Arc` now implements `ParamCurve`. ([#378][] by [@waywardmonkeys][])
 - Add `Affine::{pre,then}_skew` and `Affine::{pre,then}_reflect` fluent composition helpers. ([#563][] by [@waywardmonkeys][])
 - Add three transform matrix norms: `Affine::{nuclear_norm_squared,frobenius_norm_squared,spectral_norm}`. ([#569][] by [@tomcur][])
-- Add `stable_dash_order` option to emit dashes in a closed path in the order they appear. ([#550][] by [@RobertBrewitz][])
+- Add `StrokeOpts::stable_dash_order` to keep dashes at fixed path-relative positions instead of merging the first/last dash across. ([#550][] by [@RobertBrewitz][])
 
 ## Changed
 

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -631,6 +631,7 @@ struct DashIterator<'a, T> {
     stash: Vec<PathEl>,
     stash_ix: usize,
     stable_dash_order: bool,
+    needs_moveto: bool,
 }
 
 #[derive(PartialEq, Eq)]
@@ -659,11 +660,10 @@ impl<T: Iterator<Item = PathEl>> Iterator for DashIterator<'_, T> {
                 }
                 DashState::ToStash => {
                     if let Some(el) = self.step() {
-                        self.stash.push(el);
                         if self.stable_dash_order {
-                            self.stash_ix = self.stash.len();
                             return Some(el);
                         }
+                        self.stash.push(el);
                     }
                 }
                 DashState::Working => {
@@ -764,6 +764,7 @@ fn dash_iter<'a>(
         stash: Vec::new(),
         stash_ix: 0,
         stable_dash_order,
+        needs_moveto: true,
     }
 }
 
@@ -828,7 +829,8 @@ impl<'a, T: Iterator<Item = PathEl>> DashIterator<'a, T> {
     /// Move arc length forward to next event.
     fn step(&mut self) -> Option<PathEl> {
         let mut result = None;
-        if self.state == DashState::ToStash && self.stash.is_empty() {
+        if self.state == DashState::ToStash && self.needs_moveto {
+            self.needs_moveto = false;
             if self.is_active {
                 result = Some(PathEl::MoveTo(self.current_seg.start()));
             } else {
@@ -881,6 +883,7 @@ impl<'a, T: Iterator<Item = PathEl>> DashIterator<'a, T> {
         self.dash_ix = self.init_dash_ix;
         self.dash_remaining = self.init_dash_remaining;
         self.is_active = self.init_is_active;
+        self.needs_moveto = true;
     }
 }
 
@@ -1049,6 +1052,28 @@ mod tests {
         ];
         let iter = segments(dash(shape.path_elements(0.), 3., &dashes));
         assert_eq!(iter.collect::<Vec<PathSeg>>(), expansion);
+    }
+
+    #[test]
+    fn dash_stable_order_multi_subpath() {
+        let mut path = BezPath::new();
+        path.move_to((0., 0.));
+        path.line_to((2., 0.));
+        path.line_to((2., 2.));
+        path.line_to((0., 2.));
+        path.close_path();
+        path.move_to((10., 10.));
+        path.line_to((12., 10.));
+        path.line_to((12., 12.));
+        path.line_to((10., 12.));
+        path.close_path();
+        let dashes = [3., 1.];
+        let result: Vec<PathEl> = dash_iter(path.into_iter(), 0., &dashes, true).collect();
+        assert_eq!(result[0], PathEl::MoveTo((0., 0.).into()));
+        let second_move = result
+            .iter()
+            .position(|el| matches!(el, PathEl::MoveTo(p) if p.x == 10.0));
+        assert!(second_move.is_some(), "second subpath should have a MoveTo");
     }
 
     #[test]

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -1051,6 +1051,7 @@ mod tests {
         assert_eq!(iter.collect::<Vec<PathSeg>>(), expansion);
     }
 
+    // Differently-sized subpaths verify stable mode restarts the dash pattern per subpath without leaking state.
     #[test]
     fn dash_stable_order_multi_subpath() {
         let mut path = BezPath::new();
@@ -1060,17 +1061,34 @@ mod tests {
         path.line_to((0., 2.));
         path.close_path();
         path.move_to((10., 10.));
-        path.line_to((12., 10.));
-        path.line_to((12., 12.));
-        path.line_to((10., 12.));
+        path.line_to((15., 10.));
+        path.line_to((15., 14.));
+        path.line_to((10., 14.));
         path.close_path();
         let dashes = [3., 1.];
-        let result: Vec<PathEl> = dash_iter(path.into_iter(), 0., &dashes, true).collect();
-        assert_eq!(result[0], PathEl::MoveTo((0., 0.).into()));
-        let second_move = result
-            .iter()
-            .position(|el| matches!(el, PathEl::MoveTo(p) if p.x == 10.0));
-        assert!(second_move.is_some(), "second subpath should have a MoveTo");
+        let expansion = [
+            PathEl::MoveTo((0., 0.).into()),
+            PathEl::LineTo((2., 0.).into()),
+            PathEl::LineTo((2., 1.).into()),
+            PathEl::MoveTo((2., 2.).into()),
+            PathEl::LineTo((0., 2.).into()),
+            PathEl::LineTo((0., 1.).into()),
+            PathEl::MoveTo((10., 10.).into()),
+            PathEl::LineTo((13., 10.).into()),
+            PathEl::MoveTo((14., 10.).into()),
+            PathEl::LineTo((15., 10.).into()),
+            PathEl::LineTo((15., 12.).into()),
+            PathEl::MoveTo((15., 13.).into()),
+            PathEl::LineTo((15., 14.).into()),
+            PathEl::LineTo((13., 14.).into()),
+            PathEl::MoveTo((12., 14.).into()),
+            PathEl::LineTo((10., 14.).into()),
+            PathEl::LineTo((10., 13.).into()),
+            PathEl::MoveTo((10., 12.).into()),
+            PathEl::LineTo((10., 10.).into()),
+        ];
+        let iter = dash_iter(path.into_iter(), 0., &dashes, true);
+        assert_eq!(iter.collect::<Vec<PathEl>>(), expansion);
     }
 
     #[test]

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -287,16 +287,13 @@ pub fn stroke_with(
 ) {
     if style.dash_pattern.is_empty() {
         stroke_undashed(path, style, tolerance, ctx);
-    } else if opts.stable_dash_order {
+    } else {
         let dashed = dash_iter(
             path.into_iter(),
             style.dash_offset,
             &style.dash_pattern,
-            true,
+            opts.stable_dash_order,
         );
-        stroke_undashed(dashed, style, tolerance, ctx);
-    } else {
-        let dashed = dash(path.into_iter(), style.dash_offset, &style.dash_pattern);
         stroke_undashed(dashed, style, tolerance, ctx);
     }
 }

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -66,7 +66,7 @@ pub struct Stroke {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct StrokeOpts {
     opt_level: StrokeOptLevel,
-    /// When `true`, dashes emits in the order they appear along the path.
+    /// When `true`, dashes are emitted in the order they appear along the path. The default `false` delays a subpath's first dash so it can be merged with a dash that wraps through `ClosePath`; this option disables both the reorder and the wraparound merge, so a dash spanning the seam is truncated there.
     stable_dash_order: bool,
 }
 
@@ -187,7 +187,7 @@ impl StrokeOpts {
         self
     }
 
-    /// When `true`, dashes emits in the order they appear along the path.
+    /// When `true`, dashes are emitted in the order they appear along the path.
     pub fn stable_dash_order(mut self, stable: bool) -> Self {
         self.stable_dash_order = stable;
         self

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -66,6 +66,8 @@ pub struct Stroke {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct StrokeOpts {
     opt_level: StrokeOptLevel,
+    /// When `true`, dashes emits in the order they appear along the path.
+    stable_dash_order: bool,
 }
 
 /// Optimization level for computing stroke outlines.
@@ -86,7 +88,10 @@ pub enum StrokeOptLevel {
 impl Default for StrokeOpts {
     fn default() -> Self {
         let opt_level = StrokeOptLevel::Subdivide;
-        StrokeOpts { opt_level }
+        StrokeOpts {
+            opt_level,
+            stable_dash_order: false,
+        }
     }
 }
 
@@ -181,6 +186,12 @@ impl StrokeOpts {
         self.opt_level = opt_level;
         self
     }
+
+    /// When `true`, dashes emits in the order they appear along the path.
+    pub fn stable_dash_order(mut self, stable: bool) -> Self {
+        self.stable_dash_order = stable;
+        self
+    }
 }
 
 /// Collection of values representing lengths in a dash pattern.
@@ -249,11 +260,11 @@ impl StrokeCtx {
 pub fn stroke(
     path: impl IntoIterator<Item = PathEl>,
     style: &Stroke,
-    _opts: &StrokeOpts,
+    opts: &StrokeOpts,
     tolerance: f64,
 ) -> BezPath {
     let mut ctx = StrokeCtx::default();
-    stroke_with(path, style, _opts, tolerance, &mut ctx);
+    stroke_with(path, style, opts, tolerance, &mut ctx);
 
     ctx.output
 }
@@ -270,12 +281,20 @@ pub fn stroke(
 pub fn stroke_with(
     path: impl IntoIterator<Item = PathEl>,
     style: &Stroke,
-    _opts: &StrokeOpts,
+    opts: &StrokeOpts,
     tolerance: f64,
     ctx: &mut StrokeCtx,
 ) {
     if style.dash_pattern.is_empty() {
         stroke_undashed(path, style, tolerance, ctx);
+    } else if opts.stable_dash_order {
+        let dashed = dash_iter(
+            path.into_iter(),
+            style.dash_offset,
+            &style.dash_pattern,
+            true,
+        );
+        stroke_undashed(dashed, style, tolerance, ctx);
     } else {
         let dashed = dash(path.into_iter(), style.dash_offset, &style.dash_pattern);
         stroke_undashed(dashed, style, tolerance, ctx);
@@ -611,6 +630,7 @@ struct DashIterator<'a, T> {
     last_pt: Point,
     stash: Vec<PathEl>,
     stash_ix: usize,
+    stable_dash_order: bool,
 }
 
 #[derive(PartialEq, Eq)]
@@ -640,6 +660,10 @@ impl<T: Iterator<Item = PathEl>> Iterator for DashIterator<'_, T> {
                 DashState::ToStash => {
                     if let Some(el) = self.step() {
                         self.stash.push(el);
+                        if self.stable_dash_order {
+                            self.stash_ix = self.stash.len();
+                            return Some(el);
+                        }
                     }
                 }
                 DashState::Working => {
@@ -698,6 +722,15 @@ pub fn dash<'a>(
     dash_offset: f64,
     dashes: &'a [f64],
 ) -> impl Iterator<Item = PathEl> + 'a {
+    dash_iter(inner, dash_offset, dashes, false)
+}
+
+fn dash_iter<'a>(
+    inner: impl Iterator<Item = PathEl> + 'a,
+    dash_offset: f64,
+    dashes: &'a [f64],
+    stable_dash_order: bool,
+) -> DashIterator<'a, impl Iterator<Item = PathEl> + 'a> {
     // ensure that offset is positive and minimal by normalization using period
     let period = dashes.iter().sum();
     let dash_offset = dash_offset.rem_euclid(period);
@@ -730,6 +763,7 @@ pub fn dash<'a>(
         last_pt: Point::ORIGIN,
         stash: Vec::new(),
         stash_ix: 0,
+        stable_dash_order,
     }
 }
 
@@ -835,7 +869,7 @@ impl<'a, T: Iterator<Item = PathEl>> DashIterator<'a, T> {
         if self.state == DashState::ToStash {
             // Have looped back without breaking a dash, just play it back
             self.stash.push(PathEl::ClosePath);
-        } else if self.is_active {
+        } else if self.is_active && !self.stable_dash_order {
             // connect with path in stash, skip MoveTo.
             self.stash_ix = 1;
         }
@@ -852,6 +886,7 @@ impl<'a, T: Iterator<Item = PathEl>> DashIterator<'a, T> {
 
 #[cfg(test)]
 mod tests {
+    use super::dash_iter;
     use crate::{
         BezPath, Cap::Butt, CubicBez, Join::Miter, Line, PathEl, PathSeg, Shape, Stroke,
         StrokeOpts, dash, segments, stroke,
@@ -949,6 +984,55 @@ mod tests {
         ];
         let iter = segments(dash(shape.path_elements(0.), 0., &dashes));
         assert_eq!(iter.collect::<Vec<PathSeg>>(), expansion);
+    }
+
+    #[test]
+    fn dash_sequence_closed_path() {
+        let shape = crate::Rect::from_points((0.0, 0.0), (4.0, 4.0));
+        let dashes = [5., 1.];
+        let expansion = [
+            PathEl::MoveTo((4.0, 2.0).into()),
+            PathEl::LineTo((4.0, 4.0).into()),
+            PathEl::LineTo((1.0, 4.0).into()),
+            PathEl::MoveTo((0.0, 4.0).into()),
+            PathEl::LineTo((0.0, 0.0).into()),
+            PathEl::LineTo((4.0, 0.0).into()),
+            PathEl::LineTo((4.0, 1.0).into()),
+        ];
+        let iter = dash(shape.path_elements(0.), 0., &dashes);
+        assert_eq!(iter.collect::<Vec<PathEl>>(), expansion);
+    }
+
+    #[test]
+    fn dash_sequence_stable_order() {
+        let shape = Line::new((0.0, 0.0), (21.0, 0.0));
+        let dashes = [1., 5., 2., 5.];
+        let expansion = [
+            PathSeg::Line(Line::new((0., 0.), (1., 0.))),
+            PathSeg::Line(Line::new((6., 0.), (8., 0.))),
+            PathSeg::Line(Line::new((13., 0.), (14., 0.))),
+            PathSeg::Line(Line::new((19., 0.), (21., 0.))),
+        ];
+        let iter = segments(dash_iter(shape.path_elements(0.), 0., &dashes, true));
+        assert_eq!(iter.collect::<Vec<PathSeg>>(), expansion);
+    }
+
+    #[test]
+    fn dash_sequence_closed_path_stable_order() {
+        let shape = crate::Rect::from_points((0.0, 0.0), (4.0, 4.0));
+        let dashes = [5., 1.];
+        let expansion = [
+            PathEl::MoveTo((0.0, 0.0).into()),
+            PathEl::LineTo((4.0, 0.0).into()),
+            PathEl::LineTo((4.0, 1.0).into()),
+            PathEl::MoveTo((4.0, 2.0).into()),
+            PathEl::LineTo((4.0, 4.0).into()),
+            PathEl::LineTo((1.0, 4.0).into()),
+            PathEl::MoveTo((0.0, 4.0).into()),
+            PathEl::LineTo((0.0, 0.0).into()),
+        ];
+        let iter = dash_iter(shape.path_elements(0.), 0., &dashes, true);
+        assert_eq!(iter.collect::<Vec<PathEl>>(), expansion);
     }
 
     #[test]


### PR DESCRIPTION
Currently, DashIterator has a stash mechanism that causes the issue https://github.com/linebender/kurbo/issues/528

## Solution

- Adds `stable_dash_order` option to StrokeOpts
- Adds 12 bytes to the DashIterator
- Adds test from https://github.com/linebender/kurbo/pull/532#issuecomment-3750946795

## AI Disclosure

I first created a PoC based on my comment https://github.com/linebender/kurbo/issues/528#issuecomment-3768947405 using Claude CLI with a bunch of skills and plan mode back and forth; Code (diff: https://github.com/RobertBrewitz/kurbo/compare/main..strokeel)

I since then massaged it down to this PR.

## AI Conclusion for this PR

Using Claude code for the initial implementation proved to be a detour rather than helpful in the end :laughing: