### PR TITLE
Align path validity with SVG: only the first subpath requires a `MoveTo`

### DIFF
--- a/kurbo/src/bezpath.rs
+++ b/kurbo/src/bezpath.rs
@@ -520,10 +520,8 @@ impl BezPath {
 /// A subpath of a [`BezPath`].
 ///
 /// Returned by [`BezPath::subpaths`]. See
-/// [`BezPath`'s documentation on elements and segments][elements-and-segment]
+/// [`BezPath`'s documentation on elements and segments][BezPath#elements-and-segments]
 /// for more information.
-///
-/// [elements-and-segments]: BezPath#elements-and-segments
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Subpath<'a> {
     start: Point,

--- a/kurbo/src/bezpath.rs
+++ b/kurbo/src/bezpath.rs
@@ -48,7 +48,7 @@ use crate::common::FloatFuncs;
 /// more `LineTo`, `QuadTo`, and `CurveTo` elements. A subpath can optionally
 /// be closed with `ClosePath`. New subpaths start after a `ClosePath` or
 /// `MoveTo`. Subpaths without an initial `MoveTo` start at the previous
-/// subpath's initial point.
+/// subpath's end point.
 ///
 /// Internally, a `BezPath` is a list of [`PathEl`]s; as such it implements
 /// [`FromIterator<PathEl>`] and [`Extend<PathEl>`]:
@@ -135,9 +135,11 @@ pub enum PathEl {
     ///
     /// The first two points are the Bézier's control points, the last point is its end point.
     CurveTo(Point, Point, Point),
-    /// Close off the path.
+    /// Close off the path by drawing a line from the current location to the current subpath's
+    /// start point.
     ///
-    /// Any element after this starts a new subpath.
+    /// Any element after this starts a new subpath from the closing line's end point (or,
+    /// equivalently, from this subpath's start point).
     ClosePath,
 }
 

--- a/kurbo/src/bezpath.rs
+++ b/kurbo/src/bezpath.rs
@@ -43,9 +43,12 @@ use crate::common::FloatFuncs;
 /// For tasks like drawing, elements are a natural fit, but when doing
 /// hit-testing or subdividing, we need to have access to the segments.
 ///
-/// Conceptually, a `BezPath` contains zero or more subpaths. Each subpath
-/// *always* begins with a `MoveTo`, then has zero or more `LineTo`, `QuadTo`,
-/// and `CurveTo` elements, and optionally ends with a `ClosePath`.
+/// Conceptually, a `BezPath` contains zero or more subpaths. Each non-empty
+/// path *always* starts its first subpath with a `MoveTo`, then has zero or
+/// more `LineTo`, `QuadTo`, and `CurveTo` elements. A subpath can optionally
+/// be closed with `ClosePath`. New subpaths start after a `ClosePath` or
+/// `MoveTo`. Subpaths without an initial `MoveTo` start at the previous
+/// subpath's initial point.
 ///
 /// Internally, a `BezPath` is a list of [`PathEl`]s; as such it implements
 /// [`FromIterator<PathEl>`] and [`Extend<PathEl>`]:
@@ -107,7 +110,14 @@ pub struct BezPath(Vec<PathEl>);
 
 /// The element of a Bézier path.
 ///
-/// A valid path has `MoveTo` at the beginning of each subpath.
+/// Every valid non-empty path starts with [`PathEl::MoveTo`], beginning its first
+/// subpath. Subsequent [`PathEl::MoveTo`] elements start new subpaths. A [`PathEl::ClosePath`]
+/// followed by anything other than a [`PathEl::MoveTo`] also starts a new subpath with the same
+/// initial point as the current subpath. This matches SVG's path semantics, see
+/// [Scalable Vector Graphics 2 § 9.3.3][svg-moveto] and [§ 9.3.4][svg-closepath]
+///
+/// [svg-moveto]: https://www.w3.org/TR/SVG2/paths.html#PathDataMovetoCommands
+/// [svg-closepath]: https://www.w3.org/TR/SVG2/paths.html#PathDataClosePathCommand
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -126,6 +136,8 @@ pub enum PathEl {
     /// The first two points are the Bézier's control points, the last point is its end point.
     CurveTo(Point, Point, Point),
     /// Close off the path.
+    ///
+    /// Any element after this starts a new subpath.
     ClosePath,
 }
 

--- a/kurbo/src/bezpath.rs
+++ b/kurbo/src/bezpath.rs
@@ -344,18 +344,24 @@ impl BezPath {
             PathEl::LineTo(p) => p,
             PathEl::QuadTo(_, p2) => p2,
             PathEl::CurveTo(_, _, p3) => p3,
-            PathEl::ClosePath => return None,
+            // Drawing elements following this `ClosePath` implicitly start at this closed subpath's
+            // initial point.
+            PathEl::ClosePath => subpath_initial_point(&self.0[..ix - 1])?,
         };
         match self.0[ix] {
             PathEl::LineTo(p) => Some(PathSeg::Line(Line::new(last, p))),
             PathEl::QuadTo(p1, p2) => Some(PathSeg::Quad(QuadBez::new(last, p1, p2))),
             PathEl::CurveTo(p1, p2, p3) => Some(PathSeg::Cubic(CubicBez::new(last, p1, p2, p3))),
-            PathEl::ClosePath => self.0[..ix].iter().rev().find_map(|el| match *el {
-                PathEl::MoveTo(start) if start != last => {
-                    Some(PathSeg::Line(Line::new(last, start)))
+            PathEl::ClosePath => {
+                // If the previous element was also `ClosePath`, we don't produce a segment (and don't
+                // walk back again).
+                if matches!(self.0[ix - 1], PathEl::ClosePath) {
+                    None
+                } else {
+                    let start = subpath_initial_point(&self.0[..ix])?;
+                    (start != last).then(|| PathSeg::Line(Line::new(last, start)))
                 }
-                _ => None,
-            }),
+            }
             PathEl::MoveTo(_) => None,
         }
     }
@@ -422,14 +428,7 @@ impl BezPath {
             PathEl::LineTo(p1) => Some(*p1),
             PathEl::QuadTo(_, p2) => Some(*p2),
             PathEl::CurveTo(_, _, p3) => Some(*p3),
-            PathEl::ClosePath => self
-                .elements()
-                .iter()
-                .rev()
-                .skip(1)
-                .take_while(|el| !matches!(el, PathEl::ClosePath))
-                .last()
-                .and_then(|el| el.end_point()),
+            PathEl::ClosePath => subpath_initial_point(&self.0[..self.0.len() - 1]),
         }
     }
 
