### PR TITLE
Enable lints for `polycool`.

### DIFF
--- a/polycool/Cargo.toml
+++ b/polycool/Cargo.toml
@@ -35,6 +35,9 @@ arbtest = { workspace = true }
 # principle we could make it target-dependent.)
 criterion = { workspace = true, features = ["plotters", "cargo_bench_support"] }
 
+[lints]
+workspace = true
+
 [[bench]]
 name = "cubic_roots"
 harness = false

--- a/polycool/benches/cubic_roots.rs
+++ b/polycool/benches/cubic_roots.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 the Kurbo Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![allow(missing_docs, reason = "criterion emits undocumented functions")]
+
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 

--- a/polycool/benches/eval.rs
+++ b/polycool/benches/eval.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 the Kurbo Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![allow(missing_docs, reason = "criterion emits undocumented functions")]
+
 use criterion::{Criterion, criterion_group, criterion_main};
 use polycool::Poly;
 use std::hint::black_box;
@@ -14,15 +16,15 @@ pub fn eval(c: &mut Criterion) {
 
     group.bench_with_input("eval 2", &2, |b, _| {
         let p2 = Poly::new(coeffs_2);
-        b.iter(|| black_box(p2).eval(black_box(1.0)))
+        b.iter(|| black_box(p2).eval(black_box(1.0)));
     });
     group.bench_with_input("eval 3", &2, |b, _| {
         let p3 = Poly::new(coeffs_3);
-        b.iter(|| black_box(p3).eval(black_box(1.0)))
+        b.iter(|| black_box(p3).eval(black_box(1.0)));
     });
     group.bench_with_input("eval 3 alt", &2, |b, _| {
         let p3 = Poly::new(coeffs_3);
-        b.iter(|| black_box(p3).eval_opt(black_box(1.0)))
+        b.iter(|| black_box(p3).eval_opt(black_box(1.0)));
     });
     group.bench_with_input("eval 2 and 3", &2, |b, _| {
         let p3 = Poly::new(coeffs_3);
@@ -32,16 +34,16 @@ pub fn eval(c: &mut Criterion) {
                 black_box(p3).eval_opt(black_box(1.0)),
                 p2.eval(black_box(1.0)),
             )
-        })
+        });
     });
     group.bench_with_input("eval 2 and 3 alt", &2, |b, _| {
         let p3 = Poly::new(coeffs_3);
         let p2 = Poly::new(coeffs_2);
-        b.iter(|| black_box(p3).eval_with_deriv_opt(&p2, black_box(1.0)))
+        b.iter(|| black_box(p3).eval_with_deriv_opt(&p2, black_box(1.0)));
     });
     group.bench_with_input("eval 4", &2, |b, _| {
         let p4 = Poly::new(coeffs_4);
-        b.iter(|| black_box(p4).eval(black_box(1.0)))
+        b.iter(|| black_box(p4).eval(black_box(1.0)));
     });
 }
 

--- a/polycool/benches/quadratic_roots.rs
+++ b/polycool/benches/quadratic_roots.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 the Kurbo Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![allow(missing_docs, reason = "criterion emits undocumented functions")]
+
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
@@ -9,7 +11,7 @@ pub fn quadratic_roots(c: &mut Criterion) {
 
     c.bench_function("full", |b| b.iter(|| black_box(poly).roots()));
     c.bench_function("positive discriminant", |b| {
-        b.iter(|| black_box(poly).positive_discriminant_roots())
+        b.iter(|| black_box(poly).positive_discriminant_roots());
     });
 }
 

--- a/polycool/src/arbitrary.rs
+++ b/polycool/src/arbitrary.rs
@@ -17,6 +17,7 @@ fn check_finite(f: f64) -> Result<f64, arbitrary::Error> {
     }
 }
 
+/// Generates a float
 pub fn finite_float(u: &mut Unstructured<'_>) -> Result<f64, arbitrary::Error> {
     check_finite(u.arbitrary()?)
 }
