### PR TITLE
Add subpath closing iterator and change Shape::area() behavior

### DIFF
--- a/kurbo/src/bezpath.rs
+++ b/kurbo/src/bezpath.rs
@@ -793,6 +793,69 @@ impl Mul<&BezPath> for TranslateScale {
     }
 }
 
+/// Close all open subpaths in a path, expressed as iterator transform.
+pub fn close_subpaths<I>(elements: I) -> CloseSubpaths<I::IntoIter>
+where
+    I: IntoIterator<Item = PathEl>,
+{
+    CloseSubpaths {
+        elements: elements.into_iter(),
+        state: CloseSubpathState::Start,
+    }
+}
+
+/// An iterator that closes all open subpaths.
+///
+/// This struct is created by the [`segments`] function.
+#[derive(Clone)]
+pub struct CloseSubpaths<I: Iterator<Item = PathEl>> {
+    elements: I,
+    state: CloseSubpathState,
+}
+
+#[derive(Clone)]
+enum CloseSubpathState {
+    Start,
+    InSubpath,
+    ClosedLast,
+    PendingMoveTo(Point),
+}
+
+impl<I: Iterator<Item = PathEl>> Iterator for CloseSubpaths<I> {
+    type Item = PathEl;
+
+    fn next(&mut self) -> Option<PathEl> {
+        match self.state {
+            CloseSubpathState::Start => {
+                let el = self.elements.next();
+                if !matches!(el, Some(PathEl::ClosePath)) {
+                    self.state = CloseSubpathState::InSubpath;
+                }
+                el
+            }
+            CloseSubpathState::InSubpath => {
+                let el = self.elements.next();
+                match el {
+                    None => {
+                        self.state = CloseSubpathState::ClosedLast;
+                        Some(PathEl::ClosePath)
+                    }
+                    Some(PathEl::MoveTo(point)) => {
+                        self.state = CloseSubpathState::PendingMoveTo(point);
+                        Some(PathEl::ClosePath)
+                    }
+                    _ => el,
+                }
+            }
+            CloseSubpathState::ClosedLast => None,
+            CloseSubpathState::PendingMoveTo(point) => {
+                self.state = CloseSubpathState::Start;
+                Some(PathEl::MoveTo(point))
+            }
+        }
+    }
+}
+
 /// Transform an iterator over path elements into one over path
 /// segments.
 ///
@@ -1445,8 +1508,10 @@ impl<'a> Shape for &'a [PathEl] {
     }
 
     /// Signed area.
+    ///
+    /// Note: the path is treated as a filled path, so subpaths will be closed.
     fn area(&self) -> f64 {
-        segments(self.iter().copied()).area()
+        segments(close_subpaths(self.iter().copied())).area()
     }
 
     fn perimeter(&self, accuracy: f64) -> f64 {
@@ -2182,5 +2247,38 @@ mod tests {
         assert!(bez.contains((100.0, 300.1).into()));
         assert!(bez.contains((100.0, 299.9).into()));
         assert!(bez.contains((100.0, 300.0).into()));
+    }
+
+    #[test]
+    fn area_closed_subpath() {
+        let mut bez = BezPath::new();
+        bez.move_to((10.0, 10.0));
+        bez.line_to((100.0, 20.0));
+        bez.line_to((60.0, 100.0));
+        let area_unclosed = bez.area();
+        bez.close_path();
+        let area_closed = bez.area();
+        assert_eq!(area_unclosed, area_closed);
+
+        // Test implicit closepath in middle of path
+        let mut bez2 = BezPath::new();
+        bez2.move_to((10.0, 10.0));
+        bez2.line_to((100.0, 20.0));
+        bez2.line_to((60.0, 100.0));
+        bez2.move_to((110.0, 10.0));
+        bez2.line_to((200.0, 20.0));
+        bez2.line_to((160.0, 100.0));
+        let area_bez2 = bez2.area();
+        let mut bez3 = BezPath::new();
+        bez3.move_to((10.0, 10.0));
+        bez3.line_to((100.0, 20.0));
+        bez3.line_to((60.0, 100.0));
+        bez3.close_path();
+        bez3.move_to((110.0, 10.0));
+        bez3.line_to((200.0, 20.0));
+        bez3.line_to((160.0, 100.0));
+        bez3.close_path();
+        let area_bez3 = bez3.area();
+        assert_eq!(area_bez2, area_bez3);
     }
 }

