### PR TITLE
Update Rust edition to 2024.

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,11 @@
+# LINEBENDER RUSTFMT CONFIG - v1
+# Ensure lines end with \n even if the git configuration core.autocrlf is not set to true
+newline_style = "Unix"
+
+# `Foobar { foo, bar }` is more readable than `Foo { foo: foo, bar: bar }`
+use_field_init_shorthand = true
+
+# Commented out because it is still unstable, but works fine in practice.
+# imports_granularity = "Module"
+
+# END LINEBENDER RUSTFMT CONFIG

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = ["kurbo", "polycool"]
 #       version in the `workspace.dependencies` section in this file.
 version = "0.13.0"
 
-edition = "2021"
+edition = "2024"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files
 # and with the MSRV in the `Unreleased` section of CHANGELOG.md.
 rust-version = "1.85"

--- a/kurbo/benches/cubic.rs
+++ b/kurbo/benches/cubic.rs
@@ -5,7 +5,7 @@
 
 #![allow(missing_docs, reason = "criterion emits undocumented functions")]
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
 use kurbo::common::solve_cubic;

--- a/kurbo/benches/cubic_arclen.rs
+++ b/kurbo/benches/cubic_arclen.rs
@@ -5,7 +5,7 @@
 
 #![allow(missing_docs, reason = "criterion emits undocumented functions")]
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
 use kurbo::{CubicBez, ParamCurveArclen};

--- a/kurbo/benches/nearest.rs
+++ b/kurbo/benches/nearest.rs
@@ -5,7 +5,7 @@
 
 #![allow(missing_docs, reason = "criterion emits undocumented functions")]
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
 use kurbo::{CubicBez, ParamCurveNearest as _, Point, QuadBez};

--- a/kurbo/benches/quad_arclen.rs
+++ b/kurbo/benches/quad_arclen.rs
@@ -7,7 +7,7 @@
 
 // TODO: organize so there's less cut'n'paste from arclen_accuracy example.
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
 use kurbo::{ParamCurve, ParamCurveArclen, ParamCurveDeriv, QuadBez};

--- a/kurbo/benches/quartic.rs
+++ b/kurbo/benches/quartic.rs
@@ -5,7 +5,7 @@
 
 #![allow(missing_docs, reason = "criterion emits undocumented functions")]
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
 use kurbo::common::solve_quartic;

--- a/kurbo/benches/rect_expand.rs
+++ b/kurbo/benches/rect_expand.rs
@@ -5,7 +5,7 @@
 
 #![allow(missing_docs, reason = "criterion emits undocumented functions")]
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
 use kurbo::Rect;

--- a/kurbo/examples/arclen_accuracy.rs
+++ b/kurbo/examples/arclen_accuracy.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 
 use kurbo::{ParamCurve, ParamCurveArclen, ParamCurveDeriv, QuadBez};
 
-use kurbo::common::{GAUSS_LEGENDRE_COEFFS_24, GAUSS_LEGENDRE_COEFFS_5, GAUSS_LEGENDRE_COEFFS_7};
+use kurbo::common::{GAUSS_LEGENDRE_COEFFS_5, GAUSS_LEGENDRE_COEFFS_7, GAUSS_LEGENDRE_COEFFS_24};
 
 /// Calculate arclength using Gauss-Legendre quadrature using formula from Behdad
 /// in <https://github.com/Pomax/BezierInfo-2/issues/77>

--- a/kurbo/examples/cubic_arclen.rs
+++ b/kurbo/examples/cubic_arclen.rs
@@ -5,7 +5,7 @@
 
 #![allow(unused, reason = "a bunch of experiments in the code")]
 
-use kurbo::common::{GAUSS_LEGENDRE_COEFFS_11, GAUSS_LEGENDRE_COEFFS_7, GAUSS_LEGENDRE_COEFFS_9};
+use kurbo::common::{GAUSS_LEGENDRE_COEFFS_7, GAUSS_LEGENDRE_COEFFS_9, GAUSS_LEGENDRE_COEFFS_11};
 use kurbo::{
     CubicBez, ParamCurve, ParamCurveArclen, ParamCurveCurvature, ParamCurveDeriv, Point, Vec2,
 };
