### PR TITLE
fix: drop zero-length LineTo when dash transition lands on a vertex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This release has an [MSRV][] of 1.85.
 
 - Improved numerical robustness of winding numbers for paths. ([#537][] by [@jneem][])
 - `Affine::pre_rotate_about` calculation. ([#567][] by [@dannymcgee][])
+- Dash iterator no longer emits a zero-length `LineTo` when a dash transition lands exactly on a path vertex. ([#584][] by [@SAY-5][])
 
 ## [0.13.0] (2025-11-27)
 
@@ -214,6 +215,7 @@ Note: A changelog was not kept for or before this release
 [@xorgy]: https://github.com/xorgy
 [@xStrom]: https://github.com/xStrom
 [@RobertBrewitz]: https://github.com/RobertBrewitz
+[@SAY-5]: https://github.com/SAY-5
 
 [#288]: https://github.com/linebender/kurbo/pull/288
 [#334]: https://github.com/linebender/kurbo/pull/334
@@ -303,6 +305,7 @@ Note: A changelog was not kept for or before this release
 [#567]: https://github.com/linebender/kurbo/pull/567
 [#569]: https://github.com/linebender/kurbo/pull/569
 [#575]: https://github.com/linebender/kurbo/pull/575
+[#584]: https://github.com/linebender/kurbo/pull/584
 
 [Unreleased]: https://github.com/linebender/kurbo/compare/v0.13.0...HEAD
 [0.13.0]: https://github.com/linebender/kurbo/releases/tag/v0.13.0

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -838,9 +838,12 @@ impl<'a, T: Iterator<Item = PathEl>> DashIterator<'a, T> {
             let seg = self.current_seg.subsegment(self.t..1.0);
             let t1 = seg.inv_arclen(self.dash_remaining, DASH_ACCURACY);
             if self.is_active {
-                let subseg = seg.subsegment(0.0..t1);
-                result = Some(seg_to_el(&subseg));
-                self.state = DashState::Working;
+                // Skip a zero-length dash that ends exactly on a path vertex.
+                if t1 != 0.0 {
+                    let subseg = seg.subsegment(0.0..t1);
+                    result = Some(seg_to_el(&subseg));
+                    self.state = DashState::Working;
+                }
             } else {
                 let p = seg.eval(t1);
                 result = Some(PathEl::MoveTo(p));
@@ -905,6 +908,26 @@ mod tests {
         let stroke_style = Stroke::new(1.);
         let stroked = stroke(path, &stroke_style, &StrokeOpts::default(), 0.001);
         assert!(stroked.is_finite());
+    }
+
+    #[test]
+    /// <https://github.com/linebender/kurbo/issues/577>
+    fn dash_transition_on_vertex() {
+        let path = BezPath::from_vec(vec![
+            PathEl::MoveTo((0.0, 0.0).into()),
+            PathEl::LineTo((3.0, 0.0).into()),
+            PathEl::LineTo((3.0, 3.0).into()),
+        ]);
+        let result: Vec<PathEl> = dash_iter(path.into_iter(), 0.0, &[3.0, 1.0], true).collect();
+        assert_eq!(
+            result,
+            vec![
+                PathEl::MoveTo((0.0, 0.0).into()),
+                PathEl::LineTo((3.0, 0.0).into()),
+                PathEl::MoveTo((3.0, 1.0).into()),
+                PathEl::LineTo((3.0, 3.0).into()),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
When a dash transition lands exactly on a path vertex, the dash iterator emitted a zero-length `LineTo` at the corner before transitioning to the next dash; this skips that empty segment. Closes #577.