@@ -493,6 +492,18 @@ impl BezPath {
         }
         reversed
     }
+}
+
+/// Find the initial point of the last subpath in `elements`.
+///
+/// Subpaths started implicitly after a `ClosePath` (i.e., subpaths without their own `MoveTo`)
+/// inherit the initial point of the preceding subpath, thus the initial point of a subpath is
+/// always the nearest preceding `MoveTo`.
+fn subpath_initial_point(elements: &[PathEl]) -> Option<Point> {
+    elements.iter().rev().find_map(|el| match el {
+        PathEl::MoveTo(p) => Some(*p),
+        _ => None,
+    })
 }
 
 /// Helper for reversing a subpath.
@@ -1703,6 +1714,36 @@ mod tests {
         assert_eq!(segments, get_segs);
     }
 
+    // An implicit subpath after `ClosePath` inherits the previous subpath's
+    // initial point, and `get_seg` must return segments relative to it.
+    #[test]
+    fn test_get_seg_implicit_subpaths() {
+        let path = BezPath::from_vec(vec![
+            PathEl::MoveTo((0., 0.).into()),
+            PathEl::LineTo((10., 0.).into()),
+            PathEl::ClosePath,
+            PathEl::LineTo((5., 5.).into()),
+            PathEl::ClosePath,
+        ]);
+        assert_eq!(
+            path.get_seg(3),
+            Some(PathSeg::Line(Line::new((0., 0.), (5., 5.)))),
+        );
+        assert_eq!(
+            path.get_seg(4),
+            Some(PathSeg::Line(Line::new((5., 5.), (0., 0.)))),
+        );
+
+        // Consecutive `ClosePath`s produce no segment.
+        let path = BezPath::from_vec(vec![
+            PathEl::MoveTo((0., 0.).into()),
+            PathEl::LineTo((10., 0.).into()),
+            PathEl::ClosePath,
+            PathEl::ClosePath,
+        ]);
+        assert_eq!(path.get_seg(3), None);
+    }
+
     #[test]
     fn test_control_box() {
         // a sort of map ping looking thing drawn with a single cubic
@@ -2158,15 +2199,28 @@ mod tests {
         path.close_path();
         assert_eq!(path.current_position(), Some(Point::new(0., 0.)));
 
+        // A `ClosePath` following another `ClosePath` starts (and immediately closes) an implicit
+        // subpath inheriting the previous subpath's initial point.
         path.close_path();
-        assert_eq!(path.current_position(), None);
+        assert_eq!(path.current_position(), Some(Point::new(0., 0.)));
 
         path.move_to((0., 10.));
         assert_eq!(path.current_position(), Some(Point::new(0., 10.)));
         path.close_path();
         assert_eq!(path.current_position(), Some(Point::new(0., 10.)));
         path.close_path();
-        assert_eq!(path.current_position(), None);
+        assert_eq!(path.current_position(), Some(Point::new(0., 10.)));
+
+        // An implicit subpath started by a drawing element after `ClosePath` inherits the previous
+        // subpath's initial point; closing it returns to that point.
+        let mut path = BezPath::new();
+        path.move_to((0., 0.));
+        path.line_to((10., 10.));
+        path.close_path();
+        path.line_to((5., 5.));
+        assert_eq!(path.current_position(), Some(Point::new(5., 5.)));
+        path.close_path();
+        assert_eq!(path.current_position(), Some(Point::new(0., 0.)));
     }
 
     // Regression test for #531

--- a/kurbo/src/bezpath.rs
+++ b/kurbo/src/bezpath.rs
@@ -432,21 +432,42 @@ impl BezPath {
         }
     }
 