@@ -144,11 +144,7 @@ fn est_gauss11_error_3(c: CubicBez) -> f64 {
     let pc_err = (lp - lc) * 0.02;
     let ks = est_max_curvature(c) * lp;
     let est = ks.powi(3) * lp * 8e-9;
-    if est < pc_err {
-        est
-    } else {
-        pc_err
-    }
+    if est < pc_err { est } else { pc_err }
 }
 
 fn est_gauss9_error_3(c: CubicBez) -> f64 {
@@ -157,11 +153,7 @@ fn est_gauss9_error_3(c: CubicBez) -> f64 {
     let pc_err = (lp - lc) * 0.02;
     let ks = est_max_curvature(c) * lp;
     let est = ks.powi(3) * lp * 5e-8;
-    if est < pc_err {
-        est
-    } else {
-        pc_err
-    }
+    if est < pc_err { est } else { pc_err }
 }
 
 // A new approach based on integrating local error; the cost of evaluating the

--- a/kurbo/examples/quad_intersect.rs
+++ b/kurbo/examples/quad_intersect.rs
@@ -5,7 +5,7 @@
 //! new quartic solver.
 
 use arrayvec::ArrayVec;
-use kurbo::{common::solve_quartic, ParamCurve, Point, QuadBez, Shape};
+use kurbo::{ParamCurve, Point, QuadBez, Shape, common::solve_quartic};
 use rand::Rng;
 
 fn rand_point() -> Point {

--- a/kurbo/examples/stroke.rs
+++ b/kurbo/examples/stroke.rs
@@ -6,7 +6,7 @@
 //! This example has been lightly adapted from Vello, which in turn has
 //! been adapted from the Skia "tricky stroke" test.
 
-use kurbo::{stroke, Affine, BezPath, Cap, Join, Rect, Shape, Stroke, StrokeOpts};
+use kurbo::{Affine, BezPath, Cap, Join, Rect, Shape, Stroke, StrokeOpts, stroke};
 
 fn tricky_strokes() {
     const CELL_SIZE: f64 = 200.;

--- a/kurbo/src/bezpath.rs
+++ b/kurbo/src/bezpath.rs
@@ -13,8 +13,8 @@ use alloc::vec::Vec;
 
 use arrayvec::ArrayVec;
 
-use crate::common::{solve_cubic, solve_quadratic};
 use crate::MAX_EXTREMA;
+use crate::common::{solve_cubic, solve_quadratic};
 use crate::{
     Affine, CubicBez, Line, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea,
     ParamCurveExtrema, ParamCurveNearest, Point, QuadBez, Rect, Shape, TranslateScale, Vec2,
@@ -1062,11 +1062,7 @@ impl PathSeg {
                 }
                 let t = quad.solve_monotonic_for_y(p.y);
                 let x = quad.eval(t).x;
-                if p.x >= x {
-                    sign
-                } else {
-                    0
-                }
+                if p.x >= x { sign } else { 0 }
             }
             PathSeg::Cubic(cubic) => {
                 let p1 = cubic.p1;
@@ -1079,11 +1075,7 @@ impl PathSeg {
                 }
                 let t = cubic.solve_monotonic_for_y(p.y);
                 let x = cubic.eval(t).x;
-                if p.x >= x {
-                    sign
-                } else {
-                    0
-                }
+                if p.x >= x { sign } else { 0 }
             }
         }
     }
@@ -1284,22 +1276,14 @@ impl PathSeg {
                     d01
                 } else {
                     let d02 = c.p2 - c.p0;
-                    if d02.hypot2() > EPS {
-                        d02
-                    } else {
-                        c.p3 - c.p0
-                    }
+                    if d02.hypot2() > EPS { d02 } else { c.p3 - c.p0 }
                 };
                 let d23 = c.p3 - c.p2;
                 let d1 = if d23.hypot2() > EPS {
                     d23
                 } else {
                     let d13 = c.p3 - c.p1;
-                    if d13.hypot2() > EPS {
-                        d13
-                    } else {
-                        c.p3 - c.p0
-                    }
+                    if d13.hypot2() > EPS { d13 } else { c.p3 - c.p0 }
                 };
                 (d0, d1)
             }
