### PR TITLE
fix: Dash iterator zero-length LineTo noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ You can find its changes [documented below](#0131-2026-05-13).
 
 This release has an [MSRV][] of 1.85.
 
+## Fixed
+
+- Dashed strokes now avoid zero-length output at exact dash boundaries, preserve tiny positive remainders, and keep separate dashes from merging across `ClosePath` seams. ([#578][] by [@RobertBrewitz][])
+
 ## [0.13.1][] (2026-05-13)
 
 This release has an [MSRV][] of 1.85.
@@ -311,6 +315,7 @@ Note: A changelog was not kept for or before this release
 [#567]: https://github.com/linebender/kurbo/pull/567
 [#569]: https://github.com/linebender/kurbo/pull/569
 [#575]: https://github.com/linebender/kurbo/pull/575
+[#578]: https://github.com/linebender/kurbo/pull/578
 [#580]: https://github.com/linebender/kurbo/pull/580
 [#585]: https://github.com/linebender/kurbo/pull/585
 

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -1234,6 +1234,24 @@ mod tests {
     }
 
     #[test]
+    fn dash_ending_on_closepath_vertex_does_not_merge_across_seam() {
+        let shape = crate::Rect::from_points((0.0, 0.0), (3.0, 2.5));
+        let dashes = [3.0, 1.0];
+        let result = dash(shape.path_elements(0.0), 0.0, &dashes).collect::<Vec<PathEl>>();
+        let expected = vec![
+            PathEl::MoveTo((0.5, 2.5).into()),
+            PathEl::LineTo((0.0, 2.5).into()),
+            PathEl::LineTo((0.0, 0.0).into()),
+            PathEl::MoveTo((0.0, 0.0).into()),
+            PathEl::LineTo((3.0, 0.0).into()),
+            PathEl::MoveTo((3.0, 1.0).into()),
+            PathEl::LineTo((3.0, 2.5).into()),
+            PathEl::LineTo((1.5, 2.5).into()),
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn dash_negative_offset() {
         let shape = Line::new((0.0, 0.0), (28.0, 0.0));
         let dashes = [4., 2.];

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -744,7 +744,7 @@ fn dash_iter<'a>(
     let mut dash_remaining = dashes[dash_ix] - dash_offset;
     let mut is_active = true;
     // Find place in dashes array for initial offset.
-    while dash_remaining < 0.0 {
+    while dash_remaining <= DASH_ACCURACY {
         dash_ix = (dash_ix + 1) % dashes.len();
         dash_remaining += dashes[dash_ix];
         is_active = !is_active;
@@ -867,6 +867,17 @@ impl<'a, T: Iterator<Item = PathEl>> DashIterator<'a, T> {
                 result = Some(seg_to_el(&seg));
             }
             self.dash_remaining -= self.seg_remaining;
+
+            // If a dash transition coincides with a path vertex, advance the dash now
+            if self.is_active && self.dash_remaining <= DASH_ACCURACY {
+                self.is_active = false;
+                self.dash_ix += 1;
+                if self.dash_ix == self.dashes.len() {
+                    self.dash_ix = 0;
+                }
+                self.dash_remaining = self.dashes[self.dash_ix];
+            }
+
             self.get_input();
         }
         result
@@ -896,8 +907,12 @@ impl<'a, T: Iterator<Item = PathEl>> DashIterator<'a, T> {
 mod tests {
     use super::dash_iter;
     use crate::{
-        BezPath, Cap::Butt, CubicBez, Join::Miter, Line, PathEl, PathSeg, Shape, Stroke,
-        StrokeOpts, dash, segments, stroke,
+        BezPath,
+        Cap::Butt,
+        CubicBez,
+        Join::Miter,
+        Line, PathEl, PathSeg, Shape, Stroke, StrokeOpts, dash, segments,
+        stroke::{self, DASH_ACCURACY},
     };
 
     // A degenerate stroke with a cusp at the endpoint.
@@ -911,7 +926,7 @@ mod tests {
         );
         let path = curve.into_path(0.1);
         let stroke_style = Stroke::new(1.);
-        let stroked = stroke(path, &stroke_style, &StrokeOpts::default(), 0.001);
+        let stroked = stroke::stroke(path, &stroke_style, &StrokeOpts::default(), 0.001);
         assert!(stroked.is_finite());
     }
 
@@ -942,7 +957,7 @@ mod tests {
             .with_join(Miter)
             .with_caps(Butt)
             .with_dashes(0.0, [73.0, 12.0]);
-        let stroke = stroke(path, &stroke_style, &StrokeOpts::default(), 0.25);
+        let stroke = stroke::stroke(path, &stroke_style, &StrokeOpts::default(), 0.25);
         assert_eq!(stroke, expected_stroke);
     }
 
@@ -975,7 +990,7 @@ mod tests {
         let stroke_style = Stroke::new(30.).with_caps(Butt).with_join(Miter);
         for cubic in &broken_cubics {
             let path = CubicBez::new(cubic[0], cubic[1], cubic[2], cubic[3]).into_path(0.1);
-            let stroked = stroke(path, &stroke_style, &StrokeOpts::default(), 0.001);
+            let stroked = stroke::stroke(path, &stroke_style, &StrokeOpts::default(), 0.001);
             assert!(stroked.is_finite());
         }
     }
@@ -1097,6 +1112,92 @@ mod tests {
         ];
         let iter = dash_iter(path.into_iter(), 0., &dashes, true);
         assert_eq!(iter.collect::<Vec<PathEl>>(), expansion);
+    }
+
+    #[test]
+    fn dash_transition_on_vertex() {
+        let mut path = BezPath::new();
+        path.move_to((0., 0.));
+        path.line_to((3., 0.));
+        path.line_to((3., 3.));
+        let dashes = [3., 1.];
+        let expected = [
+            PathEl::MoveTo((0., 0.).into()),
+            PathEl::LineTo((3., 0.).into()),
+            PathEl::MoveTo((3., 1.).into()),
+            PathEl::LineTo((3., 3.).into()),
+        ];
+        let result: Vec<PathEl> = dash_iter(path.into_iter(), 0., &dashes, false).collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn dash_transition_on_vertex_stable_dash_order() {
+        let mut path = BezPath::new();
+        path.move_to((0., 0.));
+        path.line_to((3., 0.));
+        path.line_to((3., 3.));
+        let dashes = [3., 1.];
+        let expected = [
+            PathEl::MoveTo((0., 0.).into()),
+            PathEl::LineTo((3., 0.).into()),
+            PathEl::MoveTo((3., 1.).into()),
+            PathEl::LineTo((3., 3.).into()),
+        ];
+        let result: Vec<PathEl> = dash_iter(path.into_iter(), 0., &dashes, true).collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn dash_no_zero_length_across_offsets() {
+        let mut path = BezPath::new();
+        path.move_to((0., 0.));
+        path.line_to((3., 0.));
+        path.line_to((3., 3.));
+        path.line_to((0., 3.));
+        let dashes = [3., 1.];
+        let offsets = [
+            0.0,
+            3.0,
+            3.0 + DASH_ACCURACY * 0.1,
+            3.0 + DASH_ACCURACY * 10.0,
+        ];
+        let stable = false;
+        for &offset in &offsets {
+            let result: Vec<PathEl> = dash_iter(path.iter(), offset, &dashes, stable).collect();
+            let bad = result.windows(2).any(|w| match (w[0], w[1]) {
+                (PathEl::LineTo(a), PathEl::LineTo(b)) => a == b,
+                (PathEl::MoveTo(a), PathEl::LineTo(b)) => a == b,
+                _ => false,
+            });
+            assert!(!bad, "zero-length LineTo at offset {offset}: {result:?}");
+        }
+    }
+
+    #[test]
+    fn dash_no_zero_length_across_offsets_stable_dash_order() {
+        let mut path = BezPath::new();
+        path.move_to((0., 0.));
+        path.line_to((3., 0.));
+        path.line_to((3., 3.));
+        path.line_to((0., 3.));
+        let dashes = [3., 1.];
+        let offsets = [
+            0.0,
+            3.0,
+            3.0 + DASH_ACCURACY * 0.1,
+            3.0 + DASH_ACCURACY * 10.0,
+        ];
+        let stable = true;
+        for &offset in &offsets {
+            let result: Vec<PathEl> = dash_iter(path.iter(), offset, &dashes, stable).collect();
+            let bad = result.windows(2).any(|w| match (w[0], w[1]) {
+                (PathEl::LineTo(a), PathEl::LineTo(b)) => a == b,
+                (PathEl::MoveTo(a), PathEl::LineTo(b)) => a == b,
+                _ => false,
+            });
+            assert!(!bad, "zero-length LineTo at offset {offset}: {result:?}");
+        }
     }
 
     #[test]

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -744,7 +744,7 @@ fn dash_iter<'a>(
     let mut dash_remaining = dashes[dash_ix] - dash_offset;
     let mut is_active = true;
     // Find place in dashes array for initial offset.
-    while dash_remaining <= DASH_ACCURACY {
+    while dash_remaining <= 0.0 {
         dash_ix = (dash_ix + 1) % dashes.len();
         dash_remaining += dashes[dash_ix];
         is_active = !is_active;
@@ -869,7 +869,7 @@ impl<'a, T: Iterator<Item = PathEl>> DashIterator<'a, T> {
             self.dash_remaining -= self.seg_remaining;
 
             // If a dash transition coincides with a path vertex, advance the dash now
-            if self.is_active && self.dash_remaining <= DASH_ACCURACY {
+            if self.is_active && self.dash_remaining <= 0.0 {
                 self.is_active = false;
                 self.dash_ix += 1;
                 if self.dash_ix == self.dashes.len() {

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -1132,23 +1132,6 @@ mod tests {
     }
 
     #[test]
-    fn dash_transition_on_vertex_stable_dash_order() {
-        let mut path = BezPath::new();
-        path.move_to((0., 0.));
-        path.line_to((3., 0.));
-        path.line_to((3., 3.));
-        let dashes = [3., 1.];
-        let expected = [
-            PathEl::MoveTo((0., 0.).into()),
-            PathEl::LineTo((3., 0.).into()),
-            PathEl::MoveTo((3., 1.).into()),
-            PathEl::LineTo((3., 3.).into()),
-        ];
-        let result: Vec<PathEl> = dash_iter(path.into_iter(), 0., &dashes, true).collect();
-        assert_eq!(result, expected);
-    }
-
-    #[test]
     fn dash_no_zero_length_across_offsets() {
         let mut path = BezPath::new();
         path.move_to((0., 0.));
@@ -1163,32 +1146,6 @@ mod tests {
             3.0 + DASH_ACCURACY * 10.0,
         ];
         let stable = false;
-        for &offset in &offsets {
-            let result: Vec<PathEl> = dash_iter(path.iter(), offset, &dashes, stable).collect();
-            let bad = result.windows(2).any(|w| match (w[0], w[1]) {
-                (PathEl::LineTo(a), PathEl::LineTo(b)) => a == b,
-                (PathEl::MoveTo(a), PathEl::LineTo(b)) => a == b,
-                _ => false,
-            });
-            assert!(!bad, "zero-length LineTo at offset {offset}: {result:?}");
-        }
-    }
-
-    #[test]
-    fn dash_no_zero_length_across_offsets_stable_dash_order() {
-        let mut path = BezPath::new();
-        path.move_to((0., 0.));
-        path.line_to((3., 0.));
-        path.line_to((3., 3.));
-        path.line_to((0., 3.));
-        let dashes = [3., 1.];
-        let offsets = [
-            0.0,
-            3.0,
-            3.0 + DASH_ACCURACY * 0.1,
-            3.0 + DASH_ACCURACY * 10.0,
-        ];
-        let stable = true;
         for &offset in &offsets {
             let result: Vec<PathEl> = dash_iter(path.iter(), offset, &dashes, stable).collect();
             let bad = result.windows(2).any(|w| match (w[0], w[1]) {

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -1201,6 +1201,39 @@ mod tests {
     }
 
     #[test]
+    fn dash_preserves_small_initial_dash() {
+        let tiny_remainder = DASH_ACCURACY * 0.5;
+        let shape = Line::new((0.0, 0.0), (1.0, 0.0));
+        let dashes = [3.0, 1.0];
+        let dash_offset = 3.0 - tiny_remainder;
+        let expected_dash_end = dashes[0] - dash_offset;
+        let result = dash(shape.path_elements(0.0), dash_offset, &dashes).collect::<Vec<PathEl>>();
+        let expected = vec![
+            PathEl::MoveTo((0.0, 0.0).into()),
+            PathEl::LineTo((expected_dash_end, 0.0).into()),
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn dash_preserves_small_remainder_across_vertex() {
+        let tiny_remainder = DASH_ACCURACY * 0.5;
+        let mut path = BezPath::new();
+        path.move_to((0.0, 0.0));
+        path.line_to((3.0, 0.0));
+        path.line_to((3.0, 1.0));
+        let dashes = [3.0 + tiny_remainder, 1.0];
+        let expected_dash_end = dashes[0] - 3.0;
+        let result = dash(path.iter(), 0.0, &dashes).collect::<Vec<PathEl>>();
+        let expected = vec![
+            PathEl::MoveTo((0.0, 0.0).into()),
+            PathEl::LineTo((3.0, 0.0).into()),
+            PathEl::LineTo((3.0, expected_dash_end).into()),
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn dash_negative_offset() {
         let shape = Line::new((0.0, 0.0), (28.0, 0.0));
         let dashes = [4., 2.];


### PR DESCRIPTION
Resolves and adds tests to quality assures the fix for https://github.com/linebender/kurbo/issues/577

- dash_iter now treats an exactly exhausted dash the same as an overshot one at initialization
- dash_iter now advances dash phase immediately when a dash ends exactly on a path vertex, instead of carrying an active zero remainder into the next segment.
- New dashed-stroke regression tests