-    /// Returns an iterator over the subpaths of this path. See [Elements and Segments](#elements-and-segments) for more information.
-    pub fn subpaths(&self) -> impl Iterator<Item = &[PathEl]> {
+    /// Returns an iterator over the subpaths of this path.
+    ///
+    /// A subpath begins with a [`PathEl::MoveTo`] or implicitly with a drawing command following a
+    /// [`PathEl::ClosePath`]; in the latter case the subpath inherits its initial point from the
+    /// preceding subpath.
+    ///
+    /// See [Elements and Segments](#elements-and-segments) for more information.
+    pub fn subpaths(&self) -> impl Iterator<Item = Subpath<'_>> {
         let elements = self.elements();
         let mut i = 0;
+        let mut initial_point = Point::ZERO;
 
         core::iter::from_fn(move || {
             if i >= elements.len() {
                 return None;
             }
             let start = i;
-            i += 1;
-            while i < elements.len() && !matches!(elements[i], PathEl::MoveTo(_)) {
-                i += 1;
+            if let PathEl::MoveTo(p) = elements[i] {
+                initial_point = p;
             }
-            Some(&elements[start..i])
+            // An implicit subpath inherits `initial_point` from the previous iteration.
+            i += 1;
+            while i < elements.len() {
+                match elements[i] {
+                    PathEl::MoveTo(_) => break,
+                    PathEl::ClosePath => {
+                        i += 1;
+                        break;
+                    }
+                    _ => i += 1,
+                }
+            }
+            Some(Subpath {
+                start: initial_point,
+                elements: &elements[start..i],
+            })
         })
     }
 
@@ -491,6 +512,37 @@ impl BezPath {
             reversed.push(PathEl::MoveTo(start_pt));
         }
         reversed
+    }
+}
+
+/// A subpath of a [`BezPath`].
+///
+/// Returned by [`BezPath::subpaths`]. See
+/// [`BezPath`'s documentation on elements and segments][elements-and-segment]
+/// for more information.
+///
+/// [elements-and-segments]: BezPath#elements-and-segments
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Subpath<'a> {
+    start: Point,
+    elements: &'a [PathEl],
+}
+
+impl<'a> Subpath<'a> {
+    /// The initial point of this subpath.
+    ///
+    /// For subpaths that begin with an explicit [`PathEl::MoveTo`], this is the `MoveTo` target.
+    /// For implicit subpaths (those that follow a [`PathEl::ClosePath`] without a `MoveTo`) this is
+    /// the initial point of the preceding subpath.
+    pub fn start(&self) -> Point {
+        self.start
+    }
+
+    /// The elements of this subpath.
+    ///
+    /// The first element is a [`PathEl::MoveTo`] for subpaths with an explicit initial point.
+    pub fn elements(&self) -> &'a [PathEl] {
+        self.elements
     }
 }
 
