### PR TITLE
Unify workspace dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,31 +122,6 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot 0.5.0",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
@@ -155,8 +130,8 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot 0.6.0",
- "itertools 0.13.0",
+ "criterion-plot",
+ "itertools",
  "num-traits",
  "oorandom",
  "plotters",
@@ -165,16 +140,6 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
 ]
 
 [[package]]
@@ -184,7 +149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
- "itertools 0.13.0",
+ "itertools",
 ]
 
 [[package]]
@@ -264,32 +229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,7 +260,7 @@ name = "kurbo"
 version = "0.13.0"
 dependencies = [
  "arrayvec",
- "criterion 0.5.1",
+ "criterion",
  "euclid",
  "getrandom",
  "libm",
@@ -420,7 +359,7 @@ dependencies = [
  "arbitrary",
  "arbtest",
  "arrayvec",
- "criterion 0.7.0",
+ "criterion",
  "libm",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,18 @@ repository = "https://github.com/linebender/kurbo"
 kurbo = { version = "0.13.0", path = "kurbo", default-features = false }
 polycool = { version = "0.4.0", path = "polycool", default-features = false }
 
+arbitrary = "1.4.2"
+arbtest = "0.3.2"
+arrayvec = { version = "0.7.6", default-features = false }
+criterion = { version = "0.7.0", default-features = false }
+euclid = { version = "0.22", default-features = false }
+libm = "0.2.16"
+mint = "0.5.9"
+rand = "0.9.4"
+schemars = "0.8.22"
+serde = { version = "1.0.228", default-features = false }
+smallvec = "1.15.1"
+
 [workspace.lints]
 rust.unsafe_code = "forbid"
 

--- a/kurbo/Cargo.toml
+++ b/kurbo/Cargo.toml
@@ -15,9 +15,6 @@ all-features = true
 default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
-[lints]
-workspace = true
-
 [features]
 default = ["std"]
 # Get floating point functions from the standard library (likely using your target's libc)
@@ -35,46 +32,29 @@ serde = ["smallvec/serde", "dep:serde"]
 schemars = ["schemars/smallvec", "dep:schemars"]
 
 [dependencies]
-smallvec = { version = "1.15.1", features = ["const_new"] }
-euclid = { version = "0.22", optional = true, default-features = false }
-polycool.workspace = true
-
-[dependencies.arrayvec]
-version = "0.7.6"
-default-features = false
-
-[dependencies.libm]
-version = "0.2.16"
-optional = true
-
-[dependencies.mint]
-version = "0.5.9"
-optional = true
-
-[dependencies.schemars]
-version = "0.8.22"
-optional = true
-
-[dependencies.serde]
-version = "1.0.228"
-optional = true
-default-features = false
-features = ["alloc", "derive"]
+arrayvec = { workspace = true }
+euclid = { workspace = true, optional = true }
+libm = { workspace = true, optional = true }
+mint = { workspace = true, optional = true }
+polycool = { workspace = true }
+schemars = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, features = ["alloc", "derive"] }
+smallvec = { workspace = true, features = ["const_new"] }
 
 [dev-dependencies]
 # This is used for research but not really needed; maybe refactor.
-rand = "0.9.4"
+rand = { workspace = true }
 # wasm doesn't support rayon, so disable criterion's rayon support. (In
 # principle we could make it target-dependent.)
-criterion = { version = "0.5.1", default-features = false, features = [
-    "plotters",
-    "cargo_bench_support",
-] }
+criterion = { workspace = true, features = ["plotters", "cargo_bench_support"] }
 
 [target.wasm32-unknown-unknown.dev-dependencies]
 # We have a transitive dependency on getrandom and it does not automatically
 # support wasm32-unknown-unknown. We need to enable the wasm_js feature.
 getrandom = { version = "0.3.4", features = ["wasm_js"] }
+
+[lints]
+workspace = true
 
 [[bench]]
 name = "cubic"

--- a/polycool/Cargo.toml
+++ b/polycool/Cargo.toml
@@ -1,12 +1,19 @@
 [package]
 name = "polycool"
 version = "0.4.0"
-edition = "2024"
+license.workspace = true
+edition.workspace = true
 description = "Polynomial root-finding"
 keywords = ["polynomial", "roots", "numerical"]
 categories = ["mathematics"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/linebender/kurbo"
+repository.workspace = true
+rust-version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+# There are no platform specific docs.
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
 
 [features]
 default = ["std"]
@@ -16,20 +23,17 @@ arbitrary = ["dep:arbitrary"]
 libm = ["dep:libm"]
 
 [dependencies]
-arbitrary = { version = "1.4.2", optional = true }
-arrayvec = { version = "0.7.6", default-features = false }
-libm = { version = "0.2.16", optional = true }
+arbitrary = { workspace = true, optional = true }
+arrayvec = { workspace = true }
+libm = { workspace = true, optional = true }
 
 [dev-dependencies]
-arbitrary = "1.4.2"
-arbtest = "0.3.2"
+arbitrary = { workspace = true }
+arbtest = { workspace = true }
 
 # wasm doesn't support rayon, so disable criterion's rayon support. (In
 # principle we could make it target-dependent.)
-criterion = { version = "0.7.0", default-features = false, features = [
-    "plotters",
-    "cargo_bench_support",
-] }
+criterion = { workspace = true, features = ["plotters", "cargo_bench_support"] }
 
 [[bench]]
 name = "cubic_roots"


### PR DESCRIPTION
Now that this workspace has two packages it's worth keeping track of dependency versions at the workspace level, which matches how other Linebender repos do it.

This revealed that we were pulling in two different versions of `criterion`. Looks like `kurbo` can bench fine with the unified newer version too.