### PR TITLE
Fix panic when fitting a sliver via fit_to_bezpath_opt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This release has an [MSRV][] of 1.85.
 ## Added
 - `serde` and `schemars` support for `Axis`. ([#591][] by [@waywardmonkeys][])
 
+## Fixed
+
+- `fit_to_cubic` no longer gives up on a range whose endpoints are close together but whose curve doubles back on itself, which could make `fit_to_bezpath_opt` panic on near-degenerate paths. ([#597][] by [@mlwilkerson][])
+
 ## [0.13.1][] (2026-05-13)
 
 This release has an [MSRV][] of 1.85.
@@ -215,6 +219,7 @@ Note: A changelog was not kept for or before this release
 [@nils-mathieu]: https://github.com/nils-mathieu
 [@Philipp-M]: https://github.com/Philipp-M
 [@platlas]: https://github.com/platlas
+[@mlwilkerson]: https://github.com/mlwilkerson
 [@PoignardAzur]: https://github.com/PoignardAzur
 [@raphlinus]: https://github.com/raphlinus
 [@RobertBrewitz]: https://github.com/RobertBrewitz
@@ -317,6 +322,7 @@ Note: A changelog was not kept for or before this release
 [#580]: https://github.com/linebender/kurbo/pull/580
 [#585]: https://github.com/linebender/kurbo/pull/585
 [#591]: https://github.com/linebender/kurbo/pull/591
+[#597]: https://github.com/linebender/kurbo/pull/597
 
 [Unreleased]: https://github.com/linebender/kurbo/compare/v0.13.1...HEAD
 [0.13.1]: https://github.com/linebender/kurbo/releases/tag/v0.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ This release has an [MSRV][] of 1.85.
 
 ## Fixed
 
-- `fit_to_cubic` no longer gives up on a range whose endpoints are close together but whose curve doubles back on itself, which could make `fit_to_bezpath_opt` panic on near-degenerate paths. ([#597][] by [@mlwilkerson][])
-- `fit_to_bezpath_opt` no longer panics when a range accepted by its segment search turns out not to fit; it subdivides and retries instead. ([#597][] by [@mlwilkerson][])
+- `fit_to_cubic` no longer gives up on a range whose endpoints are close together but whose curve doubles back on itself, which could make `fit_to_bezpath_opt` panic on near-degenerate paths. ([#603][])
+- `fit_to_bezpath_opt` no longer panics when a range accepted by its segment search turns out not to fit; it subdivides and retries instead. ([#603][])
 
 ## [0.13.1][] (2026-05-13)
 
@@ -220,7 +220,6 @@ Note: A changelog was not kept for or before this release
 [@nils-mathieu]: https://github.com/nils-mathieu
 [@Philipp-M]: https://github.com/Philipp-M
 [@platlas]: https://github.com/platlas
-[@mlwilkerson]: https://github.com/mlwilkerson
 [@PoignardAzur]: https://github.com/PoignardAzur
 [@raphlinus]: https://github.com/raphlinus
 [@RobertBrewitz]: https://github.com/RobertBrewitz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This release has an [MSRV][] of 1.85.
 ## Fixed
 
 - `fit_to_cubic` no longer gives up on a range whose endpoints are close together but whose curve doubles back on itself, which could make `fit_to_bezpath_opt` panic on near-degenerate paths. ([#597][] by [@mlwilkerson][])
+- `fit_to_bezpath_opt` no longer panics when a range accepted by its segment search turns out not to fit; it subdivides and retries instead. ([#597][] by [@mlwilkerson][])
 
 ## [0.13.1][] (2026-05-13)
 

--- a/kurbo/src/fit.rs
+++ b/kurbo/src/fit.rs
@@ -653,7 +653,24 @@ fn fit_to_bezpath_opt_inner(
         } else {
             range.end
         };
-        let (c, _) = fit_to_cubic(source, t0..t1, accuracy).unwrap();
+        let c = match fit_to_cubic(source, t0..t1, accuracy) {
+            Some((c, _)) => c,
+            None => {
+                // The segment search concluded this range fits, but the error
+                // metric is not monotonic in accuracy, so the fit can still fail
+                // here. Report a subdivision point as if it were a cusp, so the
+                // range is retried in smaller pieces.
+                let t = 0.5 * (t0 + t1);
+                if t > t0 && t < t1 {
+                    path.truncate(path_len);
+                    return Some(t);
+                }
+                // The range can no longer be subdivided, so just draw a line.
+                let p0 = source.sample_pt_tangent(t0, 1.0).p;
+                let p3 = source.sample_pt_tangent(t1, -1.0).p;
+                CubicBez::new(p0, p0.lerp(p3, 1.0 / 3.0), p3.lerp(p0, 1.0 / 3.0), p3)
+            }
+        };
         if i == 0 && range.start == 0.0 {
             path.move_to(c.p0);
         }

--- a/kurbo/src/fit.rs
+++ b/kurbo/src/fit.rs
@@ -396,7 +396,17 @@ pub fn fit_to_cubic(
     let acc2 = accuracy * accuracy;
     if chord2 <= acc2 {
         // Special case very short chords; try to fit a line.
-        return try_fit_line(source, accuracy, range, start.p, end.p);
+        if let Some(line) = try_fit_line(source, accuracy, range.clone(), start.p, end.p) {
+            return Some(line);
+        }
+        if chord2 == 0.0 {
+            // The cubic fit below is scaled by the chord, so it can't do
+            // anything with a zero-length one.
+            return None;
+        }
+        // A short chord doesn't imply a short curve: the source can double back
+        // on itself, in which case a line is a poor fit but a cubic may not be.
+        // Fall through to the general fit rather than giving up here.
     }
     let th = d.atan2();
     fn mod_2pi(th: f64) -> f64 {

--- a/kurbo/src/simplify.rs
+++ b/kurbo/src/simplify.rs
@@ -378,9 +378,9 @@ impl SimplifyOptions {
 
 #[cfg(test)]
 mod tests {
-    use crate::BezPath;
+    use crate::{BezPath, Point, fit_to_bezpath_opt};
 
-    use super::{SimplifyOptions, simplify_bezpath};
+    use super::{SimplifyBezPath, SimplifyOptions, simplify_bezpath};
 
     #[test]
     fn simplify_lines_corner() {
@@ -392,5 +392,22 @@ mod tests {
         let options = SimplifyOptions::default();
         let simplified = simplify_bezpath(path.clone(), 1.0, &options);
         assert_eq!(path, simplified);
+    }
+
+    #[test]
+    fn simplify_sliver() {
+        // A closed quadrilateral whose vertices are nearly collinear, making
+        // the shape a very thin sliver. Optimized fitting of such a path used
+        // to panic.
+        let pts = [(1.0, 0.7), (4.1, 2.0), (4.4, 2.1), (0.0, 0.0)];
+        let mut path = BezPath::new();
+        path.move_to(Point::new(pts[0].0, pts[0].1));
+        for (x, y) in &pts[1..] {
+            path.line_to(Point::new(*x, *y));
+        }
+        path.close_path();
+
+        let simplified = fit_to_bezpath_opt(&SimplifyBezPath::new(path), 2.0);
+        assert!(!simplified.is_empty());
     }
 }


### PR DESCRIPTION
Closes #601 

This was heavily assisted by Claude. Needs capable human review to confirm or correct it.

  # Fix panic in `fit_to_bezpath_opt` on near-degenerate paths

  ## Repro

  ```rust
  use kurbo::simplify::SimplifyBezPath;
  use kurbo::{BezPath, Point};

  // A closed quadrilateral whose four vertices are nearly collinear.
  let pts = [(1.0, 0.7), (4.1, 2.0), (4.4, 2.1), (0.0, 0.0)];
  let mut path = BezPath::new();
  path.move_to(Point::new(pts[0].0, pts[0].1));
  for (x, y) in &pts[1..] {
      path.line_to(Point::new(*x, *y));
  }
  path.close_path();

  kurbo::fit_to_bezpath_opt(&SimplifyBezPath::new(path), 2.0); // panics
  ```

  ```
  panicked at kurbo/src/fit.rs:646:61: called `Option::unwrap()` on a `None` value
  ```

  ## Root cause

  `fit_to_bezpath_opt` works in two passes. The first searches for split points and
  the number of segments needed, at a *tightened* accuracy `x`. The second re-walks
  the range and builds each cubic, at the *requested* accuracy — and ended in
  `fit_to_cubic(source, t0..t1, accuracy).unwrap()`, on the assumption that the
  search pass had already proven each piece fittable.

  That assumption does not hold, because the two passes can take different code
  paths. For the repro, the first piece runs from `(1.0, 0.7)` to `(2.56, 1.22)` —
  endpoints 1.64 apart, but the source doesn't run between them, it travels out
  toward `(4.4, 2.1)` and doubles back. A hairpin.

  - The **search pass** used `x ≈ 1.218`. Chord 1.64 > 1.218, so it ran the general
    cubic solver, which found a curve matching to within 0.036 units — but with a
    control arm ~17 units long. The long-control-arm penalty (which exists to avoid
    bumps) pushed the score just barely past tolerance. Rejected, by a hair.
  - The **build pass** used the requested accuracy of 2.0. Chord 1.64 ≤ 2.0, so
    `fit_to_cubic` took its short-chord shortcut: *"a chord this short means a tiny
    piece of curve, just try a line."* The piece isn't tiny, the line is off by more
    than 2, and the function returned `None` without ever reaching the cubic solver.

  So loosening the accuracy made fitting *harder*, by flipping the code onto a branch
  that only considers straight lines. The error metric is not monotonic in accuracy,
  and the `.unwrap()` didn't survive that.

  ## Changes

  **1. `fit_to_cubic`: don't give up when a short chord hides a long curve.**
  The short-chord shortcut now falls through to the general cubic fit when the line
  fit fails, instead of returning `None` immediately. A short chord doesn't imply a
  short curve when the source doubles back on itself. Zero-length chords still bail
  out early, since the general fit is scaled by the chord and can't do anything with
  a degenerate one. This alone fixes the repro: at accuracy 2.0 the cubic solver's
  candidate scores 1.485 against a budget of 4.0 and is accepted.

  **2. `fit_to_bezpath_opt_inner`: remove the `.unwrap()`.**
  `fit_to_cubic` is documented to return `None` when it can't meet the requested
  accuracy, so unwrapping it is a latent panic independent of which geometry
  triggers it. On `None`, the midpoint of the failing piece is now reported upward
  as if it were a cusp, so the driver subdivides and retries — the same mechanism
  already used for cusps. If the piece is too small to subdivide further, it falls
  back to emitting a line, mirroring the existing escape hatch in
  `fit_to_bezpath_rec`. That bounds the retries and guarantees termination.

  Change 1 removes the cause for this input; change 2 removes the crash class.

  ## Risk

  Change 1 touches shared code — stroke expansion and offsetting lean on
  `fit_to_cubic` heavily. It only affects ranges that previously returned `None`
  (callers already had to handle that), so it can turn a former "give up and
  subdivide" into a successful single-cubic fit. That's a quality improvement, but
  it is an output change for such paths, and worth a careful look.

  ## Testing

  - Regression test `simplify::tests::simplify_sliver` added alongside the existing
    `simplify_lines_corner`; it fails with the original panic before these changes.
  - Full workspace suite, clippy `--all-targets`, and `cargo fmt --check` are clean
    at each commit; `--no-default-features --features libm` still builds.
  - Termination of change 2's fallback was verified by temporarily forcing *every*
    final fit to return `None`: no hang, and all 188 tests still pass on the line
    fallback path.