### PR TITLE
Add nuclear/Frobenius/spectral norms to `Affine`, add interpretation for `determinant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This release has an [MSRV][] of 1.85.
 - Ability to add and subtract `Insets` from other `Insets`. ([#549][] by [@xStrom][])
 - `Arc` now implements `ParamCurve`. ([#378][] by [@waywardmonkeys][])
 - Add `Affine::{pre,then}_skew` and `Affine::{pre,then}_reflect` fluent composition helpers. ([#563][] by [@waywardmonkeys][])
+- Add three transform matrix norms: `Affine::{nuclear_norm_squared,frobenius_norm_squared,spectral_norm}`. ([#569][] by [@tomcur][])
 
 ## Changed
 
@@ -296,6 +297,7 @@ Note: A changelog was not kept for or before this release
 [#561]: https://github.com/linebender/kurbo/pull/561
 [#563]: https://github.com/linebender/kurbo/pull/563
 [#567]: https://github.com/linebender/kurbo/pull/567
+[#569]: https://github.com/linebender/kurbo/pull/569
 
 [Unreleased]: https://github.com/linebender/kurbo/compare/v0.13.0...HEAD
 [0.13.0]: https://github.com/linebender/kurbo/releases/tag/v0.13.0

--- a/kurbo/src/affine.rs
+++ b/kurbo/src/affine.rs
@@ -308,8 +308,72 @@ impl Affine {
     }
 
     /// Compute the determinant of this transform.
+    ///
+    /// # Geometric interpretation
+    ///
+    /// Consider a region transformed by this affine. The transformed region's area is the area of
+    /// the original region scaled by the absolute value of the determinant. A negative determinant
+    /// indicates orientation reversal.
+    #[inline]
     pub const fn determinant(self) -> f64 {
         self.0[0] * self.0[3] - self.0[1] * self.0[2]
+    }
+
+    /// Compute the square of the nuclear norm of this transform.
+    ///
+    /// This is the square of the [Schatten p-norm][schatten] with `p=1`, also known as the "trace norm."
+    ///
+    /// Returns the squared norm for efficiency; take the square root as necessary.
+    ///
+    /// # Geometric interpretation
+    ///
+    /// Consider a unit circle transformed by this affine. The nuclear norm is the sum of the
+    /// resulting ellipse's radii (semi axes). That sum multiplied by π is a first-order
+    /// approximation of the ellipse's perimeter.
+    ///
+    /// [schatten]: <https://en.wikipedia.org/w/index.php?title=Matrix_norm&oldid=1348997593#Schatten_norms>
+    #[inline]
+    pub const fn nuclear_norm_squared(self) -> f64 {
+        self.frobenius_norm_squared() + 2. * self.determinant().abs()
+    }
+
+    /// Compute the square of the Frobenius norm of this transform.
+    ///
+    /// This is the square of the [Schatten p-norm][schatten] with `p=2`.
+    ///
+    /// Returns the squared norm for efficiency; take the square root as necessary.
+    ///
+    /// # Geometric interpretation
+    ///
+    /// Consider a unit circle transformed by this affine. The squared Frobenius norm is twice the
+    /// mean squared radius of the resulting ellipse. Alternatively, it is equal to the squared
+    /// distance from the ellipse's center to a corner of the rectangle spanned by the ellipse's
+    /// axes.
+    ///
+    /// [schatten]: <https://en.wikipedia.org/w/index.php?title=Matrix_norm&oldid=1348997593#Schatten_norms>
+    #[inline]
+    pub const fn frobenius_norm_squared(self) -> f64 {
+        let [a, b, c, d, _, _] = self.as_coeffs();
+        a * a + b * b + c * c + d * d
+    }
+
+    /// Compute the spectral norm of this transform.
+    ///
+    /// This is the [Schatten p-norm][schatten] with `p=∞`.
+    ///
+    /// # Geometric interpretation
+    ///
+    /// Consider a unit circle transformed by this affine. The spectral norm is the major radius
+    /// (semi-major axis) of the Ellipse.
+    ///
+    /// [schatten]: <https://en.wikipedia.org/w/index.php?title=Matrix_norm&oldid=1348997593#Schatten_norms>
+    #[inline]
+    pub fn spectral_norm(self) -> f64 {
+        // Note a different calculation, returning the `_squared` form like our nuclear and
+        // Frobenius norms, could be `0.5 (frob^2 + sqrt(frob^4 - 4 det^2))`. In terms of operations
+        // it's a wash: one fewer sqrt if the user actually wants the squared form, but it uses more
+        // muls. More importantly, that form has worse numeric conditioning.
+        self.svd().0.x
     }
 
     /// Compute the inverse transform.

--- a/kurbo/src/affine.rs
+++ b/kurbo/src/affine.rs
@@ -352,8 +352,72 @@ impl Affine {
     }
 
     /// Compute the determinant of this transform.
+    ///
+    /// # Geometric interpretation
+    ///
+    /// Consider a region transformed by this affine. The transformed region's area is the area of
+    /// the original region scaled by the absolute value of the determinant. A negative determinant
+    /// indicates orientation reversal.
+    #[inline]
     pub const fn determinant(self) -> f64 {
         self.0[0] * self.0[3] - self.0[1] * self.0[2]
+    }
+
+    /// Compute the square of the nuclear norm of this transform.
+    ///
+    /// This is the square of the [Schatten p-norm][schatten] with `p=1`, also known as the "trace norm."
+    ///
+    /// Returns the squared norm for efficiency; take the square root as necessary.
+    ///
+    /// # Geometric interpretation
+    ///
+    /// Consider a unit circle transformed by this affine. The nuclear norm is the sum of the
+    /// resulting ellipse's radii (semi axes). That sum multiplied by π is a first-order
+    /// approximation of the ellipse's perimeter.
+    ///
+    /// [schatten]: <https://en.wikipedia.org/w/index.php?title=Matrix_norm&oldid=1348997593#Schatten_norms>
+    #[inline]
+    pub const fn nuclear_norm_squared(self) -> f64 {
+        self.frobenius_norm_squared() + 2. * self.determinant().abs()
+    }
+
+    /// Compute the square of the Frobenius norm of this transform.
+    ///
+    /// This is the square of the [Schatten p-norm][schatten] with `p=2`.
+    ///
+    /// Returns the squared norm for efficiency; take the square root as necessary.
+    ///
+    /// # Geometric interpretation
+    ///
+    /// Consider a unit circle transformed by this affine. The squared Frobenius norm is twice the
+    /// mean squared radius of the resulting ellipse. Alternatively, it is equal to the squared
+    /// distance from the ellipse's center to a corner of the rectangle spanned by the ellipse's
+    /// axes.
+    ///
+    /// [schatten]: <https://en.wikipedia.org/w/index.php?title=Matrix_norm&oldid=1348997593#Schatten_norms>
+    #[inline]
+    pub const fn frobenius_norm_squared(self) -> f64 {
+        let [a, b, c, d, _, _] = self.as_coeffs();
+        a * a + b * b + c * c + d * d
+    }
+
+    /// Compute the spectral norm of this transform.
+    ///
+    /// This is the [Schatten p-norm][schatten] with `p=∞`.
+    ///
+    /// # Geometric interpretation
+    ///
+    /// Consider a unit circle transformed by this affine. The spectral norm is the major radius
+    /// (semi-major axis) of the Ellipse.
+    ///
+    /// [schatten]: <https://en.wikipedia.org/w/index.php?title=Matrix_norm&oldid=1348997593#Schatten_norms>
+    #[inline]
+    pub fn spectral_norm(self) -> f64 {
+        // Note a different calculation, returning the `_squared` form like our nuclear and
+        // Frobenius norms, could be `0.5 (frob^2 + sqrt(frob^4 - 4 det^2))`. In terms of operations
+        // it's a wash: one fewer sqrt if the user actually wants the squared form, but it uses more
+        // muls. More importantly, that form has worse numeric conditioning.
+        self.svd().0.x
     }
 
     /// Compute the inverse transform.


### PR DESCRIPTION
These are coming up a few times in the sparse strips Vellos. E.g., https://github.com/linebender/vello/blob/8afc1c6b1be8b4dff6bc93f95a4113e2db69d7cd/sparse_strips/vello_common/src/filter/gaussian_blur.rs#L27-L28 is the nuclear norm. https://github.com/linebender/vello/pull/1180 introduces the spectral norm (through `Ellipse` in that PR).