--- a/kurbo/src/cubicbez.rs
+++ b/kurbo/src/cubicbez.rs
@@ -7,8 +7,8 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::{Mul, Range};
 
-use crate::MAX_EXTREMA;
 use crate::{Line, QuadSpline, Vec2};
+use crate::{MAX_EXTREMA, close_subpaths, segments};
 use arrayvec::ArrayVec;
 
 use crate::common::{
@@ -513,7 +513,7 @@ impl Shape for CubicBez {
 
     #[inline(always)]
     fn area(&self) -> f64 {
-        0.0
+        segments(close_subpaths(self.path_elements(0.0))).area()
     }
 
     #[inline]

--- a/kurbo/src/lib.rs
+++ b/kurbo/src/lib.rs
@@ -155,8 +155,8 @@ pub use crate::affine::Affine;
 pub use crate::arc::{Arc, ArcAppendIter};
 pub use crate::axis::Axis;
 pub use crate::bezpath::{
-    BezPath, LineIntersection, MinDistance, PathEl, PathSeg, PathSegIter, Segments, flatten,
-    segments,
+    BezPath, CloseSubpaths, LineIntersection, MinDistance, PathEl, PathSeg, PathSegIter, Segments,
+    close_subpaths, flatten, segments,
 };
 pub use crate::circle::{Circle, CirclePathIter, CircleSegment};
 pub use crate::cubicbez::{CubicBez, CubicBezIter, CuspType, cubics_to_quadratic_splines};

--- a/kurbo/src/quadbez.rs
+++ b/kurbo/src/quadbez.rs
@@ -7,13 +7,13 @@ use core::ops::{Mul, Range};
 
 use arrayvec::ArrayVec;
 
-use crate::MAX_EXTREMA;
 use crate::common::{solve_cubic, solve_quadratic};
 use crate::{
     Affine, CubicBez, Line, Nearest, ParamCurve, ParamCurveArclen, ParamCurveArea,
     ParamCurveCurvature, ParamCurveDeriv, ParamCurveExtrema, ParamCurveNearest, PathEl, Point,
     Rect, Shape,
 };
+use crate::{MAX_EXTREMA, close_subpaths, segments};
 
 #[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;
@@ -158,7 +158,7 @@ impl Shape for QuadBez {
     }
 
     fn area(&self) -> f64 {
-        0.0
+        segments(close_subpaths(self.path_elements(0.0))).area()
     }
 
     #[inline]

--- a/kurbo/src/shape.rs
+++ b/kurbo/src/shape.rs
@@ -97,7 +97,9 @@ pub trait Shape {
 
     /// Signed area.
     ///
-    /// This method only produces meaningful results with closed shapes.
+    /// This method interprets the shape as a filled path. For shapes that
+    /// potentially have open subpaths, the implementation should implicitly
+    /// close the subpaths while computing area.
     ///
     /// The convention for positive area is that y increases when x is
     /// positive. Thus, it is clockwise when down is increasing y (the


### PR DESCRIPTION
This patch changes the expectation for the `area` method of the `Shape` trait, so that open subpaths are implicitly closed.

Updates the implementations for QuadBez and CubicBez.

Note: this is technically a breaking change, but it only affects external implementations of the `Shape` trait, and it seems exceedingly unlikely this will cause actual problems.

Work in progress. The implementation for `Arc` no longer meets the spec.