### PR TITLE
Add affine transform classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ You can find its changes [documented below](#0131-2026-05-13).
 
 This release has an [MSRV][] of 1.85.
 
+## Added
+
+- `TransformClass` and methods for classifying `Affine` transform differences. ([#589][] by [@waywardmonkeys][])
+
 ## [0.13.1][] (2026-05-13)
 
 This release has an [MSRV][] of 1.85.
@@ -311,8 +315,12 @@ Note: A changelog was not kept for or before this release
 [#567]: https://github.com/linebender/kurbo/pull/567
 [#569]: https://github.com/linebender/kurbo/pull/569
 [#575]: https://github.com/linebender/kurbo/pull/575
+<<<<<<< HEAD
 [#580]: https://github.com/linebender/kurbo/pull/580
 [#585]: https://github.com/linebender/kurbo/pull/585
+=======
+[#589]: https://github.com/linebender/kurbo/pull/589
+>>>>>>> e10cc9a (Add affine transform classification)
 
 [Unreleased]: https://github.com/linebender/kurbo/compare/v0.13.1...HEAD
 [0.13.1]: https://github.com/linebender/kurbo/releases/tag/v0.13.1

--- a/kurbo/src/affine.rs
+++ b/kurbo/src/affine.rs
@@ -5,7 +5,10 @@
 
 use core::ops::{Mul, MulAssign};
 
-use crate::{Point, Rect, Vec2};
+use crate::{
+    Point, Rect, Vec2,
+    transform_class::{DEFAULT_TRANSFORM_CLASS_EPSILON, TransformClass},
+};
 
 #[cfg(not(feature = "std"))]
 use crate::common::FloatFuncs;
@@ -435,6 +438,121 @@ impl Affine {
         ])
     }
 
+    /// Classify this transform relative to the identity transform.
+    ///
+    /// This returns the most restrictive [`TransformClass`] that contains this
+    /// transform, using [`DEFAULT_TRANSFORM_CLASS_EPSILON`] for numeric
+    /// comparisons. [`TransformClass::Exact`] is returned only when this
+    /// transform compares equal to [`Affine::IDENTITY`].
+    #[inline]
+    pub fn transform_class(self) -> TransformClass {
+        self.transform_class_with_epsilon(DEFAULT_TRANSFORM_CLASS_EPSILON)
+    }
+
+    /// Classify this transform relative to the identity transform, using
+    /// `epsilon` for numeric comparisons.
+    ///
+    /// Negative epsilon values are treated as their absolute value. Non-finite
+    /// epsilon values are treated as `0.0`.
+    #[inline]
+    pub fn transform_class_with_epsilon(self, epsilon: f64) -> TransformClass {
+        if self == Affine::IDENTITY {
+            return TransformClass::Exact;
+        }
+
+        if !self.is_finite() {
+            return TransformClass::Affine;
+        }
+
+        let epsilon = if epsilon.is_finite() {
+            epsilon.abs()
+        } else {
+            0.0
+        };
+        let [a, b, c, d, _, _] = self.0;
+
+        // Translation is the special case where the linear part is still identity;
+        // the final two coefficients may be anything.
+        if (a - 1.0).abs() <= epsilon
+            && b.abs() <= epsilon
+            && c.abs() <= epsilon
+            && (d - 1.0).abs() <= epsilon
+        {
+            TransformClass::TranslateOnly
+        } else {
+            let x_len_sq = a * a + b * b;
+            let y_len_sq = c * c + d * d;
+            let scale = x_len_sq.max(y_len_sq).max(1.0);
+
+            // Uniform-scale orthogonal transforms have perpendicular columns
+            // with equal length. This admits rotations, reflections, and
+            // uniform scale, but rejects shear and non-uniform scale.
+            if (a * c + b * d).abs() <= epsilon * scale
+                && (x_len_sq - y_len_sq).abs() <= epsilon * scale
+            {
+                TransformClass::Orthonormal
+            } else {
+                TransformClass::Affine
+            }
+        }
+    }
+
+    /// Classify how this transform differs from `other`.
+    ///
+    /// This is intended for cache/replay checks where `self` is the transform
+    /// an operation was recorded under and `other` is the current transform.
+    /// It uses [`DEFAULT_TRANSFORM_CLASS_EPSILON`] for numeric comparisons.
+    /// Finite transforms with the same linear part are classified as
+    /// [`TransformClass::TranslateOnly`] without computing an inverse.
+    ///
+    /// If `self` and `other` compare equal, this returns
+    /// [`TransformClass::Exact`] without computing an inverse, so singular
+    /// transforms can still exact-match.
+    #[inline]
+    pub fn transform_class_to(self, other: Affine) -> TransformClass {
+        self.transform_class_to_with_epsilon(other, DEFAULT_TRANSFORM_CLASS_EPSILON)
+    }
+
+    /// Classify how this transform differs from `other`, using `epsilon` for
+    /// numeric comparisons.
+    ///
+    /// See [`Affine::transform_class_to`] for the interpretation of `self`
+    /// and `other`.
+    #[inline]
+    pub fn transform_class_to_with_epsilon(self, other: Affine, epsilon: f64) -> TransformClass {
+        let original = self.0;
+        let current = other.0;
+        let epsilon = if epsilon.is_finite() {
+            epsilon.abs()
+        } else {
+            0.0
+        };
+        let finite = self.is_finite() && other.is_finite();
+        let mut exact_linear = true;
+        let mut same_linear = finite;
+
+        // Compare the linear part directly first. If it matches, the remaining
+        // difference can only be translation, and this also works for singular
+        // transforms where computing a relative delta would produce NaNs.
+        for i in 0..4 {
+            exact_linear &= original[i] == current[i];
+            if finite {
+                let scale = original[i].abs().max(current[i].abs()).max(1.0);
+                same_linear &= (original[i] - current[i]).abs() <= epsilon * scale;
+            }
+        }
+
+        if exact_linear && original[4] == current[4] && original[5] == current[5] {
+            TransformClass::Exact
+        } else if same_linear {
+            TransformClass::TranslateOnly
+        } else {
+            // Once the linear parts differ, classify the relative transform so
+            // rotation/reflection/uniform-scale deltas can still be recognized.
+            (other * self.inverse()).transform_class_with_epsilon(epsilon)
+        }
+    }
+
     /// Compute the bounding box of a transformed rectangle.
     ///
     /// Returns the minimal `Rect` that encloses the given `Rect` after affine transformation.
@@ -669,7 +787,7 @@ impl From<mint::ColumnMatrix2x3<f64>> for Affine {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Affine, Point, Vec2};
+    use crate::{Affine, Point, TransformClass, Vec2};
     use std::f64::consts::PI;
 
     fn assert_near(p0: Point, p1: Point) {
@@ -826,6 +944,94 @@ mod tests {
         assert!(
             (prod - det) < 1e-9,
             "The product of the singular values {s:?} ({prod}) should be equal to the absolute determinant {det}.",
+        );
+    }
+
+    #[test]
+    fn transform_class_basic() {
+        assert_eq!(Affine::IDENTITY.transform_class(), TransformClass::Exact);
+        assert_eq!(
+            Affine::translate((2., 3.)).transform_class(),
+            TransformClass::TranslateOnly
+        );
+        assert_eq!(
+            Affine::rotate(0.5).transform_class(),
+            TransformClass::Orthonormal
+        );
+        assert_eq!(
+            Affine::scale(2.).transform_class(),
+            TransformClass::Orthonormal
+        );
+        assert_eq!(
+            Affine::reflect(Point::ZERO, (1., 0.)).transform_class(),
+            TransformClass::Orthonormal
+        );
+        assert_eq!(
+            Affine::scale_non_uniform(2., 3.).transform_class(),
+            TransformClass::Affine
+        );
+        assert_eq!(
+            Affine::skew(0.5, 0.).transform_class(),
+            TransformClass::Affine
+        );
+    }
+
+    #[test]
+    fn transform_class_to_compares_delta() {
+        let recorded = Affine::translate((10., 20.))
+            .then_rotate(0.25)
+            .then_scale(3.);
+
+        assert_eq!(recorded.transform_class_to(recorded), TransformClass::Exact);
+        assert_eq!(
+            recorded.transform_class_to(recorded.then_translate(Vec2::new(4., -5.))),
+            TransformClass::TranslateOnly
+        );
+        assert_eq!(
+            recorded.transform_class_to(recorded.then_rotate(PI / 2.)),
+            TransformClass::Orthonormal
+        );
+        assert_eq!(
+            recorded.transform_class_to(recorded.then_scale_non_uniform(2., 3.)),
+            TransformClass::Affine
+        );
+    }
+
+    #[test]
+    fn transform_class_uses_epsilon_for_near_similarity() {
+        let almost_rotation = Affine::new([0., 1. + 2e-13, -1., 0., 0., 0.]);
+        assert_eq!(
+            almost_rotation.transform_class(),
+            TransformClass::Orthonormal
+        );
+        assert_eq!(
+            almost_rotation.transform_class_with_epsilon(1e-14),
+            TransformClass::Affine
+        );
+    }
+
+    #[test]
+    fn transform_class_to_uses_epsilon_for_near_same_linear_part() {
+        let original = Affine::scale(10.);
+        let current = Affine::new([10. + 5e-12, 0., 0., 10., 3., 4.]);
+
+        assert_eq!(
+            original.transform_class_to(current),
+            TransformClass::TranslateOnly
+        );
+        assert_eq!(
+            original.transform_class_to_with_epsilon(current, 1e-14),
+            TransformClass::Affine
+        );
+    }
+
+    #[test]
+    fn transform_class_to_exact_handles_singular_transform() {
+        let singular = Affine::new([0., 0., 0., 0., 5., 6.]);
+        assert_eq!(singular.transform_class_to(singular), TransformClass::Exact);
+        assert_eq!(
+            singular.transform_class_to(singular.then_translate(Vec2::new(1., 2.))),
+            TransformClass::TranslateOnly
         );
     }
 

--- a/kurbo/src/lib.rs
+++ b/kurbo/src/lib.rs
@@ -144,6 +144,7 @@ pub mod simplify;
 mod size;
 mod stroke;
 mod svg;
+mod transform_class;
 mod translate_scale;
 mod triangle;
 mod vec2;
@@ -184,6 +185,7 @@ pub use crate::stroke::{
     Cap, Dashes, Join, Stroke, StrokeCtx, StrokeOptLevel, StrokeOpts, dash, stroke, stroke_with,
 };
 pub use crate::svg::{SvgArc, SvgParseError};
+pub use crate::transform_class::{DEFAULT_TRANSFORM_CLASS_EPSILON, TransformClass};
 pub use crate::translate_scale::TranslateScale;
 pub use crate::triangle::{Triangle, TrianglePathIter};
 pub use crate::vec2::Vec2;

--- a/kurbo/src/transform_class.rs
+++ b/kurbo/src/transform_class.rs
@@ -1,0 +1,168 @@
+// Copyright 2025 the Kurbo Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Classification for how two transforms differ.
+
+/// Default tolerance used by [`crate::Affine::transform_class_to`].
+///
+/// This is intended to treat matrices produced by common floating point
+/// operations (such as `sin_cos`) as "exact enough" for classification, while
+/// still being strict.
+pub const DEFAULT_TRANSFORM_CLASS_EPSILON: f64 = 1e-12;
+
+/// A conservative classification for how a recorded operation can be replayed
+/// under a different transform.
+///
+/// This is primarily intended for comparing two transforms by classifying their
+/// *delta* transform (for example `current * recorded.inverse()`), rather than
+/// classifying a single transform in isolation.
+///
+/// Classes are ordered from most restrictive to most permissive, so
+/// `actual <= valid_under` means that a delta classified as `actual` can be
+/// used where `valid_under` is allowed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum TransformClass {
+    /// Valid only when the compared transforms are exactly equal.
+    Exact,
+    /// Valid when transforms differ by a pure translation (linear part is identity).
+    TranslateOnly,
+    /// Valid under affine transforms whose linear part is a uniform-scale
+    /// orthogonal transform (rotation/reflection, no shear).
+    ///
+    /// Note: the name comes from downstream usage; mathematically this is a
+    /// "similarity transform" when the scale is non-`1`.
+    Orthonormal,
+    /// Valid under any affine transform.
+    Affine,
+}
+
+impl TransformClass {
+    #[inline]
+    const fn rank(self) -> u8 {
+        match self {
+            Self::Exact => 0,
+            Self::TranslateOnly => 1,
+            Self::Orthonormal => 2,
+            Self::Affine => 3,
+        }
+    }
+
+    /// Returns `true` if this class includes all transforms in `other`.
+    ///
+    /// This is useful when a cached operation is valid under `self`, and a
+    /// transform delta has been classified as `other`.
+    #[inline]
+    pub const fn contains(self, other: Self) -> bool {
+        other.rank() <= self.rank()
+    }
+
+    /// Returns `true` if every transform in this class is included in `other`.
+    #[inline]
+    pub const fn is_contained_by(self, other: Self) -> bool {
+        other.contains(self)
+    }
+
+    /// Return the least permissive class that contains both `self` and `other`.
+    ///
+    /// This can be used as the step function when folding over transform
+    /// classes:
+    ///
+    /// ```
+    /// # use kurbo::TransformClass;
+    /// let classes = [
+    ///     TransformClass::Exact,
+    ///     TransformClass::TranslateOnly,
+    ///     TransformClass::Orthonormal,
+    /// ];
+    ///
+    /// let combined = classes
+    ///     .into_iter()
+    ///     .fold(TransformClass::default(), TransformClass::union);
+    ///
+    /// assert_eq!(combined, TransformClass::Orthonormal);
+    /// ```
+    #[inline]
+    pub const fn union(self, other: Self) -> Self {
+        if self.rank() >= other.rank() {
+            self
+        } else {
+            other
+        }
+    }
+}
+
+impl Default for TransformClass {
+    #[inline]
+    fn default() -> Self {
+        Self::Exact
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TransformClass;
+
+    #[test]
+    fn class_containment() {
+        assert!(TransformClass::Exact.contains(TransformClass::Exact));
+        assert!(!TransformClass::Exact.contains(TransformClass::TranslateOnly));
+
+        assert!(TransformClass::TranslateOnly.contains(TransformClass::Exact));
+        assert!(TransformClass::TranslateOnly.contains(TransformClass::TranslateOnly));
+        assert!(!TransformClass::TranslateOnly.contains(TransformClass::Orthonormal));
+
+        assert!(TransformClass::Orthonormal.contains(TransformClass::TranslateOnly));
+        assert!(TransformClass::Affine.contains(TransformClass::Orthonormal));
+        assert!(TransformClass::Orthonormal.is_contained_by(TransformClass::Affine));
+        assert!(!TransformClass::Affine.is_contained_by(TransformClass::Orthonormal));
+    }
+
+    #[test]
+    fn class_order_matches_containment() {
+        let classes = [
+            TransformClass::Exact,
+            TransformClass::TranslateOnly,
+            TransformClass::Orthonormal,
+            TransformClass::Affine,
+        ];
+
+        for valid_under in classes {
+            for actual in classes {
+                assert_eq!(valid_under.contains(actual), actual <= valid_under);
+            }
+        }
+    }
+
+    #[test]
+    fn class_union() {
+        assert_eq!(
+            TransformClass::Exact.union(TransformClass::TranslateOnly),
+            TransformClass::TranslateOnly
+        );
+        assert_eq!(
+            TransformClass::Orthonormal.union(TransformClass::TranslateOnly),
+            TransformClass::Orthonormal
+        );
+        assert_eq!(
+            TransformClass::Affine.union(TransformClass::Exact),
+            TransformClass::Affine
+        );
+    }
+
+    #[test]
+    fn class_fold() {
+        let classes = [
+            TransformClass::Exact,
+            TransformClass::TranslateOnly,
+            TransformClass::Orthonormal,
+        ];
+
+        let class = classes
+            .into_iter()
+            .fold(TransformClass::default(), TransformClass::union);
+
+        assert_eq!(class, TransformClass::Orthonormal);
+    }
+}


### PR DESCRIPTION
Add `TransformClass` for describing how restrictive an `Affine` delta is, with public `Affine` helpers for classifying a transform relative to identity or another transform.

Classify matching linear parts directly so translation-only differences avoid inversion, including singular transforms, while still using relative deltas to recognize rotation, reflection, and uniform-scale changes.