@@ -649,11 +701,13 @@ pub fn flatten(
 ) {
     let sqrt_tol = tolerance.sqrt();
     let mut last_pt = None;
+    let mut subpath_start = None;
     let mut quad_buf = Vec::new();
     for el in path {
         match el {
             PathEl::MoveTo(p) => {
                 last_pt = Some(p);
+                subpath_start = Some(p);
                 callback(PathEl::MoveTo(p));
             }
             PathEl::LineTo(p) => {
@@ -722,7 +776,9 @@ pub fn flatten(
                 last_pt = Some(p3);
             }
             PathEl::ClosePath => {
-                last_pt = None;
+                // A drawing element following this `ClosePath` starts an implicit subpath at this
+                // `ClosePath`'s endpoint (or equivalently, at the current subpath's initial point).
+                last_pt = subpath_start;
                 callback(PathEl::ClosePath);
             }
         }
@@ -1714,12 +1770,12 @@ mod tests {
         assert_eq!(segments, get_segs);
     }
 
-    // An implicit subpath after `ClosePath` inherits the previous subpath's
-    // initial point, and `get_seg` must return segments relative to it.
+    // An implicit subpath after `ClosePath` inherits the previous subpath's initial point, and
+    // `get_seg` must return segments relative to it.
     #[test]
     fn test_get_seg_implicit_subpaths() {
         let path = BezPath::from_vec(vec![
-            PathEl::MoveTo((0., 0.).into()),
+            PathEl::MoveTo((2., 3.).into()),
             PathEl::LineTo((10., 0.).into()),
             PathEl::ClosePath,
             PathEl::LineTo((5., 5.).into()),
@@ -1727,16 +1783,16 @@ mod tests {
         ]);
         assert_eq!(
             path.get_seg(3),
-            Some(PathSeg::Line(Line::new((0., 0.), (5., 5.)))),
+            Some(PathSeg::Line(Line::new((2., 3.), (5., 5.)))),
         );
         assert_eq!(
             path.get_seg(4),
-            Some(PathSeg::Line(Line::new((5., 5.), (0., 0.)))),
+            Some(PathSeg::Line(Line::new((5., 5.), (2., 3.)))),
         );
 
         // Consecutive `ClosePath`s produce no segment.
         let path = BezPath::from_vec(vec![
-            PathEl::MoveTo((0., 0.).into()),
+            PathEl::MoveTo((2., 3.).into()),
             PathEl::LineTo((10., 0.).into()),
             PathEl::ClosePath,
             PathEl::ClosePath,
@@ -1755,18 +1811,75 @@ mod tests {
 
     #[test]
     fn test_subpaths() {
-        let path = BezPath::from_svg("M10,10 L0,10 L0,0 L10,0 Z M100,100 M30,0 Q35,10,40,0 L30,0")
-            .unwrap();
+        // The following path contains four subpaths:
+        // - the first starts with a `MoveTo` is explicitly closed,
+        // - the second starts implicitly and is explicitly closed,
+        // - the third starts with a `MoveTo` and is left open, and
+        // - the fourth starts with a `MoveTo` and is left open.
+        let path = BezPath::from_svg(
+            "M10,10 L0,10 L0,0 L10,0 Z L20,20 Z M100,100 M30,0 Q35,10,40,0 L30,0",
+        )
+        .unwrap();
+
+        let subpaths: Vec<_> = path.subpaths().collect();
+        assert_eq!(subpaths.len(), 4);
+
+        assert_eq!(subpaths[0].start(), Point::new(10., 10.));
         assert_eq!(
-            vec![
-                BezPath::from_svg("M10,10 L0,10 L0,0 L10,0 Z").unwrap(),
-                BezPath::from_svg("M100,100").unwrap(),
-                BezPath::from_svg("M30,0 Q35,10,40,0 L30,0").unwrap(),
-            ],
-            path.subpaths()
-                .map(|sp| BezPath::from_vec(sp.to_vec()))
-                .collect::<Vec<_>>()
+            subpaths[0].elements(),
+            BezPath::from_svg("M10,10 L0,10 L0,0 L10,0 Z")
+                .unwrap()
+                .elements(),
         );
+
+        // Implicit subpath: inherits the last point from subpath 0.
+        assert_eq!(subpaths[1].start(), Point::new(10., 10.));
+        assert_eq!(
+            subpaths[1].elements(),
+            &[PathEl::LineTo((20., 20.).into()), PathEl::ClosePath],
+        );
+
+        assert_eq!(subpaths[2].start(), Point::new(100., 100.));
+        assert_eq!(
+            subpaths[2].elements(),
+            BezPath::from_svg("M100,100").unwrap().elements(),
+        );
+
+        assert_eq!(subpaths[3].start(), Point::new(30., 0.));
+        assert_eq!(
+            subpaths[3].elements(),
+            BezPath::from_svg("M30,0 Q35,10,40,0 L30,0")
+                .unwrap()
+                .elements(),
+        );
+    }
+
+    // A curve starting an implicit subpath after `ClosePath` starts at the preceding subpath's end
+    // point (or, equivalently, at the preceding subpath's initial point); flattening must yield the
+    // same result as the equivalent path with an explicit `MoveTo` to that point.
+    #[test]
+    fn test_flatten_implicit_subpaths() {
+        let implicit = BezPath::from_vec(vec![
+            PathEl::MoveTo((2., 3.).into()),
+            PathEl::LineTo((10., 0.).into()),
+            PathEl::ClosePath,
+            PathEl::QuadTo((15., 10.).into(), (20., 0.).into()),
+        ]);
+        let explicit = BezPath::from_vec(vec![
+            PathEl::MoveTo((2., 3.).into()),
+            PathEl::LineTo((10., 0.).into()),
+            PathEl::ClosePath,
+            PathEl::MoveTo((2., 3.).into()),
+            PathEl::QuadTo((15., 10.).into(), (20., 0.).into()),
+        ]);
+        let mut implicit_out = Vec::new();
+        flatten(implicit, 0.1, |el| implicit_out.push(el));
+        let mut explicit_out = Vec::new();
+        flatten(explicit, 0.1, |el| explicit_out.push(el));
+        // The explicit version has an extra `MoveTo(2, 3)` after `ClosePath`; remove it so we can
+        // compare the two sequences directly.
+        explicit_out.remove(3);
+        assert_eq!(implicit_out, explicit_out);
     }
 
     #[test]

--- a/kurbo/src/lib.rs
+++ b/kurbo/src/lib.rs
@@ -155,7 +155,7 @@ pub use crate::arc::{Arc, ArcAppendIter};
 pub use crate::axis::Axis;
 pub use crate::bezpath::{
     flatten, segments, BezPath, LineIntersection, MinDistance, PathEl, PathSeg, PathSegIter,
-    Segments,
+    Segments, Subpath,
 };
 pub use crate::circle::{Circle, CirclePathIter, CircleSegment};
 pub use crate::cubicbez::{cubics_to_quadratic_splines, CubicBez, CubicBezIter, CuspType};

--- a/kurbo/src/simplify.rs
+++ b/kurbo/src/simplify.rs
@@ -301,6 +301,7 @@ pub fn simplify_bezpath(
     options: &SimplifyOptions,
 ) -> BezPath {
     let mut last_pt = None;
+    let mut subpath_start = None;
     let mut last_seg: Option<PathSeg> = None;
     let mut state = SimplifyState::default();
     for el in path {
@@ -310,6 +311,7 @@ pub fn simplify_bezpath(
                 state.flush(accuracy, options);
                 state.needs_moveto = true;
                 last_pt = Some(p);
+                subpath_start = Some(p);
             }
             PathEl::LineTo(p) => {
                 let last = last_pt.unwrap();
@@ -337,6 +339,9 @@ pub fn simplify_bezpath(
                 state.result.close_path();
                 state.needs_moveto = true;
                 last_seg = None;
+                // A drawing element following this `ClosePath` starts an implicit
+                // subpath at the current subpath's initial point.
+                last_pt = subpath_start;
                 continue;
             }
         }
@@ -392,5 +397,32 @@ mod tests {
         let options = SimplifyOptions::default();
         let simplified = simplify_bezpath(path.clone(), 1.0, &options);
         assert_eq!(path, simplified);
+    }
+
+    // An implicit subpath after `ClosePath` starts the preceding subpath's end point (or,
+    // equivalently, at the preceding subpath's initial point); simplifying must yield the same
+    // result as the equivalent path with an explicit `MoveTo` to that point.
+    #[test]
+    fn simplify_implicit_subpaths() {
+        use crate::PathEl;
+
+        let implicit = BezPath::from_vec(vec![
+            PathEl::MoveTo((2., 3.).into()),
+            PathEl::LineTo((10., 0.).into()),
+            PathEl::ClosePath,
+            PathEl::LineTo((5., 5.).into()),
+        ]);
+        let explicit = BezPath::from_vec(vec![
+            PathEl::MoveTo((2., 3.).into()),
+            PathEl::LineTo((10., 0.).into()),
+            PathEl::ClosePath,
+            PathEl::MoveTo((2., 3.).into()),
+            PathEl::LineTo((5., 5.).into()),
+        ]);
+        let options = SimplifyOptions::default();
+        assert_eq!(
+            simplify_bezpath(implicit, 1.0, &options),
+            simplify_bezpath(explicit, 1.0, &options),
+        );
     }
 }

--- a/kurbo/src/svg.rs
+++ b/kurbo/src/svg.rs
@@ -106,20 +106,12 @@ impl BezPath {
         let mut last_cmd = 0;
         let mut last_ctrl = None;
         let mut first_pt = Point::ORIGIN;
-        let mut implicit_moveto = None;
         while let Some(c) = lexer.get_cmd(last_cmd) {
-            if c != b'm' && c != b'M' {
-                if path.elements().is_empty() {
-                    return Err(SvgParseError::UninitializedPath);
-                }
-
-                if let Some(pt) = implicit_moveto.take() {
-                    path.move_to(pt);
-                }
+            if c != b'm' && c != b'M' && path.elements().is_empty() {
+                return Err(SvgParseError::UninitializedPath);
             }
             match c {
                 b'm' | b'M' => {
-                    implicit_moveto = None;
                     let pt = lexer.get_maybe_relative(c)?;
                     path.move_to(pt);
                     lexer.last_pt = pt;
@@ -235,7 +227,6 @@ impl BezPath {
                 b'z' | b'Z' => {
                     path.close_path();
                     lexer.last_pt = first_pt;
-                    implicit_moveto = Some(first_pt);
                 }
                 _ => return Err(SvgParseError::UnknownCommand(c as char)),
             }


### PR DESCRIPTION
Match SVG semantics:

> A path data segment (if there is one) must begin with a "moveto" command.

And:

> If a "closepath" is followed immediately by a "moveto", then the "moveto" identifies the start point of the next subpath. If a "closepath" is followed immediately by any other command, then the next subpath starts at the same initial point as the current subpath.