### PR TITLE
Fix odd-length dash patterns swapping dashes and gaps when `dash_length` increases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,9 @@ This release has an [MSRV][] of 1.85.
 
 ## Fixed
 
-- Improved numerical robustness of winding numbers for paths. ([#537][] by [@jneem][])
+- Improve numerical robustness of winding numbers for paths. ([#537][] by [@jneem][])
 - `Affine::pre_rotate_about` calculation. ([#567][] by [@dannymcgee][])
+- Odd-length dash patterns no longer swap dashes and gaps when `dash_offset` increases. ([#585][] by [@Keavon][])
 
 ## [0.13.0] (2025-11-27)
 
@@ -52,7 +53,7 @@ This release has an [MSRV][] of 1.85.
 - The `Line::nearest` method to calculate the projection of a point onto a line segment has been made more performant. ([#505][] by [@tomcur][])
 - The `QuadBez::arclen` calculation has been made more numerically stable ([#503][] by [@jneem][]).
 - `SvgParseError` now implements `core::error:Error`. It previously implemented `std::error::Error` in `std`-enabled builds. ([#517][] by [@Bombaninha][])
-- The behavior of open versus closed shapes when using `BezPath::extend` (extending Bezier paths using an iterator over `PathEl`) has been clarified. [#523][] by [@DJMcNab][])
+- The behavior of open versus closed shapes when using `BezPath::extend` (extending Bezier paths using an iterator over `PathEl`) has been clarified. ([#523][] by [@DJMcNab][])
 - More methods are marked `inline`. ([#506][] by [@LaurenzV][], [#509][] by [@tomcur][])
 
 The following functions are now callable from `const` contexts. ([#510][], [#512][], [#521][], [#522][], [#524][], [#525][], [#526][] by [@tomcur][])
@@ -198,6 +199,7 @@ Note: A changelog was not kept for or before this release
 [@gemberg]: https://github.com/gemberg
 [@jneem]: https://github.com/jneem
 [@jrmoulton]: https://github.com/jrmoulton
+[@Keavon]: https://github.com/Keavon
 [@juliapaci]: https://github.com/juliapaci
 [@LaurenzV]: https://github.com/LaurenzV
 [@liferooter]: https://github.com/liferooter
@@ -303,6 +305,7 @@ Note: A changelog was not kept for or before this release
 [#567]: https://github.com/linebender/kurbo/pull/567
 [#569]: https://github.com/linebender/kurbo/pull/569
 [#575]: https://github.com/linebender/kurbo/pull/575
+[#585]: https://github.com/linebender/kurbo/pull/585
 
 [Unreleased]: https://github.com/linebender/kurbo/compare/v0.13.0...HEAD
 [0.13.0]: https://github.com/linebender/kurbo/releases/tag/v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,8 +201,8 @@ Note: A changelog was not kept for or before this release
 [@gemberg]: https://github.com/gemberg
 [@jneem]: https://github.com/jneem
 [@jrmoulton]: https://github.com/jrmoulton
-[@Keavon]: https://github.com/Keavon
 [@juliapaci]: https://github.com/juliapaci
+[@Keavon]: https://github.com/Keavon
 [@LaurenzV]: https://github.com/LaurenzV
 [@liferooter]: https://github.com/liferooter
 [@nils-mathieu]: https://github.com/nils-mathieu
@@ -210,6 +210,7 @@ Note: A changelog was not kept for or before this release
 [@platlas]: https://github.com/platlas
 [@PoignardAzur]: https://github.com/PoignardAzur
 [@raphlinus]: https://github.com/raphlinus
+[@RobertBrewitz]: https://github.com/RobertBrewitz
 [@rsheeter]: https://github.com/rsheeter
 [@sagudev]: https://github.com/sagudev
 [@simoncozens]: https://github.com/simoncozens
@@ -217,7 +218,6 @@ Note: A changelog was not kept for or before this release
 [@waywardmonkeys]: https://github.com/waywardmonkeys
 [@xorgy]: https://github.com/xorgy
 [@xStrom]: https://github.com/xStrom
-[@RobertBrewitz]: https://github.com/RobertBrewitz
 
 [#288]: https://github.com/linebender/kurbo/pull/288
 [#334]: https://github.com/linebender/kurbo/pull/334

--- a/kurbo/src/stroke.rs
+++ b/kurbo/src/stroke.rs
@@ -728,8 +728,16 @@ fn dash_iter<'a>(
     dashes: &'a [f64],
     stable_dash_order: bool,
 ) -> DashIterator<'a, impl Iterator<Item = PathEl> + 'a> {
-    // ensure that offset is positive and minimal by normalization using period
+    // Ensure that offset is positive and minimal by normalization using period
     let period = dashes.iter().sum();
+    // The SVG spec requires odd-length dash arrays to be doubled to become even-length:
+    // <https://www.w3.org/TR/SVG2/painting.html#StrokeDasharrayProperty>
+    // This prevents gaps and dashes from swapping with one another as the offset increases.
+    let period = if dashes.len() % 2 == 1 {
+        2.0 * period
+    } else {
+        period
+    };
     let dash_offset = dash_offset.rem_euclid(period);
 
     let mut dash_ix = 0;
@@ -1098,6 +1106,34 @@ mod tests {
         let pos = segments(dash(shape.path_elements(0.), 60., &dashes)).collect::<Vec<PathSeg>>();
         let neg = segments(dash(shape.path_elements(0.), -60., &dashes)).collect::<Vec<PathSeg>>();
         assert_eq!(neg, pos);
+    }
+
+    #[test]
+    fn dash_odd_length_matches_doubled() {
+        let shape = Line::new((0.0, 0.0), (50.0, 0.0));
+        let odd = [10.];
+        let doubled = [10., 10.];
+        for offset in [0., 5., 9., 10., 11., 15., 20., 25., 100., -7.] {
+            let from_odd =
+                segments(dash(shape.path_elements(0.), offset, &odd)).collect::<Vec<PathSeg>>();
+            let from_doubled =
+                segments(dash(shape.path_elements(0.), offset, &doubled)).collect::<Vec<PathSeg>>();
+            assert_eq!(from_odd, from_doubled, "mismatch at offset {offset}");
+        }
+    }
+
+    #[test]
+    fn dash_three_element_matches_doubled() {
+        let shape = Line::new((0.0, 0.0), (200.0, 0.0));
+        let three = [20., 10., 3.];
+        let doubled = [20., 10., 3., 20., 10., 3.];
+        for offset in [0., 15., 32., 33., 34., 50., 66., 99.] {
+            let from_three =
+                segments(dash(shape.path_elements(0.), offset, &three)).collect::<Vec<PathSeg>>();
+            let from_doubled =
+                segments(dash(shape.path_elements(0.), offset, &doubled)).collect::<Vec<PathSeg>>();
+            assert_eq!(from_three, from_doubled, "mismatch at offset {offset}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Given any odd-length dash pattern like `[10]` or `[10, 3, 20]` (shown in the demo below), increasing the `dash_length` property would incorrectly cause the stroked dash areas and the non-stroked gap areas to swap places, in violation of the SVG spec.

Before:

https://github.com/user-attachments/assets/e5150ede-918f-4a6b-a52b-023c041c8235

After:

https://github.com/user-attachments/assets/ba384948-f192-49cc-b242-117299704403

This fixes Kurbo to comply with the [SVG spec](https://www.w3.org/TR/SVG2/painting.html#StrokeDasharrayProperty):

<img width="1649" height="600" alt="image" src="https://github.com/user-attachments/assets/54fd2ef4-81b3-4601-8b5f-22345c6b2761" />

AI disclosure: I used Claude Code to pinpoint the bug and find the appropriate solution, which I then cleaned up to be a tidy one-liner. I've tested it in Graphite and confirmed (as shown in the videos above) that it works as expected.