@@ -26,7 +27,7 @@ fn another_finite_float(orig: f64, u: &mut Unstructured<'_>) -> Result<f64, arbi
     let close: bool = u.arbitrary()?;
     if close {
         let ulps: i32 = u.int_in_range(-32..=32)?;
-        let scale = 1.0f64 + ulps as f64 * f64::EPSILON;
+        let scale = 1.0_f64 + ulps as f64 * f64::EPSILON;
         check_finite(orig * scale)
     } else {
         finite_float(u)
@@ -36,9 +37,9 @@ fn another_finite_float(orig: f64, u: &mut Unstructured<'_>) -> Result<f64, arbi
 /// An arbitrary float in (-1.0, 1.0).
 pub fn float_in_unit_interval(u: &mut Unstructured<'_>) -> Result<f64, arbitrary::Error> {
     let mantissa: u64 = u.arbitrary()?;
-    let mantissa = mantissa & ((1u64 << 52) - 1);
+    let mantissa = mantissa & ((1_u64 << 52) - 1);
     let negative: bool = u.arbitrary()?;
-    let sign: u64 = if negative { 1u64 << 63 } else { 0 };
+    let sign: u64 = if negative { 1_u64 << 63 } else { 0 };
 
     // 1023 is an exponent of zero, which would lead to numbers of the form 1.something.
     // `% 1023` means we get a maximum exponent of 1022, so our biggest number is 0.11111...
@@ -49,7 +50,7 @@ pub fn float_in_unit_interval(u: &mut Unstructured<'_>) -> Result<f64, arbitrary
     let exponent: u64 = if large {
         1022 << 52
     } else {
-        (u.arbitrary::<u64>()? % 1023u64) << 52
+        (u.arbitrary::<u64>()? % 1023_u64) << 52
     };
 
     Ok(f64::from_bits(sign | exponent | mantissa))
@@ -67,7 +68,7 @@ pub fn cubic(u: &mut Unstructured<'_>) -> Result<Cubic, arbitrary::Error> {
 
 /// Generate an arbitrary polynomial (with finite coefficients).
 pub fn poly<const N: usize>(u: &mut Unstructured<'_>) -> Result<Poly<N>, arbitrary::Error> {
-    assert!(N >= 2);
+    assert!(N >= 2, "N is below 2");
 
     let use_coeffs: bool = u.arbitrary()?;
     if use_coeffs {
@@ -107,7 +108,7 @@ pub fn poly_with_planted_root<const N: usize>(
     root: f64,
     buffer: f64,
 ) -> Result<Poly<N>, arbitrary::Error> {
-    assert!(N >= 2);
+    assert!(N >= 2, "N is below 2");
 
     // Generate the roots, with a bias towards roots being almost-repeated.
     let mut coeffs = [0.0; N];

--- a/polycool/src/cubic.rs
+++ b/polycool/src/cubic.rs
@@ -91,7 +91,7 @@ impl Cubic {
 
     #[cold]
     fn rescaled_critical_points(&self) -> Option<(f64, f64)> {
-        let scale = 2.0f64.powi(-515);
+        let scale = 2.0_f64.powi(-515);
         (*self * scale).critical_points()
     }
 

--- a/polycool/src/lib.rs
+++ b/polycool/src/lib.rs
@@ -7,6 +7,16 @@
 //! for finding roots in a bounded interval. We aspire to have
 //! more, with thorough tests and benchmarks.
 
+// LINEBENDER LINT SET - lib.rs - v4
+// See https://linebender.org/wiki/canonical-lints/
+// These lints shouldn't apply to examples or tests.
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+// These lints shouldn't apply to examples.
+#![warn(clippy::print_stdout, clippy::print_stderr)]
+// Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
+#![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
+// END LINEBENDER LINT SET
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 mod cubic;
 #[cfg(feature = "libm")]

--- a/polycool/src/poly.rs
+++ b/polycool/src/poly.rs
@@ -45,8 +45,8 @@ impl<const N: usize> Poly<N> {
     /// The constant coefficient comes first, then the linear coefficient, and
     /// so on. So if you pass `[c, b, a]` you'll get the polynomial
     /// `a x^2 + b x + c`.
-    pub const fn new(coeffs: [f64; N]) -> Poly<N> {
-        Poly { coeffs }
+    pub const fn new(coeffs: [f64; N]) -> Self {
+        Self { coeffs }
     }
 
     /// The coefficients of this polynomial.
@@ -71,7 +71,7 @@ impl<const N: usize> Poly<N> {
     ///
     /// Always returns a non-negative number, or NaN if some coefficient is NaN.
     pub fn max_abs_coefficient(&self) -> f64 {
-        let mut max = 0.0f64;
+        let mut max = 0.0_f64;
         for c in &self.coeffs {
             max = max.max(c.abs());
         }
@@ -204,9 +204,9 @@ impl_roots_between_recursive!(9, 8);
 impl_roots_between_recursive!(10, 9);
 
 impl<const N: usize> core::ops::Mul<f64> for Poly<N> {
-    type Output = Poly<N>;
+    type Output = Self;
 
-    fn mul(mut self, scale: f64) -> Poly<N> {
+    fn mul(mut self, scale: f64) -> Self {
         self *= scale;
         self
     }
@@ -229,9 +229,9 @@ impl<const N: usize> core::ops::Mul<f64> for &Poly<N> {
 }
 
 impl<const N: usize> core::ops::Div<f64> for Poly<N> {
-    type Output = Poly<N>;
+    type Output = Self;
 
-    fn div(mut self, scale: f64) -> Poly<N> {
+    fn div(mut self, scale: f64) -> Self {
         self /= scale;
         self
     }
@@ -253,33 +253,33 @@ impl<const N: usize> core::ops::Div<f64> for &Poly<N> {
     }
 }
 
-impl<const N: usize> core::ops::AddAssign<&Poly<N>> for Poly<N> {
-    fn add_assign(&mut self, rhs: &Poly<N>) {
+impl<const N: usize> core::ops::AddAssign<&Self> for Poly<N> {
+    fn add_assign(&mut self, rhs: &Self) {
         for (c, d) in self.coeffs.iter_mut().zip(rhs.coeffs) {
             *c += d;
         }
     }
 }
 
-impl<const N: usize> core::ops::AddAssign<Poly<N>> for Poly<N> {
-    fn add_assign(&mut self, rhs: Poly<N>) {
+impl<const N: usize> core::ops::AddAssign<Self> for Poly<N> {
+    fn add_assign(&mut self, rhs: Self) {
         *self += &rhs;
     }
 }
 
-impl<const N: usize> core::ops::Add<Poly<N>> for Poly<N> {
-    type Output = Poly<N>;
+impl<const N: usize> core::ops::Add<Self> for Poly<N> {
+    type Output = Self;
 
-    fn add(mut self, rhs: Poly<N>) -> Poly<N> {
+    fn add(mut self, rhs: Self) -> Self {
         self += rhs;
         self
     }
 }
 
-impl<const N: usize> core::ops::Add<&Poly<N>> for Poly<N> {
-    type Output = Poly<N>;
+impl<const N: usize> core::ops::Add<&Self> for Poly<N> {
+    type Output = Self;
 
-    fn add(mut self, rhs: &Poly<N>) -> Poly<N> {
+    fn add(mut self, rhs: &Self) -> Self {
         self += rhs;
         self
     }
@@ -294,33 +294,33 @@ impl<const N: usize> core::ops::Add<Poly<N>> for &Poly<N> {
     }
 }
 
-impl<const N: usize> core::ops::SubAssign<&Poly<N>> for Poly<N> {
-    fn sub_assign(&mut self, rhs: &Poly<N>) {
+impl<const N: usize> core::ops::SubAssign<&Self> for Poly<N> {
+    fn sub_assign(&mut self, rhs: &Self) {
         for (c, d) in self.coeffs.iter_mut().zip(rhs.coeffs) {
             *c -= d;
         }
     }
 }
 
-impl<const N: usize> core::ops::SubAssign<Poly<N>> for Poly<N> {
-    fn sub_assign(&mut self, rhs: Poly<N>) {
+impl<const N: usize> core::ops::SubAssign<Self> for Poly<N> {
+    fn sub_assign(&mut self, rhs: Self) {
         *self -= &rhs;
     }
 }
 
-impl<const N: usize> core::ops::Sub<Poly<N>> for Poly<N> {
-    type Output = Poly<N>;
+impl<const N: usize> core::ops::Sub<Self> for Poly<N> {
+    type Output = Self;
 
-    fn sub(mut self, rhs: Poly<N>) -> Poly<N> {
+    fn sub(mut self, rhs: Self) -> Self {
         self -= rhs;
         self
     }
 }
 
-impl<const N: usize> core::ops::Sub<&Poly<N>> for Poly<N> {
-    type Output = Poly<N>;
+impl<const N: usize> core::ops::Sub<&Self> for Poly<N> {
+    type Output = Self;
 
-    fn sub(mut self, rhs: &Poly<N>) -> Poly<N> {
+    fn sub(mut self, rhs: &Self) -> Self {
         self -= rhs;
         self
     }
@@ -381,7 +381,7 @@ mod tests {
             // We can't expect great accuracy for very large roots,
             // because the polynomial evaluation will involve very
             // large terms.
-            let accuracy = accuracy * r.abs().powi(N as i32 - 1).max(1.0);
+            let accuracy = accuracy * r.abs().powi(i32::try_from(N).unwrap() - 1).max(1.0);
             // The solver aims for accuracy in the parameter, not the value.
             // So the value's accuracy will be affected by the derivative
             // at the root.
@@ -399,7 +399,7 @@ mod tests {
         arbtest::arbtest(|u| {
             let poly: Poly<4> = crate::arbitrary::poly(u)?;
             // Ignore very large polynomials, because they'll just overflow everything.
-            if (poly.max_abs_coefficient() * 10.0f64.powi(4)).is_infinite() {
+            if (poly.max_abs_coefficient() * 10.0_f64.powi(4)).is_infinite() {
                 return Err(arbitrary::Error::IncorrectFormat);
             }
             let roots = poly.roots_between(-10.0, 10.0, 1e-13);
@@ -414,7 +414,7 @@ mod tests {
     fn root_evaluation_deg4() {
         arbtest::arbtest(|u| {
             let poly: Poly<5> = crate::arbitrary::poly(u)?;
-            if (poly.max_abs_coefficient() * 10.0f64.powi(5)).is_infinite() {
+            if (poly.max_abs_coefficient() * 10.0_f64.powi(5)).is_infinite() {
                 return Err(arbitrary::Error::IncorrectFormat);
             }
             let roots = poly.roots_between(-10.0, 10.0, 1e-13);
@@ -428,7 +428,7 @@ mod tests {
     fn root_evaluation_deg9() {
         arbtest::arbtest(|u| {
             let poly: Poly<10> = crate::arbitrary::poly(u)?;
-            if (poly.max_abs_coefficient() * 10.0f64.powi(11)).is_infinite() {
+            if (poly.max_abs_coefficient() * 10.0_f64.powi(11)).is_infinite() {
                 return Err(arbitrary::Error::IncorrectFormat);
             }
             let roots = poly.roots_between(-10.0, 10.0, 1e-13);

--- a/polycool/src/poly_dyn.rs
+++ b/polycool/src/poly_dyn.rs
@@ -34,10 +34,10 @@ impl<'a> std::ops::Mul<&'a PolyDyn> for &'a PolyDyn {
     }
 }
 
-impl std::ops::Mul<&PolyDyn> for PolyDyn {
-    type Output = PolyDyn;
+impl std::ops::Mul<&Self> for PolyDyn {
+    type Output = Self;
 
-    fn mul(self, rhs: &PolyDyn) -> PolyDyn {
+    fn mul(self, rhs: &Self) -> Self {
         (&self) * rhs
     }
 }
@@ -48,7 +48,7 @@ impl PolyDyn {
     /// The first coefficient provided will be the constant term, the second will
     /// be the linear term, and so on.
     pub fn new(coeffs: impl IntoIterator<Item = f64>) -> Self {
-        PolyDyn {
+        Self {
             coeffs: coeffs.into_iter().collect(),
         }
     }
@@ -65,7 +65,7 @@ impl PolyDyn {
     }
 
     /// Returns the polynomial that's the derivative of this polynomial.
-    pub fn deriv(&self) -> PolyDyn {
+    pub fn deriv(&self) -> Self {
         let mut coeffs = Vec::with_capacity(self.coeffs.len().saturating_sub(1));
         // If we're empty (meaning that we're the constant zero polynomial),
         // this will just return the zero polynomial again: no need for a
@@ -73,7 +73,7 @@ impl PolyDyn {
         for (i, c) in self.coeffs.iter().enumerate().skip(1) {
             coeffs.push(c * (i as f64));
         }
-        PolyDyn { coeffs }
+        Self { coeffs }
     }
 
     /// Evaluates this polynomial at a point.

--- a/polycool/src/quadratic.rs
+++ b/polycool/src/quadratic.rs
@@ -30,7 +30,7 @@ impl Quadratic {
             let mut ret = ArrayVec::new();
             let mut push = |r: f64| {
                 if r.is_finite() {
-                    ret.push(r)
+                    ret.push(r);
                 }
             };
             if disc > 0.0 {
@@ -67,7 +67,7 @@ impl Quadratic {
             // do an extra factor of 2^{-3} for some wiggle room. This can't
             // completely destroy all the coefficients: because of the overflow,
             // we know that at least one of them was big.
-            let scale = 2.0f64.powi(-515);
+            let scale = 2.0_f64.powi(-515);
             // If we're infinite, just give up. (Otherwise, we'd stack overflow
             // by repeatedly trying to rescale.)
             if self.is_finite() {
@@ -100,7 +100,7 @@ impl Quadratic {
     #[cold]
     fn positive_discriminant_roots_scaled(&self) -> Option<(f64, f64)> {
         if self.is_finite() {
-            let scale = 2.0f64.powi(-515);
+            let scale = 2.0_f64.powi(-515);
             (*self * scale).positive_discriminant_roots()
         } else {
             None

--- a/polycool/src/yuksel.rs
+++ b/polycool/src/yuksel.rs
@@ -19,7 +19,10 @@ pub(crate) fn find_root<F: Fn(f64) -> f64, DF: Fn(f64) -> f64>(
     if !val_lower.is_finite() || !val_upper.is_finite() {
         return f64::NAN;
     }
-    debug_assert!(different_signs(val_lower, val_upper));
+    debug_assert!(
+        different_signs(val_lower, val_upper),
+        "lower and upper values have the same sign"
+    );
 
     let mut x = lower + (upper - lower) / 2.0;
     let mut step = (upper - lower) / 2.0;
@@ -49,8 +52,8 @@ pub(crate) fn find_root<F: Fn(f64) -> f64, DF: Fn(f64) -> f64>(
             lower = x;
         }
 
-        debug_assert!(deriv_x.is_finite());
-        debug_assert!(val_x.is_finite());
+        debug_assert!(deriv_x.is_finite(), "deriv_x is not finite");
+        debug_assert!(val_x.is_finite(), "val_x is not finite");
 
         step = -val_x / deriv_x;
         let mut new_x = x + step;


### PR DESCRIPTION
The standard Linebender lints were not yet enabled for `polycool`. This PR enables them and also tweaks the code to satisfy Clippy.