@@ -2119,18 +2103,22 @@ mod tests {
         let r = Rect::from_points((x0, y0), (x1, y1));
 
         let path0 = r.into_path(0.0);
-        assert!(path0
-            .elements()
-            .iter()
-            .skip(1)
-            .all(|el| !matches!(el, PathEl::MoveTo(_))));
+        assert!(
+            path0
+                .elements()
+                .iter()
+                .skip(1)
+                .all(|el| !matches!(el, PathEl::MoveTo(_)))
+        );
 
         let path1 = BezPath::from_path_segments(path0.segments());
-        assert!(path1
-            .elements()
-            .iter()
-            .skip(1)
-            .all(|el| !matches!(el, PathEl::MoveTo(_))));
+        assert!(
+            path1
+                .elements()
+                .iter()
+                .skip(1)
+                .all(|el| !matches!(el, PathEl::MoveTo(_)))
+        );
     }
 
     #[test]

--- a/kurbo/src/cubicbez.rs
+++ b/kurbo/src/cubicbez.rs
@@ -12,8 +12,8 @@ use crate::{Line, QuadSpline, Vec2};
 use arrayvec::ArrayVec;
 
 use crate::common::{
-    solve_cubic, solve_quadratic, solve_quartic, GAUSS_LEGENDRE_COEFFS_16_HALF,
-    GAUSS_LEGENDRE_COEFFS_24_HALF, GAUSS_LEGENDRE_COEFFS_8, GAUSS_LEGENDRE_COEFFS_8_HALF,
+    GAUSS_LEGENDRE_COEFFS_8, GAUSS_LEGENDRE_COEFFS_8_HALF, GAUSS_LEGENDRE_COEFFS_16_HALF,
+    GAUSS_LEGENDRE_COEFFS_24_HALF, solve_cubic, solve_quadratic, solve_quartic,
 };
 use crate::{
     Affine, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea, ParamCurveCurvature,
@@ -831,9 +831,9 @@ pub fn cubics_to_quadratic_splines(curves: &[CubicBez], accuracy: f64) -> Option
 #[cfg(test)]
 mod tests {
     use crate::{
-        cubics_to_quadratic_splines, Affine, CubicBez, Nearest, ParamCurve, ParamCurveArclen,
-        ParamCurveArea, ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest, Point, QuadBez,
-        QuadSpline,
+        Affine, CubicBez, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea, ParamCurveDeriv,
+        ParamCurveExtrema, ParamCurveNearest, Point, QuadBez, QuadSpline,
+        cubics_to_quadratic_splines,
     };
 
     #[test]

--- a/kurbo/src/fit.rs
+++ b/kurbo/src/fit.rs
@@ -11,11 +11,11 @@ use alloc::vec::Vec;
 use arrayvec::ArrayVec;
 
 use crate::{
-    common::{
-        factor_quartic_inner, solve_cubic, solve_itp_fallible, solve_quadratic,
-        GAUSS_LEGENDRE_COEFFS_16,
-    },
     Affine, BezPath, CubicBez, Line, ParamCurve, ParamCurveArclen, ParamCurveNearest, Point, Vec2,
+    common::{
+        GAUSS_LEGENDRE_COEFFS_16, factor_quartic_inner, solve_cubic, solve_itp_fallible,
+        solve_quadratic,
+    },
 };
 
 #[cfg(not(feature = "std"))]
@@ -527,11 +527,7 @@ fn cubic_fit(th0: f64, th1: f64, area: f64, mx: f64) -> ArrayVec<(CubicBez, f64,
         .filter_map(|&d0| {
             let (d0, d1) = if d0 > 0.0 {
                 let d1 = (d0 * s0 - area * (10. / 3.)) / (0.5 * d0 * s01 - s1);
-                if d1 > 0.0 {
-                    (d0, d1)
-                } else {
-                    (s1 / s01, 0.0)
-                }
+                if d1 > 0.0 { (d0, d1) } else { (s1 / s01, 0.0) }
             } else {
                 (0.0, s0 / s01)
             };

--- a/kurbo/src/lib.rs
+++ b/kurbo/src/lib.rs
@@ -154,21 +154,21 @@ pub use crate::affine::Affine;
 pub use crate::arc::{Arc, ArcAppendIter};
 pub use crate::axis::Axis;
 pub use crate::bezpath::{
-    flatten, segments, BezPath, LineIntersection, MinDistance, PathEl, PathSeg, PathSegIter,
-    Segments,
+    BezPath, LineIntersection, MinDistance, PathEl, PathSeg, PathSegIter, Segments, flatten,
+    segments,
 };
 pub use crate::circle::{Circle, CirclePathIter, CircleSegment};
-pub use crate::cubicbez::{cubics_to_quadratic_splines, CubicBez, CubicBezIter, CuspType};
+pub use crate::cubicbez::{CubicBez, CubicBezIter, CuspType, cubics_to_quadratic_splines};
 pub use crate::ellipse::Ellipse;
 pub use crate::fit::{
-    fit_to_bezpath, fit_to_bezpath_opt, fit_to_cubic, CurveFitSample, ParamCurveFit,
+    CurveFitSample, ParamCurveFit, fit_to_bezpath, fit_to_bezpath_opt, fit_to_cubic,
 };
 pub use crate::insets::Insets;
 pub use crate::line::{ConstPoint, Line, LinePathIter};
 pub use crate::moments::{Moments, ParamCurveMoments};
 pub use crate::param_curve::{
-    Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea, ParamCurveCurvature, ParamCurveDeriv,
-    ParamCurveExtrema, ParamCurveNearest, DEFAULT_ACCURACY, MAX_EXTREMA,
+    DEFAULT_ACCURACY, MAX_EXTREMA, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea,
+    ParamCurveCurvature, ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest,
 };
 pub use crate::point::Point;
 pub use crate::quadbez::{QuadBez, QuadBezIter};
@@ -179,7 +179,7 @@ pub use crate::rounded_rect_radii::RoundedRectRadii;
 pub use crate::shape::Shape;
 pub use crate::size::Size;
 pub use crate::stroke::{
-    dash, stroke, stroke_with, Cap, Dashes, Join, Stroke, StrokeCtx, StrokeOptLevel, StrokeOpts,
+    Cap, Dashes, Join, Stroke, StrokeCtx, StrokeOptLevel, StrokeOpts, dash, stroke, stroke_with,
 };
 pub use crate::svg::{SvgArc, SvgParseError};
 pub use crate::translate_scale::TranslateScale;

--- a/kurbo/src/line.rs
+++ b/kurbo/src/line.rs
@@ -8,9 +8,9 @@ use core::ops::{Add, Mul, Range, Sub};
 use arrayvec::ArrayVec;
 
 use crate::{
-    Affine, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea, ParamCurveCurvature,
-    ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest, PathEl, Point, Rect, Shape, Vec2,
-    DEFAULT_ACCURACY, MAX_EXTREMA,
+    Affine, DEFAULT_ACCURACY, MAX_EXTREMA, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea,
+    ParamCurveCurvature, ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest, PathEl, Point,
+    Rect, Shape, Vec2,
 };
 
 /// A single line.
@@ -380,29 +380,35 @@ mod tests {
 
     #[test]
     fn line_is_finite() {
-        assert!((Line {
-            p0: Point { x: 0., y: 0. },
-            p1: Point { x: 1., y: 1. }
-        })
-        .is_finite());
+        assert!(
+            (Line {
+                p0: Point { x: 0., y: 0. },
+                p1: Point { x: 1., y: 1. }
+            })
+            .is_finite()
+        );
 
-        assert!(!(Line {
-            p0: Point { x: 0., y: 0. },
-            p1: Point {
-                x: f64::INFINITY,
-                y: 1.
-            }
-        })
-        .is_finite());
+        assert!(
+            !(Line {
+                p0: Point { x: 0., y: 0. },
+                p1: Point {
+                    x: f64::INFINITY,
+                    y: 1.
+                }
+            })
+            .is_finite()
+        );
 
-        assert!(!(Line {
-            p0: Point { x: 0., y: 0. },
-            p1: Point {
-                x: 0.,
-                y: f64::INFINITY
-            }
-        })
-        .is_finite());
+        assert!(
+            !(Line {
+                p0: Point { x: 0., y: 0. },
+                p1: Point {
+                    x: 0.,
+                    y: f64::INFINITY
+                }
+            })
+            .is_finite()
+        );
     }
 
     #[test]

--- a/kurbo/src/mindist.rs
+++ b/kurbo/src/mindist.rs
@@ -259,7 +259,7 @@ fn choose(n: u8, k: u8) -> u32 {
 #[cfg(test)]
 mod tests {
     use crate::mindist::A_r;
-    use crate::mindist::{choose, D_rk};
+    use crate::mindist::{D_rk, choose};
     use crate::param_curve::ParamCurve;
     use crate::{CubicBez, Line, PathSeg, Vec2};
 

--- a/kurbo/src/offset.rs
+++ b/kurbo/src/offset.rs
@@ -12,8 +12,8 @@ use arrayvec::ArrayVec;
 use crate::common::FloatFuncs;
 
 use crate::{
-    common::{solve_itp, solve_quadratic},
     BezPath, CubicBez, ParamCurve, ParamCurveDeriv, PathSeg, Point, QuadBez, Vec2,
+    common::{solve_itp, solve_quadratic},
 };
 
 /// State used for computing an offset curve of a single cubic.

--- a/kurbo/src/param_curve.rs
+++ b/kurbo/src/param_curve.rs
@@ -7,7 +7,7 @@ use core::ops::Range;
 
 use arrayvec::ArrayVec;
 
-use crate::{common, Point, Rect};
+use crate::{Point, Rect, common};
 
 #[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;

--- a/kurbo/src/quadbez.rs
+++ b/kurbo/src/quadbez.rs
@@ -7,8 +7,8 @@ use core::ops::{Mul, Range};
 
 use arrayvec::ArrayVec;
 
-use crate::common::{solve_cubic, solve_quadratic};
 use crate::MAX_EXTREMA;
+use crate::common::{solve_cubic, solve_quadratic};
 use crate::{
     Affine, CubicBez, Line, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea,
     ParamCurveCurvature, ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest, PathEl, Point,

--- a/kurbo/src/quadspline.rs
+++ b/kurbo/src/quadspline.rs
@@ -72,10 +72,12 @@ mod tests {
 
     #[test]
     fn one_point_no_quads() {
-        assert!(QuadSpline::new(vec![Point::new(1.0, 1.0)])
-            .to_quads()
-            .next()
-            .is_none());
+        assert!(
+            QuadSpline::new(vec![Point::new(1.0, 1.0)])
+                .to_quads()
+                .next()
+                .is_none()
+        );
     }
 
     #[test]

--- a/kurbo/src/rounded_rect.rs
+++ b/kurbo/src/rounded_rect.rs
@@ -6,7 +6,7 @@
 use core::f64::consts::{FRAC_PI_2, FRAC_PI_4};
 use core::ops::{Add, Sub};
 
-use crate::{arc::ArcAppendIter, Arc, PathEl, Point, Rect, RoundedRectRadii, Shape, Size, Vec2};
+use crate::{Arc, PathEl, Point, Rect, RoundedRectRadii, Shape, Size, Vec2, arc::ArcAppendIter};
 
 #[allow(unused_imports)] // This is unused in later versions of Rust because of additions to core::f32
 #[cfg(not(feature = "std"))]
@@ -347,11 +347,7 @@ impl Shape for RoundedRect {
         //    (px, py) is inside a circle centered around the origin with the
         //    given radius.
         let inside = px * px + py * py <= radius * radius;
-        if inside {
-            1
-        } else {
-            0
-        }
+        if inside { 1 } else { 0 }
     }
 
     #[inline]

--- a/kurbo/src/shape.rs
+++ b/kurbo/src/shape.rs
@@ -3,7 +3,7 @@
 
 //! A generic trait for shapes.
 
-use crate::{segments, BezPath, Circle, Line, PathEl, Point, Rect, RoundedRect, Segments};
+use crate::{BezPath, Circle, Line, PathEl, Point, Rect, RoundedRect, Segments, segments};
 
 /// A generic trait for open and closed shapes.
 ///

--- a/kurbo/src/simplify.rs
+++ b/kurbo/src/simplify.rs
@@ -38,8 +38,8 @@ use core::ops::Range;
 use crate::common::FloatFuncs;
 
 use crate::{
-    fit_to_bezpath, fit_to_bezpath_opt, BezPath, CubicBez, CurveFitSample, Line, ParamCurve,
-    ParamCurveDeriv, ParamCurveFit, PathEl, PathSeg, Point, QuadBez, Vec2,
+    BezPath, CubicBez, CurveFitSample, Line, ParamCurve, ParamCurveDeriv, ParamCurveFit, PathEl,
+    PathSeg, Point, QuadBez, Vec2, fit_to_bezpath, fit_to_bezpath_opt,
 };
 
 /// A Bézier path which has been prepared for simplification.
@@ -380,7 +380,7 @@ impl SimplifyOptions {
 mod tests {
     use crate::BezPath;
 
-    use super::{simplify_bezpath, SimplifyOptions};
+    use super::{SimplifyOptions, simplify_bezpath};
 
     #[test]
     fn simplify_lines_corner() {

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -11,8 +11,8 @@ use smallvec::SmallVec;
 use crate::common::FloatFuncs;
 
 use crate::{
-    common::solve_quadratic, Affine, Arc, BezPath, CubicBez, Line, ParamCurve, ParamCurveArclen,
-    PathEl, PathSeg, Point, QuadBez, Vec2,
+    Affine, Arc, BezPath, CubicBez, Line, ParamCurve, ParamCurveArclen, PathEl, PathSeg, Point,
+    QuadBez, Vec2, common::solve_quadratic,
 };
 
 /// Defines the connection between two segments of a stroke.
@@ -853,8 +853,8 @@ impl<'a, T: Iterator<Item = PathEl>> DashIterator<'a, T> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        dash, segments, stroke, BezPath, Cap::Butt, CubicBez, Join::Miter, Line, PathEl, PathSeg,
-        Shape, Stroke, StrokeOpts,
+        BezPath, Cap::Butt, CubicBez, Join::Miter, Line, PathEl, PathSeg, Shape, Stroke,
+        StrokeOpts, dash, segments, stroke,
     };
 
     // A degenerate stroke with a cusp at the endpoint.

--- a/kurbo/src/triangle.rs
+++ b/kurbo/src/triangle.rs
@@ -220,11 +220,7 @@ impl Shape for Triangle {
         let s1 = (self.c - self.b).cross(pt - self.b).signum();
         let s2 = (self.a - self.c).cross(pt - self.c).signum();
 
-        if s0 == s1 && s1 == s2 {
-            s0 as i32
-        } else {
-            0
-        }
+        if s0 == s1 && s1 == s2 { s0 as i32 } else { 0 }
     }
 
     #[inline]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,0 @@
-max_width = 100
-use_field_init_shorthand = true
-newline_style = "Unix"


### PR DESCRIPTION
* Renamed `rustfmt.toml` to `.rustfmt.toml` and added the standard Linebender comments to it.
  The effective settings remain the same.
* All source files contain only formatting changes due to new 2024 rules.